### PR TITLE
fix(observability): drop docker-log backfill in alloy

### DIFF
--- a/config/monitor/alloy/config.alloy
+++ b/config/monitor/alloy/config.alloy
@@ -38,6 +38,18 @@ loki.source.docker "containers" {
 loki.process "parse_json" {
     forward_to = [loki.write.local.receiver]
 
+    // Drop docker-log backfill from before alloy started. Without this,
+    // alloy replays each long-running container's full stdout buffer on
+    // boot, and Loki rejects entries older than its per-stream creation
+    // grace period (~1h) with HTTP 400 "entry too far behind", producing
+    // a burst of error lines in alloy's own logs. Five minutes is plenty
+    // of headroom for the boot race between alloy and the goSignals
+    // services without keeping any actually stale entries.
+    stage.drop {
+        older_than          = "5m"
+        drop_counter_reason = "old_backfill"
+    }
+
     stage.json {
         expressions = {
             service      = "service",


### PR DESCRIPTION
## Summary

Suppresses the boot-time error spam in the alloy container's own logs that follows from `loki.source.docker` replaying each long-running container's full stdout buffer.

Adds a single `stage.drop { older_than = "5m" }` at the head of `loki.process.parse_json` so backfill is discarded silently at the collector instead of being shipped, rejected by Loki, and retried ten times before being dropped anyway.

### Root cause
Loki enforces a per-stream creation-grace-period (~1h after the latest entry in a stream); entries older than that are rejected with HTTP 400 `entry too far behind`. The dev compose containers can have been running for days, so on alloy startup Loki rejects most of the replayed buffer. Alloy retries each batch ~10× before logging `final error sending batch, no retries left, dropping data`. Net effect: 380 error lines in the first 90s of alloy's life, all transient and unactionable.

### Production note
Production deployments running Alloy as a per-pod DaemonSet don't hit this — the alloy lifecycle tracks the pod lifecycle, so there's no historical buffer to replay. This is a dev-compose-only annoyance.

## Test plan

- [x] `docker compose -f docker-compose-dev.yml restart alloy` then `docker logs --since 60s alloy | grep -c level=error` → `0` (was 380).
- [x] `curl -fsS http://localhost:3200/metrics | grep loki_process_dropped_lines_total` shows the counter incrementing with `reason="old_backfill"`.
- [x] `bash scripts/verify-observability.sh` passes all 8 checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)