### PR TITLE
fix(eventRouter): sync stream.RemoteAddress after outbound push (#27)

### DIFF
--- a/DECISIONS_LOG.md
+++ b/DECISIONS_LOG.md
@@ -1,5 +1,34 @@
 # Architectural Decision & Regression Log
 
+## [2026-05-06] Stream `remote_address` field on StreamStateRecord
+
+### Change
+`StreamStateRecord` now carries a `*RemoteIP` (`pkg/ssfModels`) populated for all four
+delivery modes — `ReceivePush`, `DeliveryPoll` (inbound, from `r.RemoteAddr` and
+`X-Forwarded-For`/`X-Real-IP`), and `DeliveryPush`, `ReceivePoll` (outbound, captured
+via `httptrace.WithClientTrace` on the resolved TCP peer). It surfaces in stream
+state JSON as `remote_address` with `protocol`, `ip`, and `forwarded` sub-fields,
+omitted on streams that have never had a successful connection.
+
+### Invariants
+- Capture happens only after authorization succeeds — unauthenticated probes never
+  pollute the field.
+- `X-Forwarded-For` / `X-Real-IP` are stored as informational metadata only; no auth
+  or trust path consumes them.
+- Mongo persistence uses a `$set` scoped to `remote_address`, so it does not race
+  with concurrent `UpdateStreamStatus` writes on the same document.
+- `pushEvent` and `runPollLoop` mirror the persisted value back into their local
+  stream pointer after a successful update so the only-when-changed guard on the
+  next iteration short-circuits instead of issuing redundant DB writes (see
+  regression #27).
+
+### Regression Verification
+- `go test ./pkg/ssfModels/...`
+- `go test ./internal/eventRouter/... -run TestPushEvent_`
+- `go test ./pkg/goSignals/server/test/... -run TestRemoteAddressSuite`
+
+---
+
 ## [2026-04-10] SPIFFE Dual-Validation Strategy (Resilient MTLS)
 
 ### Problem

--- a/internal/eventRouter/event_router.go
+++ b/internal/eventRouter/event_router.go
@@ -1245,6 +1245,9 @@ func (r *router) pushEvent(stream *model.StreamStateRecord, event *model.AgEvent
 		remoteIP := model.BuildOutboundRemoteIP(scheme, capturedAddr)
 		if !remoteIP.Equals(stream.RemoteAddress) {
 			r.provider.UpdateRemoteAddress(configuration.Id, remoteIP)
+			// Keep the loop's local stream pointer in sync so the next pushEvent's
+			// Equals check can short-circuit instead of triggering a redundant DB write.
+			stream.RemoteAddress = remoteIP
 		}
 	}
 

--- a/internal/eventRouter/pushevent_remote_address_test.go
+++ b/internal/eventRouter/pushevent_remote_address_test.go
@@ -1,0 +1,111 @@
+package eventRouter
+
+import (
+    "net/http"
+    "net/http/httptest"
+    "testing"
+
+    "github.com/i2-open/i2goSignals/internal/authUtil"
+    "github.com/i2-open/i2goSignals/internal/providers/dbProviders"
+    "github.com/i2-open/i2goSignals/pkg/goSet"
+    "github.com/i2-open/i2goSignals/pkg/goSetPush"
+    "github.com/i2-open/i2goSignals/pkg/ssfModels"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// mustCreateForwardModeStream creates a DeliveryPush stream in RouteModeForward (no signing key needed)
+// pointing at the supplied endpoint URL.
+func mustCreateForwardModeStream(t *testing.T, provider dbProviders.DbProviderInterface, projectId, endpoint string) *model.StreamStateRecord {
+    t.Helper()
+    cfg := model.StreamConfiguration{
+        Iss:             "DEFAULT",
+        Aud:             []string{"https://receiver.example.com"},
+        EventsDelivered: []string{"https://schemas.openid.net/secevent/risc/event-type/account-disabled"},
+        RouteMode:       model.RouteModeForward,
+        Delivery: &model.OneOfStreamConfigurationDelivery{
+            PushTransmitMethod: &model.PushTransmitMethod{
+                Method:      model.DeliveryPush,
+                EndpointUrl: endpoint,
+            },
+        },
+    }
+    created, err := provider.CreateStream(cfg, authUtil.ConvertProject(projectId))
+    require.NoError(t, err)
+    state, err := provider.GetStreamState(created.Id)
+    require.NoError(t, err)
+    require.NotNil(t, state)
+    return state
+}
+
+// TestPushEvent_UpdatesLocalRemoteAddressOnFirstPush verifies that after a successful push,
+// the local stream pointer's RemoteAddress field is updated alongside the persisted value.
+//
+// Without this, the in-memory stream held by runPushLoop drifts out of sync with the DB,
+// and the only-when-changed guard in pushEvent triggers a redundant DB write on every
+// subsequent push (since stream.RemoteAddress stays nil from the loop's perspective).
+func TestPushEvent_UpdatesLocalRemoteAddressOnFirstPush(t *testing.T) {
+    receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+        w.WriteHeader(http.StatusAccepted)
+    }))
+    defer receiver.Close()
+
+    r, provider := newTestRouter(t)
+    projectId := projectIdFromProvider(t, provider)
+    stream := mustCreateForwardModeStream(t, provider, projectId, receiver.URL+"/events/test")
+    require.Nil(t, stream.RemoteAddress, "precondition: RemoteAddress is nil before any push")
+
+    event := &model.AgEventRecord{
+        Jti:      "jti-1",
+        Original: "raw-token-string",
+        Event:    goSet.SecurityEventToken{},
+    }
+
+    cls := r.pushEvent(stream, event, nil, "")
+    require.Equal(t, goSetPush.ClassAccepted, cls.Class, "push to mock receiver should classify as accepted")
+
+    // The fix: local stream pointer must reflect the persisted remote address so the next
+    // pushEvent's Equals() check can short-circuit.
+    require.NotNil(t, stream.RemoteAddress, "stream.RemoteAddress should be populated locally after push")
+    assert.NotEmpty(t, stream.RemoteAddress.IP, "captured IP should be non-empty")
+    assert.Equal(t, "http", stream.RemoteAddress.Protocol, "scheme should match the endpoint URL")
+
+    // Also confirm the persisted record matches — this is the existing contract from #26.
+    persisted, err := provider.GetStreamState(stream.StreamConfiguration.Id)
+    require.NoError(t, err)
+    require.NotNil(t, persisted.RemoteAddress)
+    assert.Equal(t, stream.RemoteAddress.IP, persisted.RemoteAddress.IP, "in-memory and persisted IP must match")
+}
+
+// TestPushEvent_SecondPushSamePeerIsNoop verifies the only-when-changed optimization:
+// when the local stream's RemoteAddress already matches the captured peer, pushEvent
+// must not issue another UpdateRemoteAddress call.
+//
+// We assert this indirectly by checking that the local stream pointer's RemoteAddress
+// stays equal across the two calls — if the fix is in place, the second call's Equals()
+// check returns true and the provider call is skipped.
+func TestPushEvent_SecondPushSamePeerIsNoop(t *testing.T) {
+    receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+        w.WriteHeader(http.StatusAccepted)
+    }))
+    defer receiver.Close()
+
+    r, provider := newTestRouter(t)
+    projectId := projectIdFromProvider(t, provider)
+    stream := mustCreateForwardModeStream(t, provider, projectId, receiver.URL+"/events/test")
+
+    event1 := &model.AgEventRecord{Jti: "jti-1", Original: "raw-1"}
+    event2 := &model.AgEventRecord{Jti: "jti-2", Original: "raw-2"}
+
+    cls1 := r.pushEvent(stream, event1, nil, "")
+    require.Equal(t, goSetPush.ClassAccepted, cls1.Class)
+    require.NotNil(t, stream.RemoteAddress, "first push should populate RemoteAddress")
+    firstAddr := *stream.RemoteAddress
+
+    cls2 := r.pushEvent(stream, event2, nil, "")
+    require.Equal(t, goSetPush.ClassAccepted, cls2.Class)
+    require.NotNil(t, stream.RemoteAddress, "second push must not clear RemoteAddress")
+
+    assert.True(t, stream.RemoteAddress.Equals(&firstAddr),
+        "second push to same peer must leave local RemoteAddress unchanged")
+}


### PR DESCRIPTION
## Summary
- Closes #27 — review checklist for the remote peer address feature (#24/#25/#26).
- Fixes a regression in `internal/eventRouter/event_router.go`: after `pushEvent` called `provider.UpdateRemoteAddress`, the runPushLoop's local `*StreamStateRecord` retained its previous (often `nil`) `RemoteAddress`, so the only-when-changed guard never short-circuited and every successful push issued another Mongo `$set`. Mirroring the persisted value back into `stream.RemoteAddress` matches what `runPollLoop` already does and restores the intended optimization.
- Adds `DECISIONS_LOG.md` entry documenting the new `remote_address` field, invariants, and regression verification.
- Adds `internal/eventRouter/pushevent_remote_address_test.go` with two regression tests (TDD RED→GREEN).

## Review checklist results
| # | Item | Status |
|---|------|--------|
| 1 | JSON shape `{protocol, ip, forwarded}` with omitempty | Pass |
| 2 | `X-Forwarded-For` not used in trust decisions | Pass |
| 3 | Mongo `$set` scoped to `remote_address` only | Pass |
| 4 | In-memory cache stays consistent | **Fixed in this PR** |
| 5 | httptrace doesn't break cancellation | Pass |
| 6 | Capture only after auth | Pass |
| 7 | `Equals` covers all 3 fields incl. nil | Pass |
| 8 | `RemoteIP` deserializable by goSignalsAdmin | Pass |
| 9 | DECISIONS_LOG entry | **Added in this PR** |

## Test plan
- [x] `go test -race ./internal/eventRouter/...` — passes (incl. new regression tests)
- [x] `go test -race ./pkg/ssfModels/... ./internal/dao/memory/... ./internal/dao/mongo/...` — passes
- [x] `go test -race ./pkg/goSignals/server/test/... -run TestRemoteAddressSuite` — passes
- [x] `go test -race ./pkg/goSignals/...` — passes (full server suite)
- [x] `go vet ./internal/eventRouter/ ./pkg/ssfModels/` — only pre-existing warnings (per CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)