### PR TITLE
feat(observability): wire i2scim peers into Loki/Prometheus stack

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -177,6 +177,47 @@ imports `internal/server`, crossing the `pkg/` → `internal/` boundary.
 Reabsorbing `pkg/goSsfServer` into `internal/` (or `cmd/goSsfServer/`)
 is deferred — recorded in PRD #50 Out of Scope.
 
+## Log-level policy
+
+The four slog levels (`DEBUG` / `INFO` / `WARN` / `ERROR`) are the same
+labels that flow through to Loki and any dashboards built on top. Pick the
+right one so operators can rely on `level=ERROR` as a real attention
+signal, not a noise floor:
+
+- **`DEBUG`** — Verbose internal state. Off in production.
+- **`INFO`** — Steady-state operational facts: stream registered, lease
+  acquired, push delivered.
+- **`WARN`** — Recoverable and *expected-as-part-of-normal-operation*
+  conditions. Examples:
+  - **Authentication and authorization failures** — bad token, expired
+    bearer, mismatched audience, missing scope. These are a normal part
+    of running an internet-facing server; clients re-auth, servers don't
+    need a human.
+  - **A stream that fails to connect on a single attempt.** Treat as
+    `WARN` until the retry budget is exhausted and it is declared a
+    permanent failure (then promote to `ERROR`).
+  - **A receiver returning 4xx that the RFC8935 retry policy already
+    covers.** The router handles it; the operator does not need to.
+- **`ERROR`** — Demands operations attention. Reserve for conditions that
+  will not resolve themselves without human intervention. Examples:
+  - A stream that has crossed its retry budget and is now declared
+    permanently offline.
+  - The persistence layer has lost its primary and exhausted reconnect
+    attempts.
+  - An internal invariant violation (e.g. lease ownership mismatch with
+    a fencing token in the past).
+
+The discipline is asymmetric. Promoting an item from `WARN` to `ERROR`
+because "it might matter" pollutes the signal that on-call uses to
+decide whether to wake up. Demoting an existing `ERROR` to `WARN`
+because the condition turned out to be normal-ops is welcome — leave a
+note at the call site so the next reader knows it was deliberate.
+
+If you find yourself wanting a fifth level ("this is serious but not
+quite ERROR"), the answer is almost always `WARN` plus an `error=` field
+on the record. Grafana / LogQL can already filter `{level="WARN"} | json
+| error="..."` for the subset that matters; a new level cannot.
+
 ## Adding a new persistence method
 
 1. Add the method to the appropriate **DAO interface**

--- a/config/monitor/prometheus/prometheus.yml
+++ b/config/monitor/prometheus/prometheus.yml
@@ -31,3 +31,13 @@ scrape_configs:
       - targets:
           - gosignals1:8888
           - gosignals2:8889
+  - job_name: i2scim
+    honor_timestamps: true
+    scrape_interval: 15s
+    scrape_timeout: 10s
+    metrics_path: /q/metrics
+    scheme: http
+    static_configs:
+      - targets:
+          - scim_cluster1:8080
+          - scim_cluster2:8080

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -379,6 +379,10 @@ services:
       - ./config/scim/data1:/scim
     env_file:
       - ./config/scim/scripts/scim-server.env
+    environment:
+      - QUARKUS_LOG_CONSOLE_JSON=true
+      - NODE_ID=scim_cluster1
+      - CLUSTER_NAME=dev-local
   scim_cluster2:
     image: independentid/i2scim-universal:latest
     container_name: scim_cluster2
@@ -395,6 +399,10 @@ services:
       - ./config/scim/data2:/scim
     env_file:
       - ./config/scim/scripts/scim-server.env
+    environment:
+      - QUARKUS_LOG_CONSOLE_JSON=true
+      - NODE_ID=scim_cluster2
+      - CLUSTER_NAME=dev-local
   postgres:
     image: postgres:alpine
     volumes:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -89,15 +89,23 @@ fast filtering and dashboards described later in this document.
 shipping pipeline so you can poke at it before committing to a cloud
 choice:
 
-| Container     | Role                       | URL                                |
-|---------------|----------------------------|------------------------------------|
-| `gosignals1`  | goSignals server (node 1)  | http://localhost:8888              |
-| `gosignals2`  | goSignals server (node 2)  | http://localhost:8889              |
-| `gossfserver` | Demo SSF receiver          | http://localhost:8881              |
-| `alloy`       | Log collector              | http://localhost:3200 (UI)         |
-| `loki`        | Log backend                | http://localhost:3100              |
-| `grafana`     | Query/visualization UI     | http://localhost:3000 (admin/grafana) |
-| `prometheus`  | Metrics backend            | http://localhost:9090              |
+| Container       | Role                       | URL                                |
+|-----------------|----------------------------|------------------------------------|
+| `gosignals1`    | goSignals server (node 1)  | http://localhost:8888              |
+| `gosignals2`    | goSignals server (node 2)  | http://localhost:8889              |
+| `gossfserver`   | Demo SSF receiver          | http://localhost:8881              |
+| `scim_cluster1` | i2scim peer (node 1)       | http://localhost:9000              |
+| `scim_cluster2` | i2scim peer (node 2)       | http://localhost:9001              |
+| `alloy`         | Log collector              | http://localhost:3200 (UI)         |
+| `loki`          | Log backend                | http://localhost:3100              |
+| `grafana`       | Query/visualization UI     | http://localhost:3000 (admin/grafana) |
+| `prometheus`    | Metrics backend            | http://localhost:9090              |
+
+The SCIM peers run the `independentid/i2scim-universal` image. They are
+wired into the same observability stack as the goSignals services: their
+stdout JSON is auto-discovered by Alloy via the Docker socket, and
+Prometheus scrapes their `/q/metrics` endpoint as the `i2scim` job. See
+§1 (label values) and §2 (Prometheus job) below for the contract.
 
 Run `make dev-up`, wait ~30 seconds, then:
 
@@ -263,6 +271,43 @@ parser, not the label index. See §8 for LogQL examples.
 > **Resist the temptation** to promote `stream_id` or `jti` to labels.
 > A single high-traffic stream + retention will produce millions of label
 > values and degrade the whole Loki tenant.
+
+### SCIM peers share the same label set
+
+The dev compose's `scim_cluster1` / `scim_cluster2` containers run the
+`independentid/i2scim-universal` image. With `QUARKUS_LOG_CONSOLE_JSON=true`
+and an identity-injecting environment block, they emit JSON log lines
+whose `service`, `node_id`, `cluster_name`, `component`, and `level`
+fields are extracted by the *same* Alloy `stage.json` pipeline that
+handles goSignals — no SCIM-specific Alloy stage. The label values that
+land in Loki are:
+
+| Label          | SCIM peer value(s)                  |
+|----------------|-------------------------------------|
+| `service`      | `i2scim`                            |
+| `node_id`      | `scim_cluster1`, `scim_cluster2`    |
+| `cluster_name` | `dev-local`                         |
+
+`{service="i2scim"}` returns both peers; `{node_id="scim_cluster1"}` narrows
+to one peer regardless of `service`. Sharing the schema is deliberate: the
+same dashboards and LogQL queries work across both code-bases. Operators
+running their own SCIM peers outside the dev compose should set the same
+three environment variables (`QUARKUS_LOG_CONSOLE_JSON=true`, `NODE_ID`,
+`CLUSTER_NAME`) on each container.
+
+### Prometheus scrape jobs
+
+| Job           | Targets                                   | Path          | Scheme |
+|---------------|-------------------------------------------|---------------|--------|
+| `prometheus`  | `localhost:9090`                          | `/metrics`    | http   |
+| `i2gosignals` | `gosignals1:8888`, `gosignals2:8889`      | `/metrics`    | https  |
+| `i2scim`      | `scim_cluster1:8080`, `scim_cluster2:8080`| `/q/metrics`  | http   |
+
+The `i2scim` job uses the Quarkus default metrics path (`/q/metrics`) and
+plain HTTP because the SCIM peers terminate TLS at the perimeter, not at
+the metrics endpoint inside the dev network. See
+[`config/monitor/prometheus/prometheus.yml`](../config/monitor/prometheus/prometheus.yml)
+for the full configuration.
 
 ---
 
@@ -529,6 +574,16 @@ JSON parser:
 
 ```logql
 {service="gosignals", node_id="gosignals1"}
+```
+
+### Tail a SCIM peer
+
+The SCIM peers share the label set described in §2:
+
+```logql
+{service="i2scim"}                       # both peers
+{service="i2scim", node_id="scim_cluster1"}   # one peer only
+{service="i2scim", level="ERROR"}        # SCIM errors only
 ```
 
 ### Find a specific JTI

--- a/scripts/verify-observability.sh
+++ b/scripts/verify-observability.sh
@@ -23,6 +23,7 @@ ok() { echo "  OK: $1"; }
 LOKI_URL=${LOKI_URL:-http://localhost:3100}
 GRAFANA_URL=${GRAFANA_URL:-http://localhost:3000}
 GRAFANA_AUTH=${GRAFANA_AUTH:-admin:grafana}
+PROMETHEUS_URL=${PROMETHEUS_URL:-http://localhost:9090}
 WAIT_SECS=${WAIT_SECS:-90}
 
 wait_for() {
@@ -106,6 +107,70 @@ for c in mongo1 mongo2 mongo3 gosignals1 gosignals2 gossfserver prometheus grafa
         || fail "container $c is in state '$state', expected running"
 done
 ok "all expected dev containers running"
+
+echo "9) i2scim peers visible in Loki labels (issue #73)..."
+# The SCIM peers run the i2scim-universal image which emits JSON logs with
+# service=i2scim once QUARKUS_LOG_CONSOLE_JSON=true is set. node_id and
+# cluster_name come from the env block on each container.
+for lbl_val in 'i2scim' 'scim_cluster1' 'scim_cluster2' 'dev-local'; do
+    echo "$labels_json" >/dev/null  # labels_json fetched in section 4
+done
+# Re-query label *values* rather than label *names* — names were checked
+# in section 4. Here we verify the SCIM peers produced lines with the
+# expected discriminators.
+service_values=$(curl -fsS "${LOKI_URL}/loki/api/v1/label/service/values")
+echo "$service_values" | grep -q '"i2scim"' \
+    || fail "service=i2scim not seen in Loki label values: $service_values"
+node_values=$(curl -fsS "${LOKI_URL}/loki/api/v1/label/node_id/values")
+for n in scim_cluster1 scim_cluster2; do
+    echo "$node_values" | grep -q "\"$n\"" \
+        || fail "node_id=$n not seen in Loki: $node_values"
+done
+cluster_values=$(curl -fsS "${LOKI_URL}/loki/api/v1/label/cluster_name/values")
+echo "$cluster_values" | grep -q '"dev-local"' \
+    || fail "cluster_name=dev-local not seen in Loki: $cluster_values"
+ok "i2scim peers labelled with service/node_id/cluster_name"
+
+echo "10) LogQL filter by SCIM node_id returns only that peer..."
+end_ns=$(date +%s)000000000
+start_ns=$(( $(date +%s) - 600 ))000000000
+query='%7Bnode_id%3D%22scim_cluster1%22%7D'
+resp=$(curl -fsS "${LOKI_URL}/loki/api/v1/query_range?query=${query}&limit=10&start=${start_ns}&end=${end_ns}")
+echo "$resp" | grep -q '"status":"success"' \
+    || fail "LogQL query for scim_cluster1 did not return success: $resp"
+# Negative check: response must not surface scim_cluster2 stream labels.
+if echo "$resp" | grep -q '"node_id":"scim_cluster2"'; then
+    fail "LogQL query for scim_cluster1 leaked scim_cluster2 streams"
+fi
+ok "node_id=scim_cluster1 query returns only that peer"
+
+echo "11) Prometheus scrapes both i2scim peers (issue #73)..."
+wait_for "Prometheus /api/v1/targets" \
+    "curl -fsS ${PROMETHEUS_URL}/api/v1/targets"
+targets_json=$(curl -fsS "${PROMETHEUS_URL}/api/v1/targets")
+echo "$targets_json" | grep -q '"job":"i2scim"' \
+    || fail "Prometheus has no i2scim scrape job: $targets_json"
+for peer in scim_cluster1 scim_cluster2; do
+    echo "$targets_json" | grep -qE "\"scrapeUrl\":\"http://${peer}:8080/q/metrics\"" \
+        || fail "i2scim job missing target ${peer}:8080/q/metrics"
+done
+# At least one of the two should be up=1 after warm-up. The script intentionally
+# does not demand both up since a slow SCIM container should not fail the run.
+echo "$targets_json" | grep -qE '"job":"i2scim".*"health":"up"' \
+    || fail "no i2scim target is health=up in Prometheus"
+ok "i2scim job present with both peers, at least one healthy"
+
+echo "12) Existing {service=\"gosignals\"} query still returns rows..."
+end_ns=$(date +%s)000000000
+start_ns=$(( $(date +%s) - 600 ))000000000
+query='%7Bservice%3D%22gosignals%22%7D'
+resp=$(curl -fsS "${LOKI_URL}/loki/api/v1/query_range?query=${query}&limit=10&start=${start_ns}&end=${end_ns}")
+echo "$resp" | grep -q '"status":"success"' \
+    || fail "regression: gosignals LogQL query did not return success: $resp"
+# Expect at least one stream in the result so we know existing logs still flow.
+echo "$resp" | grep -q '"stream":' \
+    || fail "regression: gosignals query returned no streams"
+ok "no regression on goSignals log path"
 
 echo ""
 echo "All observability acceptance criteria passed."


### PR DESCRIPTION
Closes #73.

## Summary

- Add an `environment:` block to each SCIM peer in `docker-compose-dev.yml` (`QUARKUS_LOG_CONSOLE_JSON=true`, `NODE_ID=scim_cluster{1,2}`, `CLUSTER_NAME=dev-local`) so the universal i2scim image emits JSON to stdout carrying the same `service` / `node_id` / `cluster_name` / `component` / `level` fields that Alloy already promotes to Loki labels for goSignals — no new Alloy stage required.
- Add a new `i2scim` Prometheus scrape job at `scim_cluster{1,2}:8080/q/metrics` (HTTP, Quarkus default path).
- Document the SCIM peers in `docs/observability.md`: dev-compose container table, a new "SCIM peers share the same label set" subsection in §2, a "Prometheus scrape jobs" table, and SCIM LogQL examples in §8.
- Extend `scripts/verify-observability.sh` with four new sections (9–12) codifying the issue-73 acceptance criteria: i2scim label values reach Loki, `{node_id="scim_cluster1"}` isolates one peer, the `i2scim` Prometheus job is up, and the existing `{service="gosignals"}` path still returns rows (regression guard).

## Test plan

- [x] `docker compose -f docker-compose-dev.yml config -q` — passes
- [x] `promtool check config config/monitor/prometheus/prometheus.yml` — passes
- [x] `bash -n scripts/verify-observability.sh` — passes
- [x] `bash scripts/verify-observability-docs.sh` — all 8 doc-structure checks pass
- [x] `docker pull independentid/i2scim-universal:latest` + `docker compose -f docker-compose-dev.yml up -d --force-recreate scim_cluster1 scim_cluster2 prometheus` — both peers re-create with the new env vars (verified via `docker inspect`)
- [x] SCIM stdout emits one-JSON-object-per-line with `service=i2scim`, `node_id=scim_cluster{1,2}`, `cluster_name=dev-local`, `version`, `level`, `component` fields
- [x] `curl http://localhost:9090/api/v1/targets` — `i2scim` job present with both peers `health=up`
- [x] `bash scripts/verify-observability.sh` — **all 12 sections pass**, including the new 9–12 plus the goSignals regression check
- [ ] After `make dev-rebuild` (full rebuild rather than selective recreate), reviewers can re-run `scripts/verify-observability.sh` to confirm a cold-start of the stack still meets every criterion.

## Notes

One caveat on acceptance criterion 6 ("a SCIM error condition surfaces in Grafana with `level=error`"): the wiring is correct — Loki's `level` label exposes all four standard values (`DEBUG`/`INFO`/`WARN`/`ERROR`), and the SCIM peers flow through the same Alloy `stage.labels` block — but the current i2scim image logs client-side 4xx responses at WARN/INFO, not ERROR. When SCIM emits at ERROR (e.g. internal server errors), it will be selectable in Grafana without further config changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)