### PR TITLE
Update event types and add initial cluster support

### DIFF
--- a/cmd/goSignals/goSignals_test.go
+++ b/cmd/goSignals/goSignals_test.go
@@ -447,7 +447,7 @@ func (suite *toolSuite) Test4_PollStream() {
 	streamConfig, err := suite.pd.cli.Data.GetStreamConfig("scimPoll")
 	assert.NoError(suite.T(), err, "Error getting stream config for scimPoll")
 	assert.NotNilf(suite.T(), streamConfig, "Stream config for scimPoll not null")
-	assert.Len(suite.T(), streamConfig.EventsDelivered, 4, "Should be 4 events delivered")
+	assert.Len(suite.T(), streamConfig.EventsDelivered, 2, "Should be 2 events delivered")
 	endpoint := fmt.Sprintf("http://%s/poll/%s", server1Addr, streamConfig.Id)
 	assert.Equal(suite.T(), endpoint, streamConfig.Delivery.PollTransmitMethod.EndpointUrl, "Event endpoint present")
 	testLog.Println(fmt.Sprintf("Result:\n%s", res))
@@ -459,7 +459,7 @@ func (suite *toolSuite) Test4_PollStream() {
 	assert.NoError(suite.T(), err, "Add stream has no error")
 
 	streamConfigPoll, err := suite.pd.cli.Data.GetStreamConfig("scimPollRec")
-	assert.Len(suite.T(), streamConfigPoll.EventsDelivered, 4, "Should be 4 events delivered")
+	assert.Len(suite.T(), streamConfigPoll.EventsDelivered, 2, "Should be 2 events delivered")
 
 	// Reset so the next subtest can work.
 	res, err = suite.executeCommand("delete stream scimPollRec", true)
@@ -472,7 +472,7 @@ func (suite *toolSuite) Test4_PollStream() {
 	assert.NoError(suite.T(), err, "Add stream has no error")
 
 	streamConfigPoll, err = suite.pd.cli.Data.GetStreamConfig("scimPollRec")
-	assert.Len(suite.T(), streamConfigPoll.EventsDelivered, 4, "Should be 4 events delivered")
+	assert.Len(suite.T(), streamConfigPoll.EventsDelivered, 2, "Should be 2 events delivered")
 
 	// Reset so the next subtest can work.
 	res, err = suite.executeCommand("delete stream scimPollRec", true)

--- a/cmd/goSignalsServer/main.go
+++ b/cmd/goSignalsServer/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/i2-open/i2goSignals/internal/logger"
 	"github.com/i2-open/i2goSignals/internal/providers/dbProviders"
 	"github.com/i2-open/i2goSignals/internal/providers/dbProviders/mongo_provider"
+	"github.com/i2-open/i2goSignals/pkg/constants"
 	ssef "github.com/i2-open/i2goSignals/pkg/goSignals/server"
 )
 
@@ -47,7 +48,7 @@ func StartProvider(dbUrl string) (dbProviders.DbProviderInterface, error) {
 func main() {
 	logger.Init(os.Getenv("LOG_LEVEL"))
 
-	mLog.Info("i2goSignals server starting...", "version", "0.0.1")
+	mLog.Info("i2goSignals server starting...", "version", constants.GoSignalsVersion)
 	port := "8888"
 	if found := stripQuotes(os.Getenv("PORT")); found != "" {
 		port = found

--- a/internal/eventRouter/event_router.go
+++ b/internal/eventRouter/event_router.go
@@ -713,7 +713,14 @@ func StreamEventMatch(stream *model.StreamStateRecord, event *model.EventRecord)
 	}
 
 	for _, eventType := range event.Types {
+		// The following events should always be returned.
 		if eventType == "https://schemas.openid.net/secevent/sse/event-type/verification" {
+			return true
+		}
+		if eventType == "https://schemas.openid.net/secevent/ssf/event-type/verification" {
+			return true
+		}
+		if eventType == "https://schemas.openid.net/secevent/ssf/event-type/stream-updated" {
 			return true
 		}
 		for _, streamType := range stream.EventsDelivered {

--- a/internal/model/model_event_types.go
+++ b/internal/model/model_event_types.go
@@ -1,24 +1,42 @@
 package model
 
+var CaepEvents = []string{
+	"https://schemas.openid.net/secevent/caep/event-type/session-revoked",
+	"https://schemas.openid.net/secevent/caep/event-type/token-claims-change",
+	"https://schemas.openid.net/secevent/caep/event-type/credential-change",
+	"https://schemas.openid.net/secevent/caep/event-type/assurance-level-change",
+	"https://schemas.openid.net/secevent/caep/event-type/device-compliance-change",
+}
+
+var RiscEvents = []string{
+	"https://schemas.openid.net/secevent/risc/event-type/account-enabled",
+	"https://schemas.openid.net/secevent/risc/event-type/account-disabled",
+	"https://schemas.openid.net/secevent/risc/event-type/account-purged",
+	"https://schemas.openid.net/secevent/risc/event-type/account-credential-change-required",
+	"https://schemas.openid.net/secevent/risc/event-type/recovery-activated",
+	"https://schemas.openid.net/secevent/risc/event-type/recovery-information-changed",
+	"https://schemas.openid.net/secevent/risc/event-type/sessions-revoked",
+	"https://schemas.openid.net/secevent/risc/event-type/identifier-changed",
+	"https://schemas.openid.net/secevent/risc/event-type/identifier-recycled",
+}
+
 const (
-	EventScimFeedAdd       = "urn:ietf:params:SCIM:event:feed:add"
-	EventScimFeedRemove    = "urn:ietf:params:SCIM:event:feed:remove"
-	EventScimCreateFull    = "urn:ietf:params:SCIM:event:prov:create:full"
-	EventScimPutFull       = "urn:ietf:params:SCIM:event:prov:put:full"
-	EventScimPatchFull     = "urn:ietf:params:SCIM:event:prov:patch:full"
-	EventScimCreateNotice  = "urn:ietf:params:SCIM:event:prov:create:notice"
-	EventScimPatchNotice   = "urn:ietf:params:SCIM:event:prov:patch:notice"
-	EventScimPutNotice     = "urn:ietf:params:SCIM:event:prov:put:notice"
-	EventScimDelete        = "urn:ietf:params:SCIM:event:prov:delete"
-	EventScimActivate      = "urn:ietf:params:SCIM:event:prov:activate"
-	EventScimDeactivate    = "urn:ietf:params:SCIM:event:prov:deactivate"
-	EventScimSigAuthMethod = "urn:ietf:params:SCIM:event:sig:authMethod"
-	EventScimSigPwdReset   = "urn:ietf:params:SCIM:event:sig:pwdReset"
-	EventScimAsyncResp     = "urn:ietf:params:SCIM:event:misc:asyncResp"
+	EventScimFeedAdd      = "urn:ietf:params:scim:event:feed:add"
+	EventScimFeedRemove   = "urn:ietf:params:scim:event:feed:remove"
+	EventScimCreateFull   = "urn:ietf:params:scim:event:prov:create:full"
+	EventScimPutFull      = "urn:ietf:params:scim:event:prov:put:full"
+	EventScimPatchFull    = "urn:ietf:params:scim:event:prov:patch:full"
+	EventScimCreateNotice = "urn:ietf:params:scim:event:prov:create:notice"
+	EventScimPatchNotice  = "urn:ietf:params:scim:event:prov:patch:notice"
+	EventScimPutNotice    = "urn:ietf:params:scim:event:prov:put:notice"
+	EventScimDelete       = "urn:ietf:params:scim:event:prov:delete"
+	EventScimActivate     = "urn:ietf:params:scim:event:prov:activate"
+	EventScimDeactivate   = "urn:ietf:params:scim:event:prov:deactivate"
+	EventScimAsyncResp    = "urn:ietf:params:scim:event:misc:asyncResp"
 )
 
 func GetSupportedEvents() []string {
-	return []string{
+	events := []string{
 		EventScimFeedAdd,
 		EventScimFeedRemove,
 		EventScimCreateFull,
@@ -30,8 +48,11 @@ func GetSupportedEvents() []string {
 		EventScimDelete,
 		EventScimActivate,
 		EventScimDeactivate,
-		EventScimSigAuthMethod,
-		EventScimSigPwdReset,
+
 		EventScimAsyncResp,
 	}
+
+	events = append(events, CaepEvents...)
+	events = append(events, RiscEvents...)
+	return events
 }

--- a/internal/model/model_poll_delivery_method.go
+++ b/internal/model/model_poll_delivery_method.go
@@ -1,9 +1,10 @@
 package model
 
 type PollTransmitMethod struct {
-	Method              string `json:"method"`                 // urn:ietf:rfc:8936
-	EndpointUrl         string `json:"endpoint_url,omitempty"` // The URL where events can be retrieved from. This is specified by the Transmitter.
-	AuthorizationHeader string `json:"authorization_header,omitempty"`
+	Method              string          `json:"method"`                 // urn:ietf:rfc:8936
+	EndpointUrl         string          `json:"endpoint_url,omitempty"` // The URL where events can be retrieved from. This is specified by the Transmitter.
+	AuthorizationHeader string          `json:"authorization_header,omitempty"`
+	PollConfig          *PollParameters `json:"poll_config,omitempty"`
 }
 
 type PollReceiveMethod struct {

--- a/internal/model/model_stream_configuration.go
+++ b/internal/model/model_stream_configuration.go
@@ -42,4 +42,11 @@ type StreamConfiguration struct {
 	ResetJti string `json:"resetJti,omitempty"`
 
 	RouteMode string `json:"route_mode,omitempty"` // Is one of RouteModeImport, RouteModeForward or RouteModePublish
+
+	// TxWellKnownUrl Used to record the well-known endpoint for the SSF transmitter. Used by receivers to discover the transmitter's configuration and capabilities.
+	// When creating a receiver, providing a value without endpoint values for Delivery (other than method) will cause i2goSignals to initiate an SSF registration with the transmitter.
+	TxWellKnownUrl *string `json:"tx_well_known_url,omitempty"`
+
+	// TxToken holds the token used for automatic SSF stream creation with the transmitter and may be updated upon success to allow access to status & verify endpoints
+	TxToken *string `json:"tx_token,omitempty"`
 }

--- a/internal/model/model_transmitter_configuration.go
+++ b/internal/model/model_transmitter_configuration.go
@@ -21,6 +21,10 @@ type ProtectedResourceMetadata struct {
 	ResourceName           *string  `json:"resource_name,omitempty"`
 }
 
+type AuthScheme struct {
+	SpecUrn string `json:"spec_urn"`
+}
+
 // Transmitters have metadata describing their configuration. [OpenID Spec](https://openid.net/specs/openid-sse-framework-1_0.html#discovery-meta)
 type TransmitterConfiguration struct {
 	// URL using the https scheme with no query or fragment component that the Transmitter asserts as its Issuer Identifier. This MUST be identical to the iss claim value in Security Event Tokens issued from this Transmitter.
@@ -46,11 +50,12 @@ type TransmitterConfiguration struct {
 
 	ClientRegistrationEndpoint string `json:"client_registration_endpoint,omitempty"`
 
-	AuthorizationSchemes []string `json:"authorization_schemes,omitempty"`
+	AuthorizationSchemes []AuthScheme `json:"authorization_schemes,omitempty"`
 
 	AuthorizationServers   []string `json:"authorization_servers,omitempty"`
 	ScopesSupported        []string `json:"scopes_supported,omitempty"`
 	BearerMethodsSupported []string `json:"bearer_methods_supported,omitempty"`
 
+	SpecVersion      string `json:"spec_version,omitempty"`
 	GoSignalsVersion string `json:"gosignals_version,omitempty"`
 }

--- a/internal/providers/dbProviders/mock_provider/provider.go
+++ b/internal/providers/dbProviders/mock_provider/provider.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -301,4 +302,8 @@ func (m *MockMongoProvider) RegisterNode(node model.ClusterNode) error {
 
 func (m *MockMongoProvider) GetActiveNodeCount() (int64, error) {
 	return 1, nil
+}
+
+func (m *MockMongoProvider) SetBaseUrl(u *url.URL) {
+	m.streamService.SetBaseUrl(u)
 }

--- a/internal/providers/dbProviders/mongo_provider/provider.go
+++ b/internal/providers/dbProviders/mongo_provider/provider.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"errors"
+	"net/url"
 	"os"
 	"sync"
 	"time"
@@ -570,4 +571,8 @@ func (m *MongoProvider) GetActiveNodeCount() (int64, error) {
 	}
 
 	return m.nodeCol.CountDocuments(ctx, filter)
+}
+
+func (m *MongoProvider) SetBaseUrl(u *url.URL) {
+	m.streamService.SetBaseUrl(u)
 }

--- a/internal/providers/dbProviders/mongo_provider/test/provider_test.go
+++ b/internal/providers/dbProviders/mongo_provider/test/provider_test.go
@@ -120,7 +120,7 @@ func (s *MongoProviderSuite) TestB_StreamConfig() {
 	s.Equal(1, len(configs), "should be one registered")
 
 	s.Equal(s.stream.Id, configs[0].Id, "should be the same s.stream id")
-	s.Equal(14, len(configs[0].EventsDelivered), "Should be 14 events configured for delivery")
+	s.Equal(26, len(configs[0].EventsDelivered), "Should be 26 events configured for delivery")
 	events, _ := s.provider.GetEventIds(s.stream.Id, model.PollParameters{
 		MaxEvents: 5, ReturnImmediately: true,
 	})

--- a/internal/providers/dbProviders/provider_interface.go
+++ b/internal/providers/dbProviders/provider_interface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rsa"
 	"encoding/json"
+	"net/url"
 	"time"
 
 	"github.com/i2-open/i2goSignals/internal/authUtil"
@@ -68,4 +69,5 @@ type DbProviderInterface interface {
 
 	// GetActiveNodeCount returns the number of nodes that have heartbeated within the last 60 seconds.
 	GetActiveNodeCount() (int64, error)
+	SetBaseUrl(u *url.URL)
 }

--- a/internal/services/stream_service.go
+++ b/internal/services/stream_service.go
@@ -1,9 +1,12 @@
 package services
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
@@ -27,6 +30,7 @@ type StreamService struct {
 	keyService      *KeyService
 	defaultIssuer   string
 	receiverStreams map[string]*model.StreamStateRecord
+	BaseUrl         *url.URL
 }
 
 func NewStreamService(streamDAO interfaces.StreamDAO, keyService *KeyService, defaultIssuer string) *StreamService {
@@ -36,6 +40,10 @@ func NewStreamService(streamDAO interfaces.StreamDAO, keyService *KeyService, de
 		defaultIssuer:   defaultIssuer,
 		receiverStreams: make(map[string]*model.StreamStateRecord),
 	}
+}
+
+func (s *StreamService) SetBaseUrl(u *url.URL) {
+	s.BaseUrl = u
 }
 
 func (s *StreamService) CreateStream(ctx context.Context, request model.StreamConfiguration, projectID string) (model.StreamConfiguration, error) {
@@ -97,6 +105,91 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamCo
 
 	case model.ReceivePoll:
 		config.Delivery = request.Delivery
+		if request.TxWellKnownUrl != nil && request.TxToken != nil && *request.TxToken != "" && *request.TxWellKnownUrl != "" {
+			// Attempt to do an SSF registration to create the Polling Transmit Stream
+			ssLog.Debug("Retrieving SSF transmitter configuration for automatic registration...")
+			// Retrieve the transmitter configuration from the WellKnownUrl
+			resp, err := http.Get(*request.TxWellKnownUrl)
+			if err != nil {
+				return model.StreamConfiguration{}, fmt.Errorf("failed to fetch transmitter configuration: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				return model.StreamConfiguration{}, fmt.Errorf("transmitter configuration returned status %d", resp.StatusCode)
+			}
+			var txConfig model.TransmitterConfiguration
+			if err := json.NewDecoder(resp.Body).Decode(&txConfig); err != nil {
+				return model.StreamConfiguration{}, fmt.Errorf("failed to decode transmitter configuration: %v", err)
+			}
+
+			if txConfig.ConfigurationEndpoint == "" {
+				return model.StreamConfiguration{}, errors.New("transmitter configuration missing configuration_endpoint")
+			}
+
+			transmitStreamReq := model.StreamConfiguration{
+				Iss: request.Iss,
+				Aud: request.Aud,
+				Delivery: &model.OneOfStreamConfigurationDelivery{
+					PollTransmitMethod: &model.PollTransmitMethod{
+						Method: model.DeliveryPoll,
+					},
+				},
+			}
+			ssLog.Debug("Submitting POLL stream registration request to transmitter...")
+			reqBody, _ := json.Marshal(transmitStreamReq)
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, txConfig.ConfigurationEndpoint, bytes.NewReader(reqBody))
+			if err != nil {
+				return model.StreamConfiguration{}, err
+			}
+			req.Header.Set("Content-Type", "application/json")
+			parts := strings.Split(*request.TxToken, " ")
+			if len(parts) == 1 {
+				req.Header.Set("Authorization", "Bearer "+*request.TxToken)
+			} else {
+				req.Header.Set("Authorization", *request.TxToken)
+			}
+
+			resp, err = http.DefaultClient.Do(req)
+			if err != nil {
+				ssLog.Error("failed to submit registration request to transmitter", "error", err)
+				return model.StreamConfiguration{}, fmt.Errorf("failed to submit registration request to transmitter: %v", err)
+			}
+			defer resp.Body.Close()
+
+			// parse the response and handle any errors. If they occur return a detailed error
+			if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+				ssLog.Warn("transmitter registration failed", "host", txConfig.ConfigurationEndpoint, "status", resp.StatusCode)
+				return model.StreamConfiguration{}, fmt.Errorf("transmitter registration failed with status %d", resp.StatusCode)
+			}
+
+			var txStreamResp model.StreamConfiguration
+			if err := json.NewDecoder(resp.Body).Decode(&txStreamResp); err != nil {
+				return model.StreamConfiguration{}, fmt.Errorf("failed to decode transmitter registration response: %v", err)
+			}
+
+			// from the response, update config.EventsDelivered with the transmitters response EventsDelivered
+			config.EventsDelivered = txStreamResp.EventsDelivered
+			config.TxWellKnownUrl = request.TxWellKnownUrl
+
+			if txStreamResp.Delivery != nil && txStreamResp.Delivery.PollTransmitMethod != nil {
+
+				config.TxToken = &txStreamResp.Delivery.PollTransmitMethod.AuthorizationHeader // Use for status and verification endpoints
+				config.Delivery.PollReceiveMethod.AuthorizationHeader = txStreamResp.Delivery.PollTransmitMethod.AuthorizationHeader
+				config.Delivery.PollReceiveMethod.EndpointUrl = txStreamResp.Delivery.PollTransmitMethod.EndpointUrl
+				config.Delivery.PollReceiveMethod.PollConfig = txStreamResp.Delivery.PollTransmitMethod.PollConfig // follow the Transmitters poll config if asserted
+
+			} else {
+				ssLog.Warn("transmitter configuration delivery is missing PollTransmitMethod information, receive creation aborted", "stream_id", config.Id, "transmitter_url", request.TxWellKnownUrl)
+				return model.StreamConfiguration{}, errors.New("unexpected response did not include delivery information")
+			}
+
+			// Allow the request to override the Transmitters poll config if asserted
+			if request.Delivery.PollReceiveMethod.PollConfig != nil {
+				config.Delivery.PollReceiveMethod.PollConfig = request.Delivery.PollReceiveMethod.PollConfig
+			}
+			ssLog.Debug("Poll stream transmitter created.", "stream_id", config.Id)
+		}
+
 		method := config.Delivery.PollReceiveMethod
 
 		if request.RouteMode == "" {
@@ -138,11 +231,114 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamCo
 	if err != nil {
 		return model.StreamConfiguration{}, err
 	}
+	ssLog.Info("Stream created", "id", streamRec.Id, "type", config.Delivery.GetMethod())
 
 	// If this is a receiver stream, load its JWKS
 	if streamRec.IsReceiver() {
 		s.receiverStreams[config.Id] = streamRec
 		s.loadJwksForReceiver(ctx, streamRec)
+		ssLog.Debug("Receiver started", "id", streamRec.Id)
+	}
+
+	// If automatic transmitter registration is requested for ReceivePush, do it now.
+	// The stream is now active and in the DB.
+	if request.Delivery.GetMethod() == model.ReceivePush && request.TxWellKnownUrl != nil && request.TxToken != nil {
+		ssLog.Debug("Retrieving SSF transmitter configuration for automatic registration...")
+		// Retrieve the transmitter configuration from the WellKnownUrl
+		resp, err := http.Get(*request.TxWellKnownUrl)
+		if err != nil {
+			_ = s.DeleteStream(ctx, config.Id)
+			return model.StreamConfiguration{}, fmt.Errorf("failed to fetch transmitter configuration: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			_ = s.DeleteStream(ctx, config.Id)
+			return model.StreamConfiguration{}, fmt.Errorf("transmitter configuration returned status %d", resp.StatusCode)
+		}
+		var txConfig model.TransmitterConfiguration
+		if err := json.NewDecoder(resp.Body).Decode(&txConfig); err != nil {
+			_ = s.DeleteStream(ctx, config.Id)
+			return model.StreamConfiguration{}, fmt.Errorf("failed to decode transmitter configuration: %v", err)
+		}
+
+		if txConfig.ConfigurationEndpoint == "" {
+			_ = s.DeleteStream(ctx, config.Id)
+			return model.StreamConfiguration{}, errors.New("transmitter configuration missing configuration_endpoint")
+		}
+
+		method := streamRec.StreamConfiguration.Delivery.PushReceiveMethod
+		endpoint := method.EndpointUrl
+		if s.BaseUrl != nil {
+			u, _ := s.BaseUrl.Parse(endpoint)
+			endpoint = u.String()
+		}
+
+		// Using the returned configuration endpoint, form a stream create-request with model.DeliveryPush.
+		transmitStreamReq := model.StreamConfiguration{
+			Iss:             request.Iss,
+			Aud:             request.Aud,
+			EventsRequested: request.EventsRequested,
+			Delivery: &model.OneOfStreamConfigurationDelivery{
+				PushTransmitMethod: &model.PushTransmitMethod{
+					Method:              model.DeliveryPush,
+					EndpointUrl:         endpoint,
+					AuthorizationHeader: method.AuthorizationHeader,
+				},
+			},
+		}
+
+		ssLog.Debug("Submitting PUSH stream registration request to transmitter...")
+
+		// Submit the creation request to the transmitter's ConfigurationEndpoint.
+		reqBody, _ := json.Marshal(transmitStreamReq)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, txConfig.ConfigurationEndpoint, bytes.NewReader(reqBody))
+		if err != nil {
+			_ = s.DeleteStream(ctx, config.Id)
+			return model.StreamConfiguration{}, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		parts := strings.Split(*request.TxToken, " ")
+		if len(parts) == 1 {
+			req.Header.Set("Authorization", "Bearer "+*request.TxToken)
+		} else {
+			req.Header.Set("Authorization", *request.TxToken)
+		}
+
+		resp, err = http.DefaultClient.Do(req)
+		if err != nil {
+			ssLog.Error("failed to submit registration request to transmitter", "error", err)
+			_ = s.DeleteStream(ctx, config.Id)
+			return model.StreamConfiguration{}, fmt.Errorf("failed to submit registration request to transmitter: %v", err)
+		}
+		defer resp.Body.Close()
+
+		// parse the response and handle any errors. If they occur return a detailed error
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+			ssLog.Warn("transmitter registration failed", "host", txConfig.ConfigurationEndpoint, "status", resp.StatusCode)
+			_ = s.DeleteStream(ctx, config.Id)
+			return model.StreamConfiguration{}, fmt.Errorf("transmitter registration failed with status %d", resp.StatusCode)
+		}
+
+		var txStreamResp model.StreamConfiguration
+		if err := json.NewDecoder(resp.Body).Decode(&txStreamResp); err != nil {
+			_ = s.DeleteStream(ctx, config.Id)
+			return model.StreamConfiguration{}, fmt.Errorf("failed to decode transmitter registration response: %v", err)
+		}
+
+		// from the response, update config.EventsDelivered with the transmitters response EventsDelivered
+		config.EventsDelivered = txStreamResp.EventsDelivered
+		config.TxWellKnownUrl = request.TxWellKnownUrl
+		config.TxToken = request.TxToken
+
+		// Update the persisted record
+		streamRec.StreamConfiguration = config
+		err = s.streamDAO.Update(ctx, streamRec)
+		if err != nil {
+			_ = s.DeleteStream(ctx, config.Id)
+			return model.StreamConfiguration{}, fmt.Errorf("failed to update stream after registration: %v", err)
+		}
+
+		ssLog.Debug("Push transmitter stream configured to send to this receiver")
 	}
 
 	return config, nil

--- a/internal/services/stream_service_registration_test.go
+++ b/internal/services/stream_service_registration_test.go
@@ -1,0 +1,174 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/i2-open/i2goSignals/internal/dao/memory"
+	"github.com/i2-open/i2goSignals/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateStream_AutomaticRegistration(t *testing.T) {
+	// 1. Setup Mock Transmitter
+	eventsDelivered := []string{"urn:ietf:params:sse:event-type:risc:account-enabled"}
+	transmitterConfig := model.TransmitterConfiguration{
+		Issuer:                "http://transmitter.com",
+		ConfigurationEndpoint: "", // will be set later
+	}
+
+	mux := http.NewServeMux()
+
+	// Well-known endpoint
+	mux.HandleFunc("/.well-known/ssf-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(transmitterConfig)
+	})
+
+	// Stream configuration endpoint
+	mux.HandleFunc("/streams", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+		var req model.StreamConfiguration
+		err := json.NewDecoder(r.Body).Decode(&req)
+		assert.NoError(t, err)
+
+		// Verify that the EndpointUrl is absolute
+		assert.Contains(t, req.Delivery.PushTransmitMethod.EndpointUrl, "http://receiver.com/events/")
+
+		// Return updated configuration
+		req.EventsDelivered = eventsDelivered
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(req)
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	transmitterConfig.ConfigurationEndpoint = ts.URL + "/streams"
+	wellKnownUrl := ts.URL + "/.well-known/ssf-configuration"
+
+	// 2. Setup StreamService
+	streamDAO := memory.NewStreamDAO()
+	keyDAO := memory.NewKeyDAO()
+	keyService := NewKeyService(keyDAO, "http://receiver.com")
+
+	// We need to initialize token keys for the key service to have an auth issuer
+	err := keyService.InitializeTokenKey(context.Background(), "http://receiver.com")
+	assert.NoError(t, err)
+
+	svc := NewStreamService(streamDAO, keyService, "http://receiver.com")
+	baseUrl, _ := url.Parse("http://receiver.com")
+	svc.SetBaseUrl(baseUrl)
+
+	// 3. Call CreateStream
+	request := model.StreamConfiguration{
+		Iss:             "http://transmitter.com",
+		Aud:             []string{"http://receiver.com"},
+		EventsRequested: []string{"urn:ietf:params:sse:event-type:risc:account-enabled"},
+		Delivery: &model.OneOfStreamConfigurationDelivery{
+			PushReceiveMethod: &model.PushReceiveMethod{
+				Method: model.ReceivePush,
+			},
+		},
+		TxWellKnownUrl: &wellKnownUrl,
+		TxToken:        &[]string{"test-token"}[0],
+	}
+
+	ctx := context.Background()
+	config, err := svc.CreateStream(ctx, request, "test-project")
+
+	// 4. Verify Results
+	assert.NoError(t, err)
+	assert.Equal(t, eventsDelivered, config.EventsDelivered)
+}
+
+func TestCreateStream_AutomaticPollRegistration(t *testing.T) {
+	// 1. Setup Mock Transmitter
+	eventsDelivered := []string{"urn:ietf:params:sse:event-type:risc:account-enabled"}
+	transmitterConfig := model.TransmitterConfiguration{
+		Issuer:                "http://transmitter.com",
+		ConfigurationEndpoint: "", // will be set later
+	}
+
+	mux := http.NewServeMux()
+
+	// Well-known endpoint
+	mux.HandleFunc("/.well-known/ssf-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(transmitterConfig)
+	})
+
+	// Stream configuration endpoint
+	mux.HandleFunc("/streams", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+		var req model.StreamConfiguration
+		err := json.NewDecoder(r.Body).Decode(&req)
+		assert.NoError(t, err)
+
+		// Verify that it requested Poll delivery
+		assert.Equal(t, model.DeliveryPoll, req.Delivery.GetMethod())
+
+		// Return updated configuration with Poll details
+		req.EventsDelivered = eventsDelivered
+		req.Delivery = &model.OneOfStreamConfigurationDelivery{
+			PollTransmitMethod: &model.PollTransmitMethod{
+				Method:              model.DeliveryPoll,
+				EndpointUrl:         "http://transmitter.com/poll/123",
+				AuthorizationHeader: "Bearer status-token",
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(req)
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	transmitterConfig.ConfigurationEndpoint = ts.URL + "/streams"
+	wellKnownUrl := ts.URL + "/.well-known/ssf-configuration"
+
+	// 2. Setup StreamService
+	streamDAO := memory.NewStreamDAO()
+	keyDAO := memory.NewKeyDAO()
+	keyService := NewKeyService(keyDAO, "http://receiver.com")
+
+	err := keyService.InitializeTokenKey(context.Background(), "http://receiver.com")
+	assert.NoError(t, err)
+
+	svc := NewStreamService(streamDAO, keyService, "http://receiver.com")
+	baseUrl, _ := url.Parse("http://receiver.com")
+	svc.SetBaseUrl(baseUrl)
+
+	// 3. Call CreateStream
+	request := model.StreamConfiguration{
+		Iss:             "http://transmitter.com",
+		Aud:             []string{"http://receiver.com"},
+		EventsRequested: []string{"urn:ietf:params:sse:event-type:risc:account-enabled"},
+		Delivery: &model.OneOfStreamConfigurationDelivery{
+			PollReceiveMethod: &model.PollReceiveMethod{
+				Method: model.ReceivePoll,
+			},
+		},
+		TxWellKnownUrl: &wellKnownUrl,
+		TxToken:        &[]string{"test-token"}[0],
+	}
+
+	ctx := context.Background()
+	config, err := svc.CreateStream(ctx, request, "test-project")
+
+	// 4. Verify Results
+	assert.NoError(t, err)
+	assert.Equal(t, eventsDelivered, config.EventsDelivered)
+	assert.NotNil(t, config.Delivery.PollReceiveMethod)
+	assert.Equal(t, "http://transmitter.com/poll/123", config.Delivery.PollReceiveMethod.EndpointUrl)
+	assert.Equal(t, "Bearer status-token", config.Delivery.PollReceiveMethod.AuthorizationHeader)
+	assert.NotNil(t, config.TxToken)
+	assert.Equal(t, "Bearer status-token", *config.TxToken)
+}

--- a/internal/services/stream_service_tx_token_test.go
+++ b/internal/services/stream_service_tx_token_test.go
@@ -1,0 +1,109 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/i2-open/i2goSignals/internal/dao/memory"
+	"github.com/i2-open/i2goSignals/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateStream_TxTokenResilience(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputToken     string
+		expectedHeader string
+	}{
+		{
+			name:           "Token without prefix",
+			inputToken:     "test-token",
+			expectedHeader: "Bearer test-token",
+		},
+		{
+			name:           "Token with Bearer prefix",
+			inputToken:     "Bearer test-token",
+			expectedHeader: "Bearer test-token",
+		},
+		{
+			name:           "Token with bearer prefix lowercase",
+			inputToken:     "bearer test-token",
+			expectedHeader: "bearer test-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 1. Setup Mock Transmitter
+			eventsDelivered := []string{"urn:ietf:params:sse:event-type:risc:account-enabled"}
+			transmitterConfig := model.TransmitterConfiguration{
+				Issuer:                "http://transmitter.com",
+				ConfigurationEndpoint: "", // will be set later
+			}
+
+			mux := http.NewServeMux()
+
+			// Well-known endpoint
+			mux.HandleFunc("/.well-known/ssf-configuration", func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(transmitterConfig)
+			})
+
+			// Stream configuration endpoint
+			mux.HandleFunc("/streams", func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, tt.expectedHeader, r.Header.Get("Authorization"))
+
+				var req model.StreamConfiguration
+				err := json.NewDecoder(r.Body).Decode(&req)
+				assert.NoError(t, err)
+
+				// Return updated configuration
+				req.EventsDelivered = eventsDelivered
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(req)
+			})
+
+			ts := httptest.NewServer(mux)
+			defer ts.Close()
+
+			transmitterConfig.ConfigurationEndpoint = ts.URL + "/streams"
+			wellKnownUrl := ts.URL + "/.well-known/ssf-configuration"
+
+			// 2. Setup StreamService
+			streamDAO := memory.NewStreamDAO()
+			keyDAO := memory.NewKeyDAO()
+			keyService := NewKeyService(keyDAO, "http://receiver.com")
+
+			err := keyService.InitializeTokenKey(context.Background(), "http://receiver.com")
+			assert.NoError(t, err)
+
+			svc := NewStreamService(streamDAO, keyService, "http://receiver.com")
+			baseUrl, _ := url.Parse("http://receiver.com")
+			svc.SetBaseUrl(baseUrl)
+
+			// 3. Call CreateStream
+			request := model.StreamConfiguration{
+				Iss:             "http://transmitter.com",
+				Aud:             []string{"http://receiver.com"},
+				EventsRequested: []string{"urn:ietf:params:sse:event-type:risc:account-enabled"},
+				Delivery: &model.OneOfStreamConfigurationDelivery{
+					PushReceiveMethod: &model.PushReceiveMethod{
+						Method: model.ReceivePush,
+					},
+				},
+				TxWellKnownUrl: &wellKnownUrl,
+				TxToken:        &tt.inputToken,
+			}
+
+			ctx := context.Background()
+			_, err = svc.CreateStream(ctx, request, "test-project")
+
+			// 4. Verify Results
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/pkg/constants/server.go
+++ b/pkg/constants/server.go
@@ -1,0 +1,9 @@
+package constants
+
+const ServerType = "goSignals"
+const GoSignalsVersion = "0.8"
+
+const BearerAuth = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+const RFC6749 = "urn:ietf:rfc:6749"
+
+const SSF_VERSION = "1_0"

--- a/pkg/goSet/events/streamUpdated_event.go
+++ b/pkg/goSet/events/streamUpdated_event.go
@@ -1,0 +1,39 @@
+package events
+
+import "github.com/i2-open/i2goSignals/pkg/goSet"
+
+type StreamUpdatePayload struct {
+	Status string  `json:"status,omitempty"`
+	Reason *string `json:"reason,omitempty"`
+}
+
+const StatusUpdatedEventUri = "https://schemas.openid.net/secevent/ssf/event-type/stream-updated"
+
+func CreateStatusUpdatedEvent(streamId string, status string, reason string, issuer string, audience []string) *goSet.SecurityEventToken {
+	var subject *goSet.EventSubject
+	if streamId != "" {
+		subject = &goSet.EventSubject{
+			SubjectIdentifier: goSet.SubjectIdentifier{
+				Format: "opaque",
+				OpaqueIdentifier: goSet.OpaqueIdentifier{
+					Id: streamId,
+				},
+			},
+		}
+	}
+
+	set := goSet.CreateSet(subject, issuer, audience)
+
+	var reasonPay *string
+	if reason != "" {
+		reasonPay = &reason
+	}
+
+	payload := StreamUpdatePayload{
+		Status: status,
+		Reason: reasonPay,
+	}
+	set.AddEventPayload(StatusUpdatedEventUri, payload)
+
+	return &set
+}

--- a/pkg/goSet/events/streamUpdated_event_test.go
+++ b/pkg/goSet/events/streamUpdated_event_test.go
@@ -1,0 +1,108 @@
+package events
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateStatusUpdatedEvent(t *testing.T) {
+	streamId := "test-stream-id"
+	status := "enabled"
+	reason := "test-reason"
+	issuer := "https://transmitter.example.com"
+	audience := []string{"https://receiver.example.com"}
+
+	set := CreateStatusUpdatedEvent(streamId, status, reason, issuer, audience)
+
+	assert.NotNil(t, set)
+	assert.Equal(t, issuer, set.Issuer)
+	assert.Equal(t, audience, []string(set.Audience))
+
+	// Check subject
+	assert.NotNil(t, set.SubjectId)
+	assert.Equal(t, "opaque", set.SubjectId.Format)
+	assert.Equal(t, streamId, set.SubjectId.Id)
+
+	// Check event payload
+	payloadInterface, ok := set.Events[StatusUpdatedEventUri]
+	assert.True(t, ok)
+
+	payload, ok := payloadInterface.(StreamUpdatePayload)
+	assert.True(t, ok)
+	assert.Equal(t, status, payload.Status)
+	assert.NotNil(t, payload.Reason)
+	assert.Equal(t, reason, *payload.Reason)
+
+	// Verify JSON marshaling
+	jsonBytes, err := json.Marshal(set)
+	assert.NoError(t, err)
+
+	var jsonMap map[string]interface{}
+	err = json.Unmarshal(jsonBytes, &jsonMap)
+	assert.NoError(t, err)
+
+	// Check sub_id in JSON
+	subId, ok := jsonMap["sub_id"].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, "opaque", subId["format"])
+	assert.Equal(t, streamId, subId["id"])
+
+	// Check events in JSON
+	events, ok := jsonMap["events"].(map[string]interface{})
+	assert.True(t, ok)
+	updateEvent, ok := events[StatusUpdatedEventUri].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, status, updateEvent["status"])
+	assert.Equal(t, reason, updateEvent["reason"])
+}
+
+func TestCreateStatusUpdatedEventNoStream(t *testing.T) {
+	status := "disabled"
+	reason := "test-reason"
+	issuer := "https://transmitter.example.com"
+	audience := []string{"https://receiver.example.com"}
+
+	set := CreateStatusUpdatedEvent("", status, reason, issuer, audience)
+
+	assert.NotNil(t, set)
+	assert.Nil(t, set.SubjectId)
+	assert.Empty(t, set.Subject)
+
+	payloadInterface, ok := set.Events[StatusUpdatedEventUri]
+	assert.True(t, ok)
+	payload := payloadInterface.(StreamUpdatePayload)
+	assert.Equal(t, status, payload.Status)
+	assert.Equal(t, reason, *payload.Reason)
+}
+
+func TestCreateStatusUpdatedEventNoReason(t *testing.T) {
+	streamId := "test-stream-id"
+	status := "paused"
+	issuer := "https://transmitter.example.com"
+	audience := []string{"https://receiver.example.com"}
+
+	set := CreateStatusUpdatedEvent(streamId, status, "", issuer, audience)
+
+	assert.NotNil(t, set)
+	payloadInterface, ok := set.Events[StatusUpdatedEventUri]
+	assert.True(t, ok)
+	payload := payloadInterface.(StreamUpdatePayload)
+	assert.Equal(t, status, payload.Status)
+	assert.Nil(t, payload.Reason)
+
+	// Verify reason is omitted in JSON
+	jsonBytes, err := json.Marshal(set)
+	assert.NoError(t, err)
+
+	var jsonMap map[string]interface{}
+	err = json.Unmarshal(jsonBytes, &jsonMap)
+	assert.NoError(t, err)
+
+	events := jsonMap["events"].(map[string]interface{})
+	updateEvent := events[StatusUpdatedEventUri].(map[string]interface{})
+	_, ok = updateEvent["reason"]
+	assert.False(t, ok, "reason should be omitted if empty")
+	assert.Equal(t, status, updateEvent["status"])
+}

--- a/pkg/goSet/events/verify_event.go
+++ b/pkg/goSet/events/verify_event.go
@@ -1,0 +1,32 @@
+package events
+
+import "github.com/i2-open/i2goSignals/pkg/goSet"
+
+type VerifyPayload struct {
+	State string `json:"state,omitempty"`
+}
+
+const VerificationEventUri = "https://schemas.openid.net/secevent/ssf/event-type/verification"
+
+func CreateVerifyEvent(streamId string, state string, issuer string, audience []string) *goSet.SecurityEventToken {
+	var subject *goSet.EventSubject
+	if streamId != "" {
+		subject = &goSet.EventSubject{
+			SubjectIdentifier: goSet.SubjectIdentifier{
+				Format: "opaque",
+				OpaqueIdentifier: goSet.OpaqueIdentifier{
+					Id: streamId,
+				},
+			},
+		}
+	}
+
+	set := goSet.CreateSet(subject, issuer, audience)
+
+	payload := VerifyPayload{
+		State: state,
+	}
+	set.AddEventPayload(VerificationEventUri, payload)
+
+	return &set
+}

--- a/pkg/goSet/events/verify_event_test.go
+++ b/pkg/goSet/events/verify_event_test.go
@@ -1,0 +1,99 @@
+package events
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateVerifyEvent(t *testing.T) {
+	streamId := "test-stream-id"
+	state := "test-state"
+	issuer := "https://transmitter.example.com"
+	audience := []string{"https://receiver.example.com"}
+
+	set := CreateVerifyEvent(streamId, state, issuer, audience)
+
+	assert.NotNil(t, set)
+	assert.Equal(t, issuer, set.Issuer)
+	assert.Equal(t, audience, []string(set.Audience))
+
+	// Check subject
+	assert.NotNil(t, set.SubjectId)
+	assert.Equal(t, "opaque", set.SubjectId.Format)
+	assert.Equal(t, streamId, set.SubjectId.Id)
+
+	// Check event payload
+	payloadInterface, ok := set.Events[VerificationEventUri]
+	assert.True(t, ok)
+
+	payload, ok := payloadInterface.(VerifyPayload)
+	assert.True(t, ok)
+	assert.Equal(t, state, payload.State)
+
+	// Verify JSON marshaling
+	jsonBytes, err := json.Marshal(set)
+	assert.NoError(t, err)
+
+	var jsonMap map[string]interface{}
+	err = json.Unmarshal(jsonBytes, &jsonMap)
+	assert.NoError(t, err)
+
+	// Check sub_id in JSON
+	subId, ok := jsonMap["sub_id"].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, "opaque", subId["format"])
+	assert.Equal(t, streamId, subId["id"])
+
+	// Check events in JSON
+	events, ok := jsonMap["events"].(map[string]interface{})
+	assert.True(t, ok)
+	verifyEvent, ok := events[VerificationEventUri].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, state, verifyEvent["state"])
+}
+
+func TestCreateVerifyEventNoStream(t *testing.T) {
+	state := "test-state"
+	issuer := "https://transmitter.example.com"
+	audience := []string{"https://receiver.example.com"}
+
+	set := CreateVerifyEvent("", state, issuer, audience)
+
+	assert.NotNil(t, set)
+	assert.Nil(t, set.SubjectId)
+	assert.Empty(t, set.Subject)
+
+	payloadInterface, ok := set.Events[VerificationEventUri]
+	assert.True(t, ok)
+	payload := payloadInterface.(VerifyPayload)
+	assert.Equal(t, state, payload.State)
+}
+
+func TestCreateVerifyEventNoState(t *testing.T) {
+	streamId := "test-stream-id"
+	issuer := "https://transmitter.example.com"
+	audience := []string{"https://receiver.example.com"}
+
+	set := CreateVerifyEvent(streamId, "", issuer, audience)
+
+	assert.NotNil(t, set)
+	payloadInterface, ok := set.Events[VerificationEventUri]
+	assert.True(t, ok)
+	payload := payloadInterface.(VerifyPayload)
+	assert.Empty(t, payload.State)
+
+	// Verify state is omitted in JSON
+	jsonBytes, err := json.Marshal(set)
+	assert.NoError(t, err)
+
+	var jsonMap map[string]interface{}
+	err = json.Unmarshal(jsonBytes, &jsonMap)
+	assert.NoError(t, err)
+
+	events := jsonMap["events"].(map[string]interface{})
+	verifyEvent := events[VerificationEventUri].(map[string]interface{})
+	_, ok = verifyEvent["state"]
+	assert.False(t, ok, "state should be omitted if empty")
+}

--- a/pkg/goSet/set.go
+++ b/pkg/goSet/set.go
@@ -173,7 +173,7 @@ func (set *SecurityEventToken) JsonBytes() []byte {
 	return jsonBuf.Bytes()
 }
 
-func (set *SecurityEventToken) AddEventPayload(eventUri string, eventClaims map[string]interface{}) {
+func (set *SecurityEventToken) AddEventPayload(eventUri string, eventClaims interface{}) {
 	if set.Events == nil {
 		set.Events = map[string]interface{}{}
 	}

--- a/pkg/goSignals/server/api_stream_management.go
+++ b/pkg/goSignals/server/api_stream_management.go
@@ -18,6 +18,7 @@ import (
 	"github.com/i2-open/i2goSignals/internal/eventRouter"
 	"github.com/i2-open/i2goSignals/internal/model"
 	"github.com/i2-open/i2goSignals/internal/providers/dbProviders/mongo_provider"
+	"github.com/i2-open/i2goSignals/pkg/constants"
 
 	"github.com/gorilla/mux"
 )
@@ -341,11 +342,6 @@ func (sa *SignalsApplication) UpdateStatus(w http.ResponseWriter, r *http.Reques
 
 }
 
-func (sa *SignalsApplication) VerificationRequest(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-	w.WriteHeader(http.StatusNotImplemented)
-}
-
 func (sa *SignalsApplication) getTransmitterConfig() *model.TransmitterConfiguration {
 	baseUrl := sa.GetBaseUrl()
 	jwksUri, _ := baseUrl.Parse("/jwks.json")
@@ -353,7 +349,7 @@ func (sa *SignalsApplication) getTransmitterConfig() *model.TransmitterConfigura
 	statusUri, _ := baseUrl.Parse("/status")
 	addSubUri, _ := baseUrl.Parse("/add-subject")
 	remSubUri, _ := baseUrl.Parse("/remove-subject")
-	verifyUri, _ := baseUrl.Parse("/verification")
+	verifyUri, _ := baseUrl.Parse("/verify")
 	regUri, _ := baseUrl.Parse("/register")
 
 	return &model.TransmitterConfiguration{
@@ -382,11 +378,16 @@ func (sa *SignalsApplication) getTransmitterConfig() *model.TransmitterConfigura
 			"poll":                         {authUtil.ScopeEventDelivery},
 			"client_registration_endpoint": {authUtil.ScopeRegister},
 		},
+		AuthorizationSchemes: []model.AuthScheme{
+			{SpecUrn: constants.BearerAuth},
+			{SpecUrn: constants.RFC6749},
+		},
 		AuthorizationServers:   sa.Auth.GetOAuthServers(),
 		ScopesSupported:        []string{authUtil.ScopeEventDelivery, authUtil.ScopeStreamAdmin, authUtil.ScopeStreamMgmt, authUtil.ScopeRegister},
 		BearerMethodsSupported: []string{"header"},
 
-		GoSignalsVersion: "0.8",
+		GoSignalsVersion: constants.GoSignalsVersion,
+		SpecVersion:      constants.SSF_VERSION,
 	}
 }
 

--- a/pkg/goSignals/server/api_verify.go
+++ b/pkg/goSignals/server/api_verify.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/i2-open/i2goSignals/internal/authUtil"
+	"github.com/i2-open/i2goSignals/internal/logger"
+	"github.com/i2-open/i2goSignals/pkg/goSet/events"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+var verifyLog = logger.Sub("VERIFY")
+
+type VerificationRequestPayload struct {
+	StreamId string `json:"stream_id"`
+	State    string `json:"state,omitempty"`
+}
+
+// VerificationRequest implements the SSF Stream Verification Event process as described in section 8.1.4.2.
+func (sa *SignalsApplication) VerificationRequest(w http.ResponseWriter, r *http.Request) {
+	verifyLog.Debug("POST VerificationRequest")
+	authCtx, status := sa.Auth.ValidateAuthorization(r, []string{authUtil.ScopeEventDelivery, authUtil.ScopeStreamMgmt})
+
+	if status != http.StatusOK {
+		w.WriteHeader(status)
+		return
+	}
+
+	var payload VerificationRequestPayload
+	err := json.NewDecoder(r.Body).Decode(&payload)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if payload.StreamId == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// The authorization token may already have a stream ID. If it does, it must match.
+	if authCtx.StreamId != "" && authCtx.StreamId != payload.StreamId {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
+	// Check if the stream exists
+	stream, err := sa.Provider.GetStream(payload.StreamId)
+	if err != nil || stream == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	// Create the verification event
+	// We need issuer and audience.
+	// Issuer is stream.Iss, Audience is stream.Aud
+	event := events.CreateVerifyEvent(payload.StreamId, payload.State, stream.Iss, stream.Aud)
+
+	// Add the event to the system
+	eventRec := sa.Provider.AddEvent(event, payload.StreamId, "")
+
+	// Trigger the event on the stream
+	streamObjId, err := primitive.ObjectIDFromHex(payload.StreamId)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	sa.Provider.AddEventToStream(eventRec.Jti, streamObjId)
+
+	// Return 204 No Content on success
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/pkg/goSignals/server/application.go
+++ b/pkg/goSignals/server/application.go
@@ -55,6 +55,9 @@ func (sa *SignalsApplication) SetBaseUrl(u *url.URL) {
 	sa.mu.Lock()
 	defer sa.mu.Unlock()
 	sa.BaseUrl = u
+	if sa.Provider != nil {
+		sa.Provider.SetBaseUrl(u)
+	}
 }
 
 func (sa *SignalsApplication) HealthCheck() bool {
@@ -108,6 +111,9 @@ func NewApplication(provider dbProviders.DbProviderInterface, baseUrlString stri
 		}
 	}
 	sa.BaseUrl = baseUrl
+	if sa.Provider != nil {
+		sa.Provider.SetBaseUrl(baseUrl)
+	}
 
 	sa.InitializePrometheus()
 
@@ -197,6 +203,9 @@ func StartServer(addr string, provider dbProviders.DbProviderInterface, baseUrlS
 	if sa.BaseUrl == nil {
 		baseUrl, _ := url.Parse("http://" + server.Addr + "/")
 		sa.BaseUrl = baseUrl
+		if sa.Provider != nil {
+			sa.Provider.SetBaseUrl(baseUrl)
+		}
 	}
 	sa.mu.Unlock()
 	serverLog.Info("Server listening", "db", provider.Name(), "addr", addr)

--- a/pkg/goSignals/server/routers.go
+++ b/pkg/goSignals/server/routers.go
@@ -218,6 +218,14 @@ func (h *HttpRouter) getRoutes() Routes {
 		},
 
 		Route{
+			"VerificationRequestSSF",
+			http.MethodPost,
+			"/verify",
+			h.sa.VerificationRequest,
+			false,
+		},
+
+		Route{
 			"WellKnownSsfConfigurationGet",
 			http.MethodGet,
 			"/.well-known/ssf-configuration",

--- a/pkg/goSignals/server/test/api_verify_test.go
+++ b/pkg/goSignals/server/test/api_verify_test.go
@@ -1,0 +1,137 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/i2-open/i2goSignals/internal/model"
+	"github.com/i2-open/i2goSignals/pkg/goSet/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type VerifySuite struct {
+	suite.Suite
+	instance *ssfInstance
+}
+
+func (suite *VerifySuite) SetupSuite() {
+	instance, err := createServer(suite.T(), "verify_test", true)
+	assert.NoError(suite.T(), err)
+	suite.instance = instance
+}
+
+func (suite *VerifySuite) TearDownSuite() {
+	if suite.instance != nil {
+		suite.instance.app.Shutdown()
+		suite.instance.ts.Close()
+	}
+}
+
+func TestVerifySuite(t *testing.T) {
+	suite.Run(t, new(VerifySuite))
+}
+
+func (suite *VerifySuite) TestTriggerVerification() {
+	t := suite.T()
+	instance := suite.instance
+
+	// 1. Create a stream
+	streamConfig := model.StreamConfiguration{
+		Iss:             "DEFAULT",
+		Aud:             []string{"https://receiver.example.com"},
+		EventsSupported: []string{"https://schemas.openid.net/secevent/ssf/event-type/verification"},
+		Delivery: &model.OneOfStreamConfigurationDelivery{
+			PollTransmitMethod: &model.PollTransmitMethod{
+				Method: model.DeliveryPoll,
+			},
+		},
+	}
+
+	body, _ := json.Marshal(streamConfig)
+	req, _ := http.NewRequest(http.MethodPost, instance.ts.URL+"/stream", bytes.NewBuffer(body))
+	req.Header.Set("Authorization", "Bearer "+instance.streamMgmtToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := instance.client.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var createdStream model.StreamConfiguration
+	_ = json.NewDecoder(resp.Body).Decode(&createdStream)
+	streamId := createdStream.Id
+
+	// 2. Generate a token for this stream specifically if needed,
+	// but the streamMgmtToken might already have access if it was created with the project ID.
+	// Actually, the server implementation of VerificationRequest allows any token with ScopeEventDelivery or ScopeStreamMgmt.
+	// ValidateAuthorization for /verification usually expects stream_id in the token or as a query param.
+
+	// Create a token for this specific stream
+	streamToken, err := instance.provider.GetAuthIssuer().IssueStreamToken(streamId, instance.projectId)
+	assert.NoError(t, err)
+
+	// 3. Trigger verification
+	verifyReq := struct {
+		StreamId string `json:"stream_id"`
+		State    string `json:"state"`
+	}{
+		StreamId: streamId,
+		State:    "test-state",
+	}
+
+	verifyBody, _ := json.Marshal(verifyReq)
+	req, _ = http.NewRequest(http.MethodPost, instance.ts.URL+"/verify", bytes.NewBuffer(verifyBody))
+	req.Header.Set("Authorization", "Bearer "+streamToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err = instance.client.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	// 4. Verify that an event was created
+	// We can check the pending events for the stream
+	jtis, _ := instance.provider.GetEventIds(streamId, model.PollParameters{MaxEvents: 10})
+	assert.Len(t, jtis, 1)
+
+	// Get the event and check its content
+	event := instance.provider.GetEvent(jtis[0])
+	assert.NotNil(t, event)
+	assert.Contains(t, event.Events, "https://schemas.openid.net/secevent/ssf/event-type/verification")
+
+	payload := event.Events["https://schemas.openid.net/secevent/ssf/event-type/verification"].(events.VerifyPayload)
+	assert.Equal(t, "test-state", payload.State)
+}
+
+func (suite *VerifySuite) TestTriggerVerificationError() {
+	t := suite.T()
+	instance := suite.instance
+
+	// 1. Invalid stream ID (404)
+	verifyReq := struct {
+		StreamId string `json:"stream_id"`
+		State    string `json:"state"`
+	}{
+		StreamId: "non-existent-stream",
+		State:    "test-state",
+	}
+
+	verifyBody, _ := json.Marshal(verifyReq)
+	req, _ := http.NewRequest(http.MethodPost, instance.ts.URL+"/verify", bytes.NewBuffer(verifyBody))
+	req.Header.Set("Authorization", "Bearer "+instance.streamMgmtToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := instance.client.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+
+	// 2. Malformed JSON (400)
+	req, _ = http.NewRequest(http.MethodPost, instance.ts.URL+"/verify", bytes.NewBuffer([]byte("{invalid-json}")))
+	req.Header.Set("Authorization", "Bearer "+instance.streamMgmtToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err = instance.client.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}

--- a/pkg/goSignals/server/test/server_test.go
+++ b/pkg/goSignals/server/test/server_test.go
@@ -200,7 +200,7 @@ func (suite *ServerSuite) Test2_WellKnownConfigs() {
 	err = json.Unmarshal(body, &config)
 	assert.NoError(suite.T(), err, "Configuration parsed and returned")
 
-	verifyUrlString := fmt.Sprintf("http://%s/verification", suite.servers[0].host)
+	verifyUrlString := fmt.Sprintf("http://%s/verify", suite.servers[0].host)
 	assert.Equal(suite.T(), verifyUrlString, config.VerificationEndpoint, "Confirm baseurl to verify url calculation correct")
 	streamUrlString := fmt.Sprintf("http://%s/stream", suite.servers[0].host)
 	assert.Equal(suite.T(), streamUrlString, config.ConfigurationEndpoint, "Configuration endpoint matches")


### PR DESCRIPTION
This pull request includes the following updates:

- Updated event types to include the latest SCIM, RISC, and CAEP specifications.
- Added auto transmitter registration functionality for creating receiver streams.
- Introduced support for verifying events.
- Implemented the initial spike for cluster support functionality.  

These changes aim to enhance system capabilities and improve scalability.