### PR TITLE
TLS everywhere for compose stacks + Grafana SSO via Keycloak

### DIFF
--- a/DECISIONS_LOG.md
+++ b/DECISIONS_LOG.md
@@ -1,5 +1,57 @@
 # Architectural Decision & Regression Log
 
+## [2026-05-16] Grafana login is SSO-only — local password form disabled
+
+### Change
+Issue #78 originally shipped Grafana with Keycloak SSO **and** kept the local
+`admin/grafana` username/password form enabled as a break-glass fallback.
+That fallback is now removed: every compose stack sets
+`GF_AUTH_DISABLE_LOGIN_FORM=true`, so Keycloak SSO is the only interactive
+login path. The generic-OAuth button is relabelled from `Keycloak` to
+**Sign in with GoSignals Realm** (`GF_AUTH_GENERIC_OAUTH_NAME=GoSignals Realm`).
+
+The TLS + SSO configuration is now applied uniformly to **all six** compose
+files — `docker-compose.yml`, `-dev.yml`, `-cluster.yml`, `-cluster-dev.yml`,
+`-spiffe.yml`, `-spiffe-dev.yml`. Issue #78 scoped SSO to only the first
+three; the other three carried a `grafana` service that still served plain
+HTTP. Because all six mount the shared `config/monitor/grafana/datasource.yml`
+(which now references `$__file{/etc/grafana/certs/ca-cert.pem}`), the three
+unconfigured stacks would have failed datasource provisioning. Each Grafana
+service now mounts `./config/certs:/etc/grafana/certs:ro` and carries the full
+HTTPS + generic-OAuth env block.
+
+### Why this carries weight
+- **One identity, no shadow path.** A local password form sitting alongside
+  SSO is a second, weaker credential the operator must remember exists. With
+  it disabled, Grafana access is governed entirely by the `gosignals` Keycloak
+  realm and the `grafana` client roles — the same identity used everywhere
+  else in the stack.
+- **API Basic Auth is deliberately *not* disabled.** `GF_AUTH_DISABLE_LOGIN_FORM`
+  only removes the interactive UI form; Grafana's API Basic Auth is a separate
+  setting and stays on. `scripts/verify-observability.sh` relies on it
+  (`-u admin:grafana`) to inspect `/api/datasources` without driving a full
+  OIDC flow. Disabling the form does not lock automation out of the API.
+- **Parity closes a real regression.** Extending the cert mount + HTTPS/SSO
+  config to all six stacks is not cosmetic — without the cert mount, the
+  shared `datasource.yml` breaks Grafana provisioning in `-cluster-dev`,
+  `-spiffe`, and `-spiffe-dev`.
+
+### Invariants
+- Every `grafana` service in every compose file mounts
+  `./config/certs:/etc/grafana/certs:ro` and sets `GF_AUTH_DISABLE_LOGIN_FORM=true`
+  alongside the `GF_AUTH_GENERIC_OAUTH_*` block.
+- A `POST /login` to Grafana with otherwise-valid credentials MUST NOT return
+  `200` — a successful form login means the form is still live.
+
+### Verification
+- `scripts/verify-observability.sh` section 14 asserts the local form is
+  disabled (`POST /login` does not yield `200`) in addition to the existing
+  OIDC admin/viewer role-mapping checks.
+- Issue #78 acceptance criteria updated to match (the break-glass criterion is
+  replaced by an SSO-only criterion).
+
+---
+
 ## [2026-05-14] v0.11.0 environment-variable taxonomy
 
 ### Change

--- a/README.md
+++ b/README.md
@@ -89,11 +89,12 @@ The `docker-compose.yml` file provides a sample environment demonstrating Push a
 
 ### Grafana SSO
 
-Grafana is served at `https://localhost:3000` and accepts either the local
-break-glass login (`admin` / `grafana`) or single sign-on against the
-`gosignals` Keycloak realm. Demo users map to Grafana org roles via the
-`grafana` client roles: `admin` → Admin, `user` → Viewer; any authenticated
-realm user with no `grafana` client role falls back to Viewer.
+Grafana is served at `https://localhost:3000`. The local username/password
+login form is disabled — the only way in is **Sign in with GoSignals Realm**,
+which authenticates against the `gosignals` Keycloak realm. Demo users map to
+Grafana org roles via the `grafana` client roles: `admin` → Admin, `user` →
+Viewer; any authenticated realm user with no `grafana` client role falls back
+to Viewer.
 
 ## Developing and Debugging (GoLand/IntelliJ)
 

--- a/README.md
+++ b/README.md
@@ -75,13 +75,25 @@ docker exec spire-server sh /etc/spire/registration/register.sh
 The `docker-compose.yml` file provides a sample environment demonstrating Push and Poll scenarios between two i2goSignals servers, along with `i2scim.io` servers for multi-master replication.
 
 1. **Build the project**: `make build`
-2. **Configure local DNS**: Add `goSignals1` and `goSignals2` to your `/etc/hosts` pointing to `127.0.0.1`.
-3. **Start services**: `docker compose up -d`
-4. **Automated Configuration**: The `scimSsfSetup` service automatically configures the streams. To perform manual configuration or explore the tool:
+2. **Configure local DNS**: Add `goSignals1`, `goSignals2`, and `keycloak` to your `/etc/hosts` pointing to `127.0.0.1`. The `keycloak` entry is required so that browser-side SSO redirects (e.g. Grafana logging in via Keycloak) resolve to the local stack.
+3. **Trust the dev CA**: The stack serves TLS with a self-signed CA. Import `config/certs/ca-cert.pem` into your browser or OS trust store so that `https://localhost:3000` (Grafana) and `https://keycloak:9080` are accepted without certificate warnings.
+   - macOS: `sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain config/certs/ca-cert.pem`
+   - Linux: copy to `/usr/local/share/ca-certificates/` and run `sudo update-ca-certificates`
+   - Firefox keeps its own store — import the CA under Settings → Privacy & Security → Certificates.
+4. **Start services**: `docker compose up -d`
+5. **Automated Configuration**: The `scimSsfSetup` service automatically configures the streams. To perform manual configuration or explore the tool:
    ```bash
    ./goSignals
    goSignals> add server gs1 http://goSignals1:8888
    ```
+
+### Grafana SSO
+
+Grafana is served at `https://localhost:3000` and accepts either the local
+break-glass login (`admin` / `grafana`) or single sign-on against the
+`gosignals` Keycloak realm. Demo users map to Grafana org roles via the
+`grafana` client roles: `admin` → Admin, `user` → Viewer; any authenticated
+realm user with no `grafana` client role falls back to Viewer.
 
 ## Developing and Debugging (GoLand/IntelliJ)
 

--- a/cmd/genTlsKeys/keySupport.go
+++ b/cmd/genTlsKeys/keySupport.go
@@ -194,6 +194,41 @@ func (config *KeyConfig) InitializeCa() error {
 	return os.WriteFile(config.CaCertFile, caPEM.Bytes(), 0644)
 }
 
+// defaultServerDNSNames returns the DNS SAN hostnames the shared development
+// server certificate must cover when SERVER_DNS_NAME is not set.
+func defaultServerDNSNames() []string {
+	return []string{
+		"goSignals1", "goSignals2", "goSsfServer",
+		"scim_cluster1", "scim_cluster2", "keycloak",
+		"prometheus", "loki", "alloy", "grafana",
+		"mongo1", "mongo2", "mongo3", "postgres",
+		"localhost",
+	}
+}
+
+// certNeedsRegeneration is the pure regenerate-or-keep decision for the server
+// certificate. Given the parsed existing certificate (nil when absent) and the
+// desired set of DNS SAN hostnames, it reports whether the certificate must be
+// regenerated and a human-readable reason.
+func certNeedsRegeneration(cert *x509.Certificate, desiredDNSNames []string) (bool, string) {
+	if cert == nil {
+		return true, "no existing server certificate"
+	}
+	if len(cert.URIs) != 1 || !strings.HasPrefix(cert.URIs[0].String(), "spiffe://") {
+		return true, "missing or invalid SPIFFE URI SAN"
+	}
+	have := make(map[string]bool, len(cert.DNSNames))
+	for _, name := range cert.DNSNames {
+		have[name] = true
+	}
+	for _, want := range desiredDNSNames {
+		if !have[want] {
+			return true, fmt.Sprintf("missing required DNS SAN %q", want)
+		}
+	}
+	return false, "certificate satisfies desired SAN set"
+}
+
 /*
 InitializeKeys creates a set of self-signed keys and writes them out to the directory in KeyConfig.CertDir
 This includes:  Certificate Authority Certificate and Key (ca-cert/ca-key), Server certificate (server-cert.pem) and key
@@ -272,30 +307,25 @@ func (config *KeyConfig) InitializeKeys() (err error) {
 	var dnsNames []string
 	domainName := os.Getenv(EnvServerDNS)
 	if domainName == "" {
-		dnsNames = []string{"goSignals1", "goSignals2", "goSsfServer", "scim_cluster1", "scim_cluster2", "keycloak", "localhost"}
+		dnsNames = defaultServerDNSNames()
 	} else {
 		dnsNames = strings.Split(domainName, ",")
 	}
 
 	if config.ServerCertExists() {
 		log.Info(fmt.Sprintf("Loading existing Server Certificate from %s ...", config.ServerCertPath))
-		certBytes, err := os.ReadFile(config.ServerCertPath)
-		if err == nil {
-			block, _ := pem.Decode(certBytes)
-			if block != nil {
-				cert, err := x509.ParseCertificate(block.Bytes)
-				if err == nil {
-					// Check if URI SANs are present and correct (exactly one)
-					if len(cert.URIs) == 1 && strings.HasPrefix(cert.URIs[0].String(), "spiffe://") {
-						log.Info("Existing Server Certificate has valid SPIFFE URI SAN. Skipping regeneration.")
-					} else {
-						log.Info("Existing Server Certificate missing or invalid SPIFFE URI SAN. Forcing regeneration.")
-						// Remove existing cert to force regeneration below
-						_ = os.Remove(config.ServerCertPath)
-						_ = os.Remove(config.ServerKeyPath)
-					}
-				}
+		var existingCert *x509.Certificate
+		if certBytes, err := os.ReadFile(config.ServerCertPath); err == nil {
+			if block, _ := pem.Decode(certBytes); block != nil {
+				existingCert, _ = x509.ParseCertificate(block.Bytes)
 			}
+		}
+		if regen, reason := certNeedsRegeneration(existingCert, dnsNames); regen {
+			log.Info("Regenerating Server Certificate: " + reason)
+			_ = os.Remove(config.ServerCertPath)
+			_ = os.Remove(config.ServerKeyPath)
+		} else {
+			log.Info("Existing Server Certificate satisfies desired SAN set. Skipping regeneration.")
 		}
 	}
 

--- a/cmd/genTlsKeys/keySupport_test.go
+++ b/cmd/genTlsKeys/keySupport_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+    "crypto/x509"
+    "encoding/pem"
+    "net/url"
+    "os"
+    "path/filepath"
+    "testing"
+)
+
+func parseServerCert(t *testing.T, dir string) *x509.Certificate {
+    t.Helper()
+    certBytes, err := os.ReadFile(filepath.Join(dir, "server-cert.pem"))
+    if err != nil {
+        t.Fatalf("reading server cert: %v", err)
+    }
+    block, _ := pem.Decode(certBytes)
+    if block == nil {
+        t.Fatal("server cert is not valid PEM")
+    }
+    cert, err := x509.ParseCertificate(block.Bytes)
+    if err != nil {
+        t.Fatalf("parsing server cert: %v", err)
+    }
+    return cert
+}
+
+func TestInitializeKeys_FreshCertCoversAllHostnames(t *testing.T) {
+    dir := t.TempDir()
+    t.Setenv(EnvCertDirectory, dir)
+
+    config := GetKeyConfig()
+    if err := config.InitializeKeys(); err != nil {
+        t.Fatalf("InitializeKeys: %v", err)
+    }
+
+    cert := parseServerCert(t, dir)
+    have := make(map[string]bool, len(cert.DNSNames))
+    for _, n := range cert.DNSNames {
+        have[n] = true
+    }
+    for _, want := range defaultServerDNSNames() {
+        if !have[want] {
+            t.Errorf("server cert missing DNS SAN %q", want)
+        }
+    }
+    if len(cert.URIs) != 1 {
+        t.Fatalf("expected exactly one URI SAN, got %d", len(cert.URIs))
+    }
+}
+
+func TestInitializeKeys_CompleteCertLeftUntouched(t *testing.T) {
+    dir := t.TempDir()
+    t.Setenv(EnvCertDirectory, dir)
+
+    config := GetKeyConfig()
+    if err := config.InitializeKeys(); err != nil {
+        t.Fatalf("first InitializeKeys: %v", err)
+    }
+    first := parseServerCert(t, dir)
+
+    config = GetKeyConfig()
+    if err := config.InitializeKeys(); err != nil {
+        t.Fatalf("second InitializeKeys: %v", err)
+    }
+    second := parseServerCert(t, dir)
+
+    if first.SerialNumber.Cmp(second.SerialNumber) != 0 {
+        t.Errorf("expected complete certificate to be left untouched, but it was regenerated")
+    }
+}
+
+func TestCertNeedsRegeneration_AbsentCertificate(t *testing.T) {
+    regen, reason := certNeedsRegeneration(nil, defaultServerDNSNames())
+    if !regen {
+        t.Fatalf("expected regeneration for absent certificate, got keep (%s)", reason)
+    }
+}
+
+func TestCertNeedsRegeneration_CompleteCertificateKept(t *testing.T) {
+    cert := &x509.Certificate{
+        DNSNames: defaultServerDNSNames(),
+        URIs:     []*url.URL{mustURL(t, "spiffe://cluster.i2gosignals.internal/workload/gosignals-node")},
+    }
+    regen, reason := certNeedsRegeneration(cert, defaultServerDNSNames())
+    if regen {
+        t.Fatalf("expected complete certificate to be kept, got regenerate (%s)", reason)
+    }
+}
+
+func TestCertNeedsRegeneration_MissingDNSSAN(t *testing.T) {
+    // A certificate generated before grafana was added to the desired set.
+    legacy := []string{"goSignals1", "goSignals2", "goSsfServer",
+        "scim_cluster1", "scim_cluster2", "keycloak", "localhost"}
+    cert := &x509.Certificate{
+        DNSNames: legacy,
+        URIs:     []*url.URL{mustURL(t, "spiffe://cluster.i2gosignals.internal/workload/gosignals-node")},
+    }
+    regen, reason := certNeedsRegeneration(cert, defaultServerDNSNames())
+    if !regen {
+        t.Fatalf("expected regeneration when a required DNS SAN is missing, got keep (%s)", reason)
+    }
+}
+
+func TestCertNeedsRegeneration_MissingSpiffeURI(t *testing.T) {
+    cases := []struct {
+        name string
+        uris []*url.URL
+    }{
+        {"no uri san", nil},
+        {"two uri sans", []*url.URL{
+            mustURL(t, "spiffe://cluster.i2gosignals.internal/workload/a"),
+            mustURL(t, "spiffe://cluster.i2gosignals.internal/workload/b"),
+        }},
+        {"non-spiffe uri", []*url.URL{mustURL(t, "https://example.com/workload")}},
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            cert := &x509.Certificate{DNSNames: defaultServerDNSNames(), URIs: tc.uris}
+            regen, reason := certNeedsRegeneration(cert, defaultServerDNSNames())
+            if !regen {
+                t.Fatalf("expected regeneration for %s, got keep (%s)", tc.name, reason)
+            }
+        })
+    }
+}
+
+func mustURL(t *testing.T, raw string) *url.URL {
+    t.Helper()
+    u, err := url.Parse(raw)
+    if err != nil {
+        t.Fatalf("parsing %q: %v", raw, err)
+    }
+    return u
+}

--- a/config/keycloak/realm/gosignals-realm.json
+++ b/config/keycloak/realm/gosignals-realm.json
@@ -218,9 +218,56 @@
           }
         }
       ]
+    },
+    {
+      "clientId": "grafana",
+      "name": "Grafana",
+      "description": "Grafana observability UI - operator SSO",
+      "enabled": true,
+      "publicClient": false,
+      "protocol": "openid-connect",
+      "clientAuthenticatorType": "client-secret",
+      "secret": "grafana-client-secret",
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "fullScopeAllowed": true,
+      "redirectUris": [
+        "https://localhost:3000/login/generic_oauth"
+      ],
+      "webOrigins": [
+        "https://localhost:3000"
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": []
     }
   ],
   "roles": {
+    "client": {
+      "grafana": [
+        {
+          "name": "admin",
+          "description": "Grafana Admin org role",
+          "clientRole": true
+        },
+        {
+          "name": "editor",
+          "description": "Grafana Editor org role",
+          "clientRole": true
+        },
+        {
+          "name": "viewer",
+          "description": "Grafana Viewer org role",
+          "clientRole": true
+        }
+      ]
+    },
     "realm": [
       {
         "name": "admin",
@@ -267,7 +314,12 @@
         "admin",
         "goSignalsRootRole",
         "goSignalsAdminRole"
-      ]
+      ],
+      "clientRoles": {
+        "grafana": [
+          "admin"
+        ]
+      }
     },
     {
       "username": "user",
@@ -286,7 +338,12 @@
       "realmRoles": [
         "user",
         "goSignalsAdminRole"
-      ]
+      ],
+      "clientRoles": {
+        "grafana": [
+          "viewer"
+        ]
+      }
     }
   ],
   "clientScopes": [
@@ -490,6 +547,21 @@
             "user.attribute": "foo",
             "access.token.claim": "true",
             "claim.name": "realm_access.roles",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
             "jsonType.label": "String"
           }
         }

--- a/config/monitor/alloy/config.alloy
+++ b/config/monitor/alloy/config.alloy
@@ -75,6 +75,11 @@ loki.process "parse_json" {
 
 loki.write "local" {
     endpoint {
-        url = "http://loki:3100/loki/api/v1/push"
+        // Loki serves HTTPS with the shared dev certificate; verify it
+        // against the local dev CA rather than skipping verification.
+        url = "https://loki:3100/loki/api/v1/push"
+        tls_config {
+            ca_file = "/etc/alloy/certs/ca-cert.pem"
+        }
     }
 }

--- a/config/monitor/grafana/datasource.yml
+++ b/config/monitor/grafana/datasource.yml
@@ -10,6 +10,12 @@ datasources:
   - name: Loki
     type: loki
     uid: loki
-    url: http://loki:3100
+    url: https://loki:3100
     access: proxy
     editable: true
+    jsonData:
+      tlsAuthWithCACert: true
+    secureJsonData:
+      # Loki serves HTTPS with the shared dev certificate; verify it against
+      # the dev CA mounted into the Grafana container (see docker-compose-dev).
+      tlsCACert: $__file{/etc/grafana/certs/ca-cert.pem}

--- a/config/monitor/grafana/datasource.yml
+++ b/config/monitor/grafana/datasource.yml
@@ -3,10 +3,17 @@ apiVersion: 1
 datasources:
   - name: Prometheus
     type: prometheus
-    url: http://prometheus:9090
+    url: https://prometheus:9090
     isDefault: true
     access: proxy
     editable: true
+    jsonData:
+      tlsAuthWithCACert: true
+    secureJsonData:
+      # Prometheus serves HTTPS with the shared dev certificate; verify it
+      # against the dev CA mounted into the Grafana container (see
+      # docker-compose-dev).
+      tlsCACert: $__file{/etc/grafana/certs/ca-cert.pem}
   - name: Loki
     type: loki
     uid: loki

--- a/config/monitor/loki/loki-config.yml
+++ b/config/monitor/loki/loki-config.yml
@@ -10,6 +10,12 @@ server:
   http_listen_port: 3100
   grpc_listen_port: 9096
   log_level: info
+  # Server-side TLS on the HTTP listener using the shared dev certificate
+  # (SANs cover `loki` and `localhost`). No client_ca_file: this is
+  # server-side TLS only, not mutual TLS — see docs/adr/0001.
+  http_tls_config:
+    cert_file: /etc/loki/certs/server-cert.pem
+    key_file: /etc/loki/certs/server-key.pem
 
 common:
   instance_addr: 127.0.0.1

--- a/config/monitor/prometheus/prometheus.yml
+++ b/config/monitor/prometheus/prometheus.yml
@@ -15,7 +15,9 @@ scrape_configs:
     scrape_interval: 15s
     scrape_timeout: 10s
     metrics_path: /metrics
-    scheme: http
+    scheme: https
+    tls_config:
+      ca_file: /etc/prometheus/certs/ca-cert.pem
     static_configs:
       - targets:
           - localhost:9090
@@ -26,7 +28,7 @@ scrape_configs:
     metrics_path: /metrics
     scheme: https
     tls_config:
-      insecure_skip_verify: true
+      ca_file: /etc/prometheus/certs/ca-cert.pem
     static_configs:
       - targets:
           - gosignals1:8888
@@ -36,8 +38,15 @@ scrape_configs:
     scrape_interval: 15s
     scrape_timeout: 10s
     metrics_path: /q/metrics
-    scheme: http
+    scheme: https
+    tls_config:
+      ca_file: /etc/prometheus/certs/ca-cert.pem
+      # The SCIM peers run on a JDK that rejects a TLS SNI whose host_name
+      # contains an underscore (RFC 1123). The container names scim_cluster1 /
+      # scim_cluster2 do, so Prometheus must send a valid SNI: `localhost` is
+      # in the shared dev certificate's SANs and the JDK accepts it.
+      server_name: localhost
     static_configs:
       - targets:
-          - scim_cluster1:8080
-          - scim_cluster2:8080
+          - scim_cluster1:8443
+          - scim_cluster2:8443

--- a/config/monitor/prometheus/web-config.yml
+++ b/config/monitor/prometheus/web-config.yml
@@ -1,0 +1,6 @@
+# Prometheus web TLS — serves the UI/API over HTTPS with the shared dev
+# certificate (its SANs cover `prometheus` and `localhost`). Server-side TLS
+# only; no client_ca_file / client_auth_type — see docs/adr/0001.
+tls_server_config:
+  cert_file: /etc/prometheus/certs/server-cert.pem
+  key_file: /etc/prometheus/certs/server-key.pem

--- a/docker-compose-cluster-dev.yml
+++ b/docker-compose-cluster-dev.yml
@@ -125,11 +125,32 @@ services:
     ports:
       - "3000:3000"
     restart: unless-stopped
+    depends_on:
+      - keycloak
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=grafana
+      - GF_SERVER_PROTOCOL=https
+      - GF_SERVER_ROOT_URL=https://localhost:3000
+      - GF_SERVER_CERT_FILE=/etc/grafana/certs/server-cert.pem
+      - GF_SERVER_CERT_KEY=/etc/grafana/certs/server-key.pem
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_AUTH_GENERIC_OAUTH_ENABLED=true
+      - GF_AUTH_GENERIC_OAUTH_NAME=GoSignals Realm
+      - GF_AUTH_GENERIC_OAUTH_CLIENT_ID=grafana
+      - GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET=grafana-client-secret
+      - GF_AUTH_GENERIC_OAUTH_SCOPES=openid email profile roles
+      - GF_AUTH_GENERIC_OAUTH_AUTH_URL=https://keycloak:9080/realms/gosignals/protocol/openid-connect/auth
+      - GF_AUTH_GENERIC_OAUTH_TOKEN_URL=https://keycloak:9080/realms/gosignals/protocol/openid-connect/token
+      - GF_AUTH_GENERIC_OAUTH_API_URL=https://keycloak:9080/realms/gosignals/protocol/openid-connect/userinfo
+      - GF_AUTH_GENERIC_OAUTH_LOGIN_ATTRIBUTE_PATH=email
+      - "GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH=contains(resource_access.grafana.roles[*], 'admin') && 'Admin' || contains(resource_access.grafana.roles[*], 'editor') && 'Editor' || 'Viewer'"
+      - GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_STRICT=false
+      - GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP=true
+      - GF_AUTH_GENERIC_OAUTH_TLS_CLIENT_CA=/etc/grafana/certs/ca-cert.pem
     volumes:
       - "./config/monitor/grafana:/etc/grafana/provisioning/datasources"
+      - "./config/certs:/etc/grafana/certs:ro"
 
   goSignals1:
     build:

--- a/docker-compose-cluster-dev.yml
+++ b/docker-compose-cluster-dev.yml
@@ -111,9 +111,11 @@ services:
     image: prom/prometheus:latest
     volumes:
       - "./config/monitor/prometheus:/etc/prometheus"
+      - "./config/certs:/etc/prometheus/certs:ro"
       - prometheus_data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--web.config.file=/etc/prometheus/web-config.yml'
     ports:
       - "9090:9090"
     restart: unless-stopped
@@ -258,8 +260,14 @@ services:
         condition: service_completed_successfully
     volumes:
       - ./config/scim/data1:/scim
+      - "./config/certs:/scim-certs:ro"
     env_file:
       - ./config/scim/scripts/scim-server.env
+    environment:
+      # Serve an HTTPS listener (Quarkus default :8443) for Prometheus to
+      # scrape /q/metrics over TLS, using the shared dev certificate.
+      - QUARKUS_HTTP_SSL_CERTIFICATE_FILES=/scim-certs/server-cert.pem
+      - QUARKUS_HTTP_SSL_CERTIFICATE_KEY_FILES=/scim-certs/server-key.pem
   scim_cluster2:
     image: independentid/i2scim-universal:0.8.0
     depends_on:
@@ -269,8 +277,14 @@ services:
         condition: service_completed_successfully
     volumes:
       - ./config/scim/data2:/scim
+      - "./config/certs:/scim-certs:ro"
     env_file:
       - ./config/scim/scripts/scim-server.env
+    environment:
+      # Serve an HTTPS listener (Quarkus default :8443) for Prometheus to
+      # scrape /q/metrics over TLS, using the shared dev certificate.
+      - QUARKUS_HTTP_SSL_CERTIFICATE_FILES=/scim-certs/server-cert.pem
+      - QUARKUS_HTTP_SSL_CERTIFICATE_KEY_FILES=/scim-certs/server-key.pem
   postgres:
     image: postgres:alpine
     volumes:

--- a/docker-compose-cluster.yml
+++ b/docker-compose-cluster.yml
@@ -121,11 +121,31 @@ services:
     ports:
       - "3000:3000"
     restart: unless-stopped
+    depends_on:
+      - keycloak
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=grafana
+      - GF_SERVER_PROTOCOL=https
+      - GF_SERVER_ROOT_URL=https://localhost:3000
+      - GF_SERVER_CERT_FILE=/etc/grafana/certs/server-cert.pem
+      - GF_SERVER_CERT_KEY=/etc/grafana/certs/server-key.pem
+      - GF_AUTH_GENERIC_OAUTH_ENABLED=true
+      - GF_AUTH_GENERIC_OAUTH_NAME=Keycloak
+      - GF_AUTH_GENERIC_OAUTH_CLIENT_ID=grafana
+      - GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET=grafana-client-secret
+      - GF_AUTH_GENERIC_OAUTH_SCOPES=openid email profile roles
+      - GF_AUTH_GENERIC_OAUTH_AUTH_URL=https://keycloak:9080/realms/gosignals/protocol/openid-connect/auth
+      - GF_AUTH_GENERIC_OAUTH_TOKEN_URL=https://keycloak:9080/realms/gosignals/protocol/openid-connect/token
+      - GF_AUTH_GENERIC_OAUTH_API_URL=https://keycloak:9080/realms/gosignals/protocol/openid-connect/userinfo
+      - GF_AUTH_GENERIC_OAUTH_LOGIN_ATTRIBUTE_PATH=email
+      - "GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH=contains(resource_access.grafana.roles[*], 'admin') && 'Admin' || contains(resource_access.grafana.roles[*], 'editor') && 'Editor' || 'Viewer'"
+      - GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_STRICT=false
+      - GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP=true
+      - GF_AUTH_GENERIC_OAUTH_TLS_CLIENT_CA=/etc/grafana/certs/ca-cert.pem
     volumes:
       - "./config/monitor/grafana:/etc/grafana/provisioning/datasources"
+      - "./config/certs:/etc/grafana/certs:ro"
 
   goSignals1:
     image: i2gosignals:v0.8

--- a/docker-compose-cluster.yml
+++ b/docker-compose-cluster.yml
@@ -109,9 +109,11 @@ services:
     image: prom/prometheus:latest
     volumes:
       - "./config/monitor/prometheus:/etc/prometheus"
+      - "./config/certs:/etc/prometheus/certs:ro"
       - prometheus_data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--web.config.file=/etc/prometheus/web-config.yml'
     ports:
       - "9090:9090"
     restart: unless-stopped
@@ -244,8 +246,15 @@ services:
         condition: service_completed_successfully
     volumes:
       - ./config/scim/data1:/scim
+      - "./config/certs:/scim-certs:ro"
     env_file:
       - ./config/scim/scripts/scim-server.env
+    environment:
+      # Serve an HTTPS listener (Quarkus default :8443) alongside the plain
+      # :8080 SCIM API, using the shared dev certificate, so Prometheus can
+      # scrape /q/metrics over TLS.
+      - QUARKUS_HTTP_SSL_CERTIFICATE_FILES=/scim-certs/server-cert.pem
+      - QUARKUS_HTTP_SSL_CERTIFICATE_KEY_FILES=/scim-certs/server-key.pem
   scim_cluster2:
     image: independentid/i2scim-universal:0.8.0
     depends_on:
@@ -255,8 +264,15 @@ services:
         condition: service_completed_successfully
     volumes:
       - ./config/scim/data2:/scim
+      - "./config/certs:/scim-certs:ro"
     env_file:
       - ./config/scim/scripts/scim-server.env
+    environment:
+      # Serve an HTTPS listener (Quarkus default :8443) alongside the plain
+      # :8080 SCIM API, using the shared dev certificate, so Prometheus can
+      # scrape /q/metrics over TLS.
+      - QUARKUS_HTTP_SSL_CERTIFICATE_FILES=/scim-certs/server-cert.pem
+      - QUARKUS_HTTP_SSL_CERTIFICATE_KEY_FILES=/scim-certs/server-key.pem
   postgres:
     image: postgres:alpine
     volumes:

--- a/docker-compose-cluster.yml
+++ b/docker-compose-cluster.yml
@@ -132,8 +132,9 @@ services:
       - GF_SERVER_ROOT_URL=https://localhost:3000
       - GF_SERVER_CERT_FILE=/etc/grafana/certs/server-cert.pem
       - GF_SERVER_CERT_KEY=/etc/grafana/certs/server-key.pem
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
       - GF_AUTH_GENERIC_OAUTH_ENABLED=true
-      - GF_AUTH_GENERIC_OAUTH_NAME=Keycloak
+      - GF_AUTH_GENERIC_OAUTH_NAME=GoSignals Realm
       - GF_AUTH_GENERIC_OAUTH_CLIENT_ID=grafana
       - GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET=grafana-client-secret
       - GF_AUTH_GENERIC_OAUTH_SCOPES=openid email profile roles

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -174,6 +174,7 @@ services:
       - "-config.file=/etc/loki/loki-config.yml"
     volumes:
       - "./config/monitor/loki:/etc/loki"
+      - "./config/certs:/etc/loki/certs:ro"
       - loki_data:/loki
     restart: unless-stopped
     # No container-level healthcheck: the grafana/loki image is distroless
@@ -203,6 +204,7 @@ services:
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
       - "./config/monitor/alloy:/etc/alloy"
+      - "./config/certs:/etc/alloy/certs:ro"
     depends_on:
       loki:
         condition: service_started

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -232,8 +232,9 @@ services:
       - GF_SERVER_ROOT_URL=https://localhost:3000
       - GF_SERVER_CERT_FILE=/etc/grafana/certs/server-cert.pem
       - GF_SERVER_CERT_KEY=/etc/grafana/certs/server-key.pem
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
       - GF_AUTH_GENERIC_OAUTH_ENABLED=true
-      - GF_AUTH_GENERIC_OAUTH_NAME=Keycloak
+      - GF_AUTH_GENERIC_OAUTH_NAME=GoSignals Realm
       - GF_AUTH_GENERIC_OAUTH_CLIENT_ID=grafana
       - GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET=grafana-client-secret
       - GF_AUTH_GENERIC_OAUTH_SCOPES=openid email profile roles

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -155,9 +155,11 @@ services:
       - frontend
     volumes:
       - "./config/monitor/prometheus:/etc/prometheus"
+      - "./config/certs:/etc/prometheus/certs:ro"
       - prometheus_data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--web.config.file=/etc/prometheus/web-config.yml'
     ports:
       - "9090:9090"
     restart: unless-stopped
@@ -399,12 +401,18 @@ services:
         condition: service_completed_successfully
     volumes:
       - ./config/scim/data1:/scim
+      - "./config/certs:/scim-certs:ro"
     env_file:
       - ./config/scim/scripts/scim-server.env
     environment:
       - QUARKUS_LOG_CONSOLE_JSON=true
       - NODE_ID=scim_cluster1
       - CLUSTER_NAME=dev-local
+      # Serve an HTTPS listener (Quarkus default :8443) alongside the plain
+      # :8080 SCIM API, using the shared dev certificate, so Prometheus can
+      # scrape /q/metrics over TLS.
+      - QUARKUS_HTTP_SSL_CERTIFICATE_FILES=/scim-certs/server-cert.pem
+      - QUARKUS_HTTP_SSL_CERTIFICATE_KEY_FILES=/scim-certs/server-key.pem
   scim_cluster2:
     image: independentid/i2scim-universal:latest
     container_name: scim_cluster2
@@ -419,12 +427,18 @@ services:
         condition: service_completed_successfully
     volumes:
       - ./config/scim/data2:/scim
+      - "./config/certs:/scim-certs:ro"
     env_file:
       - ./config/scim/scripts/scim-server.env
     environment:
       - QUARKUS_LOG_CONSOLE_JSON=true
       - NODE_ID=scim_cluster2
       - CLUSTER_NAME=dev-local
+      # Serve an HTTPS listener (Quarkus default :8443) alongside the plain
+      # :8080 SCIM API, using the shared dev certificate, so Prometheus can
+      # scrape /q/metrics over TLS.
+      - QUARKUS_HTTP_SSL_CERTIFICATE_FILES=/scim-certs/server-cert.pem
+      - QUARKUS_HTTP_SSL_CERTIFICATE_KEY_FILES=/scim-certs/server-key.pem
   postgres:
     image: postgres:alpine
     volumes:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -220,12 +220,31 @@ services:
     depends_on:
       - prometheus
       - loki
+      - keycloak
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=grafana
+      - GF_SERVER_PROTOCOL=https
+      - GF_SERVER_ROOT_URL=https://localhost:3000
+      - GF_SERVER_CERT_FILE=/etc/grafana/certs/server-cert.pem
+      - GF_SERVER_CERT_KEY=/etc/grafana/certs/server-key.pem
+      - GF_AUTH_GENERIC_OAUTH_ENABLED=true
+      - GF_AUTH_GENERIC_OAUTH_NAME=Keycloak
+      - GF_AUTH_GENERIC_OAUTH_CLIENT_ID=grafana
+      - GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET=grafana-client-secret
+      - GF_AUTH_GENERIC_OAUTH_SCOPES=openid email profile roles
+      - GF_AUTH_GENERIC_OAUTH_AUTH_URL=https://keycloak:9080/realms/gosignals/protocol/openid-connect/auth
+      - GF_AUTH_GENERIC_OAUTH_TOKEN_URL=https://keycloak:9080/realms/gosignals/protocol/openid-connect/token
+      - GF_AUTH_GENERIC_OAUTH_API_URL=https://keycloak:9080/realms/gosignals/protocol/openid-connect/userinfo
+      - GF_AUTH_GENERIC_OAUTH_LOGIN_ATTRIBUTE_PATH=email
+      - "GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH=contains(resource_access.grafana.roles[*], 'admin') && 'Admin' || contains(resource_access.grafana.roles[*], 'editor') && 'Editor' || 'Viewer'"
+      - GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_STRICT=false
+      - GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP=true
+      - GF_AUTH_GENERIC_OAUTH_TLS_CLIENT_CA=/etc/grafana/certs/ca-cert.pem
     volumes:
       - "./config/monitor/grafana:/etc/grafana/provisioning/datasources"
       - "./config/monitor/grafana-dashboards:/etc/grafana/provisioning/dashboards"
+      - "./config/certs:/etc/grafana/certs:ro"
 
   goSignals1:
     build:

--- a/docker-compose-spiffe-dev.yml
+++ b/docker-compose-spiffe-dev.yml
@@ -337,6 +337,7 @@ services:
       - backend
     volumes:
       - "./config/monitor/prometheus:/etc/prometheus"
+      - "./config/certs:/etc/prometheus/certs:ro"
       - prometheus_data:/prometheus
       - spire_sockets:/run/spire/sockets
     labels:
@@ -346,6 +347,7 @@ services:
       - I2SIG_SPIFFE_TRUST_DOMAIN=cluster.i2gosignals.internal
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--web.config.file=/etc/prometheus/web-config.yml'
     ports:
       - "9090:9090"
     restart: unless-stopped
@@ -641,12 +643,17 @@ services:
         condition: service_healthy
     volumes:
       - ./config/scim/data1:/scim
+      - "./config/certs:/scim-certs:ro"
       - spire_sockets:/run/spire/sockets
     env_file:
       - ./config/scim/scripts/scim-server.env
     environment:
       - SPIFFE_ENDPOINT_SOCKET=unix:///run/spire/sockets/agent.sock
       - I2SIG_SPIFFE_TRUST_DOMAIN=cluster.i2gosignals.internal
+      # Serve an HTTPS listener (Quarkus default :8443) for Prometheus to
+      # scrape /q/metrics over TLS, using the shared dev certificate.
+      - QUARKUS_HTTP_SSL_CERTIFICATE_FILES=/scim-certs/server-cert.pem
+      - QUARKUS_HTTP_SSL_CERTIFICATE_KEY_FILES=/scim-certs/server-key.pem
 
   scim_cluster2:
     image: independentid/i2scim-universal:latest
@@ -665,12 +672,17 @@ services:
         condition: service_healthy
     volumes:
       - ./config/scim/data2:/scim
+      - "./config/certs:/scim-certs:ro"
       - spire_sockets:/run/spire/sockets
     env_file:
       - ./config/scim/scripts/scim-server.env
     environment:
       - SPIFFE_ENDPOINT_SOCKET=unix:///run/spire/sockets/agent.sock
       - I2SIG_SPIFFE_TRUST_DOMAIN=cluster.i2gosignals.internal
+      # Serve an HTTPS listener (Quarkus default :8443) for Prometheus to
+      # scrape /q/metrics over TLS, using the shared dev certificate.
+      - QUARKUS_HTTP_SSL_CERTIFICATE_FILES=/scim-certs/server-cert.pem
+      - QUARKUS_HTTP_SSL_CERTIFICATE_KEY_FILES=/scim-certs/server-key.pem
 
 networks:
   frontend:

--- a/docker-compose-spiffe-dev.yml
+++ b/docker-compose-spiffe-dev.yml
@@ -365,13 +365,33 @@ services:
     restart: unless-stopped
     depends_on:
       - prometheus
+      - keycloak
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=grafana
+      - GF_SERVER_PROTOCOL=https
+      - GF_SERVER_ROOT_URL=https://localhost:3000
+      - GF_SERVER_CERT_FILE=/etc/grafana/certs/server-cert.pem
+      - GF_SERVER_CERT_KEY=/etc/grafana/certs/server-key.pem
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_AUTH_GENERIC_OAUTH_ENABLED=true
+      - GF_AUTH_GENERIC_OAUTH_NAME=GoSignals Realm
+      - GF_AUTH_GENERIC_OAUTH_CLIENT_ID=grafana
+      - GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET=grafana-client-secret
+      - GF_AUTH_GENERIC_OAUTH_SCOPES=openid email profile roles
+      - GF_AUTH_GENERIC_OAUTH_AUTH_URL=https://keycloak:9080/realms/gosignals/protocol/openid-connect/auth
+      - GF_AUTH_GENERIC_OAUTH_TOKEN_URL=https://keycloak:9080/realms/gosignals/protocol/openid-connect/token
+      - GF_AUTH_GENERIC_OAUTH_API_URL=https://keycloak:9080/realms/gosignals/protocol/openid-connect/userinfo
+      - GF_AUTH_GENERIC_OAUTH_LOGIN_ATTRIBUTE_PATH=email
+      - "GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH=contains(resource_access.grafana.roles[*], 'admin') && 'Admin' || contains(resource_access.grafana.roles[*], 'editor') && 'Editor' || 'Viewer'"
+      - GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_STRICT=false
+      - GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP=true
+      - GF_AUTH_GENERIC_OAUTH_TLS_CLIENT_CA=/etc/grafana/certs/ca-cert.pem
       - SPIFFE_ENDPOINT_SOCKET=unix:///run/spire/sockets/agent.sock
       - I2SIG_SPIFFE_TRUST_DOMAIN=cluster.i2gosignals.internal
     volumes:
       - "./config/monitor/grafana:/etc/grafana/provisioning/datasources"
+      - "./config/certs:/etc/grafana/certs:ro"
       - spire_sockets:/run/spire/sockets
 
   # ---------------------------------------------------------------------------

--- a/docker-compose-spiffe.yml
+++ b/docker-compose-spiffe.yml
@@ -337,6 +337,7 @@ services:
       - backend
     volumes:
       - "./config/monitor/prometheus:/etc/prometheus"
+      - "./config/certs:/etc/prometheus/certs:ro"
       - prometheus_data:/prometheus
       - spire_sockets:/run/spire/sockets
     labels:
@@ -346,6 +347,7 @@ services:
       - I2SIG_SPIFFE_TRUST_DOMAIN=cluster.i2gosignals.internal
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--web.config.file=/etc/prometheus/web-config.yml'
     ports:
       - "9090:9090"
     restart: unless-stopped
@@ -613,12 +615,17 @@ services:
         condition: service_healthy
     volumes:
       - ./config/scim/data1:/scim
+      - "./config/certs:/scim-certs:ro"
       - spire_sockets:/run/spire/sockets
     env_file:
       - ./config/scim/scripts/scim-server.env
     environment:
       - SPIFFE_ENDPOINT_SOCKET=unix:///run/spire/sockets/agent.sock
       - I2SIG_SPIFFE_TRUST_DOMAIN=cluster.i2gosignals.internal
+      # Serve an HTTPS listener (Quarkus default :8443) for Prometheus to
+      # scrape /q/metrics over TLS, using the shared dev certificate.
+      - QUARKUS_HTTP_SSL_CERTIFICATE_FILES=/scim-certs/server-cert.pem
+      - QUARKUS_HTTP_SSL_CERTIFICATE_KEY_FILES=/scim-certs/server-key.pem
 
   scim_cluster2:
     image: independentid/i2scim-universal:latest
@@ -637,12 +644,17 @@ services:
         condition: service_healthy
     volumes:
       - ./config/scim/data2:/scim
+      - "./config/certs:/scim-certs:ro"
       - spire_sockets:/run/spire/sockets
     env_file:
       - ./config/scim/scripts/scim-server.env
     environment:
       - SPIFFE_ENDPOINT_SOCKET=unix:///run/spire/sockets/agent.sock
       - I2SIG_SPIFFE_TRUST_DOMAIN=cluster.i2gosignals.internal
+      # Serve an HTTPS listener (Quarkus default :8443) for Prometheus to
+      # scrape /q/metrics over TLS, using the shared dev certificate.
+      - QUARKUS_HTTP_SSL_CERTIFICATE_FILES=/scim-certs/server-cert.pem
+      - QUARKUS_HTTP_SSL_CERTIFICATE_KEY_FILES=/scim-certs/server-key.pem
 
 networks:
   frontend:

--- a/docker-compose-spiffe.yml
+++ b/docker-compose-spiffe.yml
@@ -365,13 +365,33 @@ services:
     restart: unless-stopped
     depends_on:
       - prometheus
+      - keycloak
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=grafana
+      - GF_SERVER_PROTOCOL=https
+      - GF_SERVER_ROOT_URL=https://localhost:3000
+      - GF_SERVER_CERT_FILE=/etc/grafana/certs/server-cert.pem
+      - GF_SERVER_CERT_KEY=/etc/grafana/certs/server-key.pem
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_AUTH_GENERIC_OAUTH_ENABLED=true
+      - GF_AUTH_GENERIC_OAUTH_NAME=GoSignals Realm
+      - GF_AUTH_GENERIC_OAUTH_CLIENT_ID=grafana
+      - GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET=grafana-client-secret
+      - GF_AUTH_GENERIC_OAUTH_SCOPES=openid email profile roles
+      - GF_AUTH_GENERIC_OAUTH_AUTH_URL=https://keycloak:9080/realms/gosignals/protocol/openid-connect/auth
+      - GF_AUTH_GENERIC_OAUTH_TOKEN_URL=https://keycloak:9080/realms/gosignals/protocol/openid-connect/token
+      - GF_AUTH_GENERIC_OAUTH_API_URL=https://keycloak:9080/realms/gosignals/protocol/openid-connect/userinfo
+      - GF_AUTH_GENERIC_OAUTH_LOGIN_ATTRIBUTE_PATH=email
+      - "GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH=contains(resource_access.grafana.roles[*], 'admin') && 'Admin' || contains(resource_access.grafana.roles[*], 'editor') && 'Editor' || 'Viewer'"
+      - GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_STRICT=false
+      - GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP=true
+      - GF_AUTH_GENERIC_OAUTH_TLS_CLIENT_CA=/etc/grafana/certs/ca-cert.pem
       - SPIFFE_ENDPOINT_SOCKET=unix:///run/spire/sockets/agent.sock
       - I2SIG_SPIFFE_TRUST_DOMAIN=cluster.i2gosignals.internal
     volumes:
       - "./config/monitor/grafana:/etc/grafana/provisioning/datasources"
+      - "./config/certs:/etc/grafana/certs:ro"
       - spire_sockets:/run/spire/sockets
 
   # ---------------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,8 +173,9 @@ services:
       - GF_SERVER_ROOT_URL=https://localhost:3000
       - GF_SERVER_CERT_FILE=/etc/grafana/certs/server-cert.pem
       - GF_SERVER_CERT_KEY=/etc/grafana/certs/server-key.pem
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
       - GF_AUTH_GENERIC_OAUTH_ENABLED=true
-      - GF_AUTH_GENERIC_OAUTH_NAME=Keycloak
+      - GF_AUTH_GENERIC_OAUTH_NAME=GoSignals Realm
       - GF_AUTH_GENERIC_OAUTH_CLIENT_ID=grafana
       - GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET=grafana-client-secret
       - GF_AUTH_GENERIC_OAUTH_SCOPES=openid email profile roles

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,9 +145,11 @@ services:
       - backend
     volumes:
       - "./config/monitor/prometheus:/etc/prometheus"
+      - "./config/certs:/etc/prometheus/certs:ro"
       - prometheus_data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--web.config.file=/etc/prometheus/web-config.yml'
     ports:
       - "9090:9090"
     restart: unless-stopped
@@ -298,8 +300,15 @@ services:
         condition: service_completed_successfully
     volumes:
       - ./config/scim/data1:/scim
+      - "./config/certs:/scim-certs:ro"
     env_file:
       - ./config/scim/scripts/scim-server.env
+    environment:
+      # Serve an HTTPS listener (Quarkus default :8443) alongside the plain
+      # :8080 SCIM API, using the shared dev certificate, so Prometheus can
+      # scrape /q/metrics over TLS.
+      - QUARKUS_HTTP_SSL_CERTIFICATE_FILES=/scim-certs/server-cert.pem
+      - QUARKUS_HTTP_SSL_CERTIFICATE_KEY_FILES=/scim-certs/server-key.pem
   scim_cluster2:
     image: independentid/i2scim-universal:latest
     container_name: scim_cluster2
@@ -314,8 +323,15 @@ services:
         condition: service_completed_successfully
     volumes:
       - ./config/scim/data2:/scim
+      - "./config/certs:/scim-certs:ro"
     env_file:
       - ./config/scim/scripts/scim-server.env
+    environment:
+      # Serve an HTTPS listener (Quarkus default :8443) alongside the plain
+      # :8080 SCIM API, using the shared dev certificate, so Prometheus can
+      # scrape /q/metrics over TLS.
+      - QUARKUS_HTTP_SSL_CERTIFICATE_FILES=/scim-certs/server-cert.pem
+      - QUARKUS_HTTP_SSL_CERTIFICATE_KEY_FILES=/scim-certs/server-key.pem
   postgres:
     image: postgres:alpine
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,11 +163,30 @@ services:
     restart: unless-stopped
     depends_on:
       - prometheus
+      - keycloak
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=grafana
+      - GF_SERVER_PROTOCOL=https
+      - GF_SERVER_ROOT_URL=https://localhost:3000
+      - GF_SERVER_CERT_FILE=/etc/grafana/certs/server-cert.pem
+      - GF_SERVER_CERT_KEY=/etc/grafana/certs/server-key.pem
+      - GF_AUTH_GENERIC_OAUTH_ENABLED=true
+      - GF_AUTH_GENERIC_OAUTH_NAME=Keycloak
+      - GF_AUTH_GENERIC_OAUTH_CLIENT_ID=grafana
+      - GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET=grafana-client-secret
+      - GF_AUTH_GENERIC_OAUTH_SCOPES=openid email profile roles
+      - GF_AUTH_GENERIC_OAUTH_AUTH_URL=https://keycloak:9080/realms/gosignals/protocol/openid-connect/auth
+      - GF_AUTH_GENERIC_OAUTH_TOKEN_URL=https://keycloak:9080/realms/gosignals/protocol/openid-connect/token
+      - GF_AUTH_GENERIC_OAUTH_API_URL=https://keycloak:9080/realms/gosignals/protocol/openid-connect/userinfo
+      - GF_AUTH_GENERIC_OAUTH_LOGIN_ATTRIBUTE_PATH=email
+      - "GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH=contains(resource_access.grafana.roles[*], 'admin') && 'Admin' || contains(resource_access.grafana.roles[*], 'editor') && 'Editor' || 'Viewer'"
+      - GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_STRICT=false
+      - GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP=true
+      - GF_AUTH_GENERIC_OAUTH_TLS_CLIENT_CA=/etc/grafana/certs/ca-cert.pem
     volumes:
       - "./config/monitor/grafana:/etc/grafana/provisioning/datasources"
+      - "./config/certs:/etc/grafana/certs:ro"
 
   goSignals1:
     image: i2gosignals:latest

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -97,9 +97,24 @@ choice:
 | `scim_cluster1` | i2scim peer (node 1)       | http://localhost:9000              |
 | `scim_cluster2` | i2scim peer (node 2)       | http://localhost:9001              |
 | `alloy`         | Log collector              | http://localhost:3200 (UI)         |
-| `loki`          | Log backend                | http://localhost:3100              |
-| `grafana`       | Query/visualization UI     | http://localhost:3000 (admin/grafana) |
+| `loki`          | Log backend                | https://localhost:3100             |
+| `grafana`       | Query/visualization UI     | https://localhost:3000 (admin/grafana) |
 | `prometheus`    | Metrics backend            | http://localhost:9090              |
+
+### The log pipeline runs over TLS by default
+
+In the dev stack the log-shipping pipeline is encrypted in transit. Loki
+serves its HTTP endpoints over TLS, Alloy pushes log batches to
+`https://loki:3100`, and Grafana's provisioned Loki datasource queries Loki
+over HTTPS. Every hop verifies the server against the local dev CA
+(`config/certs/ca-cert.pem`) rather than skipping verification.
+
+All three share one certificate — the shared dev certificate produced by
+`genTlsKeys`, whose SANs cover every container hostname (`loki`, `grafana`,
+`localhost`, …). `genTlsKeys` regenerates that certificate whenever the set
+of required hostnames changes, so adding a service does not silently reuse a
+stale cert. This is server-side TLS only; mutual TLS stays scoped to the
+SPIFFE inter-cluster path (see `docs/adr/0001-per-service-keycloak-clients.md`).
 
 The SCIM peers run the `independentid/i2scim-universal` image. They are
 wired into the same observability stack as the goSignals services: their
@@ -353,7 +368,11 @@ loki.process "parse_json" {
 }
 
 loki.write "local" {
-    endpoint { url = "http://loki:3100/loki/api/v1/push" }
+    endpoint {
+        // Loki serves HTTPS; verify it against the local dev CA.
+        url = "https://loki:3100/loki/api/v1/push"
+        tls_config { ca_file = "/etc/alloy/certs/ca-cert.pem" }
+    }
 }
 ```
 
@@ -506,8 +525,10 @@ workspace_id = "00000000-0000-0000-0000-000000000000"
 The Loki shipped in the dev compose has `auth_enabled: false` because it
 is firewalled to the compose network. In production:
 
-1. **Terminate TLS at a reverse proxy** (Nginx, Caddy, Traefik). Loki
-   itself does not need a TLS-aware listener.
+1. **Serve Loki over TLS.** Loki has a native TLS-aware HTTP listener
+   (`server.http_tls_config`) — the dev compose already enables it with the
+   shared dev certificate. A reverse proxy (Nginx, Caddy, Traefik) is still
+   useful in front of it for the auth and rate-limiting Loki lacks natively.
 2. **Require HTTP Basic auth at the proxy**. Loki accepts a `X-Scope-OrgID`
    header for multi-tenancy but does not authenticate itself.
 3. **Restrict the push endpoint to internal networks** — the

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -98,7 +98,7 @@ choice:
 | `scim_cluster2` | i2scim peer (node 2)       | http://localhost:9001              |
 | `alloy`         | Log collector              | http://localhost:3200 (UI)         |
 | `loki`          | Log backend                | https://localhost:3100             |
-| `grafana`       | Query/visualization UI     | https://localhost:3000 (admin/grafana) |
+| `grafana`       | Query/visualization UI     | https://localhost:3000 (Keycloak SSO)  |
 | `prometheus`    | Metrics backend            | https://localhost:9090             |
 
 ### The observability tier runs over TLS by default
@@ -126,7 +126,8 @@ Prometheus scrapes their `/q/metrics` endpoint as the `i2scim` job. See
 
 Run `make dev-up`, wait ~30 seconds, then:
 
-1. Open Grafana at <http://localhost:3000> (log in as `admin` / `grafana`).
+1. Open Grafana at <https://localhost:3000> and choose **Sign in with
+   GoSignals Realm** (the local login form is disabled — auth is Keycloak SSO).
 2. Click **Explore** in the left rail.
 3. Select **Loki** from the datasource picker at the top.
 4. Paste `{service="gosignals"}` into the query box and run it.
@@ -570,9 +571,9 @@ goSignals uses internally (OAuth, HMAC, SPIFFE).
 ## 8. Querying examples
 
 All of the following work against the dev compose's Loki at
-`http://localhost:3100`. Open Grafana at `http://localhost:3000`
-(admin/grafana), select the Loki datasource, and paste any of the queries
-below.
+`https://localhost:3100`. Open Grafana at `https://localhost:3000`, sign in
+via **Sign in with GoSignals Realm** (Keycloak SSO), select the Loki
+datasource, and paste any of the queries below.
 
 ### All goSignals logs
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -99,15 +99,17 @@ choice:
 | `alloy`         | Log collector              | http://localhost:3200 (UI)         |
 | `loki`          | Log backend                | https://localhost:3100             |
 | `grafana`       | Query/visualization UI     | https://localhost:3000 (admin/grafana) |
-| `prometheus`    | Metrics backend            | http://localhost:9090              |
+| `prometheus`    | Metrics backend            | https://localhost:9090             |
 
-### The log pipeline runs over TLS by default
+### The observability tier runs over TLS by default
 
-In the dev stack the log-shipping pipeline is encrypted in transit. Loki
-serves its HTTP endpoints over TLS, Alloy pushes log batches to
+In the dev stack the observability tier is encrypted in transit. For logs,
+Loki serves its HTTP endpoints over TLS, Alloy pushes log batches to
 `https://loki:3100`, and Grafana's provisioned Loki datasource queries Loki
-over HTTPS. Every hop verifies the server against the local dev CA
-(`config/certs/ca-cert.pem`) rather than skipping verification.
+over HTTPS. For metrics, Prometheus serves its UI/API over TLS, scrapes every
+target (including its own self-scrape) over HTTPS, and Grafana's Prometheus
+datasource queries it over HTTPS. Every hop verifies the server against the
+local dev CA (`config/certs/ca-cert.pem`) rather than skipping verification.
 
 All three share one certificate — the shared dev certificate produced by
 `genTlsKeys`, whose SANs cover every container hostname (`loki`, `grafana`,
@@ -314,13 +316,21 @@ three environment variables (`QUARKUS_LOG_CONSOLE_JSON=true`, `NODE_ID`,
 
 | Job           | Targets                                   | Path          | Scheme |
 |---------------|-------------------------------------------|---------------|--------|
-| `prometheus`  | `localhost:9090`                          | `/metrics`    | http   |
+| `prometheus`  | `localhost:9090`                          | `/metrics`    | https  |
 | `i2gosignals` | `gosignals1:8888`, `gosignals2:8889`      | `/metrics`    | https  |
-| `i2scim`      | `scim_cluster1:8080`, `scim_cluster2:8080`| `/q/metrics`  | http   |
+| `i2scim`      | `scim_cluster1:8443`, `scim_cluster2:8443`| `/q/metrics`  | https  |
 
-The `i2scim` job uses the Quarkus default metrics path (`/q/metrics`) and
-plain HTTP because the SCIM peers terminate TLS at the perimeter, not at
-the metrics endpoint inside the dev network. See
+Every scrape — including the Prometheus self-scrape — runs over HTTPS and
+verifies the target against the local dev CA. The SCIM peers serve an HTTPS
+listener on `:8443` (Quarkus default) alongside their plain `:8080` SCIM API,
+so `/q/metrics` is reachable over TLS.
+
+One caveat lives in the `i2scim` job's `tls_config`: it sets
+`server_name: localhost`. The SCIM peers run on a JDK that rejects a TLS SNI
+whose `host_name` contains an underscore (RFC 1123), and the container names
+`scim_cluster1` / `scim_cluster2` do — so Prometheus must send a valid SNI.
+`localhost` is in the shared dev certificate's SANs and the JDK accepts it.
+See
 [`config/monitor/prometheus/prometheus.yml`](../config/monitor/prometheus/prometheus.yml)
 for the full configuration.
 

--- a/scripts/verify-observability.sh
+++ b/scripts/verify-observability.sh
@@ -21,10 +21,39 @@ fail() {
 ok() { echo "  OK: $1"; }
 
 LOKI_URL=${LOKI_URL:-http://localhost:3100}
-GRAFANA_URL=${GRAFANA_URL:-http://localhost:3000}
+GRAFANA_URL=${GRAFANA_URL:-https://localhost:3000}
 GRAFANA_AUTH=${GRAFANA_AUTH:-admin:grafana}
 PROMETHEUS_URL=${PROMETHEUS_URL:-http://localhost:9090}
+CA_CERT=${CA_CERT:-config/certs/ca-cert.pem}
+KEYCLOAK_HOST=${KEYCLOAK_HOST:-keycloak:9080}
 WAIT_SECS=${WAIT_SECS:-90}
+
+# Grafana is served over TLS with the shared dev certificate; every call to it
+# must verify against the dev CA rather than skip verification.
+gcurl() { curl --cacert "${CA_CERT}" "$@"; }
+
+# Drive a full OIDC authorization-code login against Keycloak from the host.
+# Keycloak issues redirects to https://keycloak:9080; --resolve maps that name
+# to the published port so the script needs no /etc/hosts entry. A single
+# cookie jar carries Grafana's oauth_state and Keycloak's session cookies
+# across the redirect chain. Returns non-zero if any step fails.
+oidc_login() {
+    local user="$1" pass="$2" jar="$3"
+    local kc=(curl -s --cacert "${CA_CERT}" --resolve "${KEYCLOAK_HOST}:127.0.0.1"
+              -c "$jar" -b "$jar")
+    local login_page action
+    login_page=$("${kc[@]}" -L "${GRAFANA_URL}/login/generic_oauth") || return 1
+    action=$(printf '%s' "$login_page" \
+        | grep -oE 'action="[^"]*login-actions/authenticate[^"]*"' \
+        | head -1 | sed -E 's/.*action="([^"]*)".*/\1/' | sed 's/&amp;/\&/g')
+    [ -n "$action" ] || return 2
+    "${kc[@]}" -L -o /dev/null \
+        --data-urlencode "username=${user}" \
+        --data-urlencode "password=${pass}" \
+        --data-urlencode "credentialId=" \
+        "$action" || return 3
+    return 0
+}
 
 wait_for() {
     local desc="$1"
@@ -47,8 +76,8 @@ wait_for "Loki /ready" "curl -fsS ${LOKI_URL}/ready"
 ok "Loki ready"
 
 echo "2) Grafana datasource provisioning includes Loki..."
-wait_for "Grafana API" "curl -fsS -u ${GRAFANA_AUTH} ${GRAFANA_URL}/api/datasources"
-ds_json=$(curl -fsS -u "${GRAFANA_AUTH}" "${GRAFANA_URL}/api/datasources")
+wait_for "Grafana API" "gcurl -fsS -u ${GRAFANA_AUTH} ${GRAFANA_URL}/api/datasources"
+ds_json=$(gcurl -fsS -u "${GRAFANA_AUTH}" "${GRAFANA_URL}/api/datasources")
 echo "$ds_json" | grep -q '"type":"loki"' \
     || fail "Grafana does not list Loki datasource: $ds_json"
 ok "Loki datasource present in Grafana"
@@ -171,6 +200,47 @@ echo "$resp" | grep -q '"status":"success"' \
 echo "$resp" | grep -q '"stream":' \
     || fail "regression: gosignals query returned no streams"
 ok "no regression on goSignals log path"
+
+echo "13) Grafana is served over TLS with a CA-verifiable certificate (issue #78)..."
+wait_for "Grafana HTTPS" "gcurl -fsS ${GRAFANA_URL}/api/health"
+gcurl -fsS "${GRAFANA_URL}/api/health" >/dev/null \
+    || fail "Grafana did not present a CA-verifiable certificate at ${GRAFANA_URL}"
+# Negative check: the TLS port must not also answer plaintext HTTP.
+if curl -fsS "http://localhost:3000/api/health" >/dev/null 2>&1; then
+    fail "Grafana still answers plaintext HTTP on :3000 (expected HTTPS only)"
+fi
+ok "Grafana serves HTTPS with a certificate signed by the dev CA"
+
+echo "14) Grafana OIDC login via Keycloak succeeds with role mapping (issue #78)..."
+wait_for "Grafana generic_oauth route" \
+    "gcurl -fsS -o /dev/null ${GRAFANA_URL}/login/generic_oauth"
+
+admin_jar=$(mktemp)
+oidc_login admin admin "$admin_jar" \
+    || fail "OIDC authorization-code login as 'admin' did not complete"
+admin_user=$(gcurl -s -b "$admin_jar" "${GRAFANA_URL}/api/user")
+echo "$admin_user" | grep -q '"email":"admin@gosignals.local"' \
+    || fail "Grafana /api/user after OIDC 'admin' login unexpected: $admin_user"
+# Only an Admin can list org users; this confirms grafana:admin -> Grafana Admin.
+admin_org=$(gcurl -s -b "$admin_jar" "${GRAFANA_URL}/api/org/users")
+echo "$admin_org" | grep -q '"role":"Admin"' \
+    || fail "OIDC 'admin' did not receive Grafana Admin: $admin_org"
+ok "OIDC login as 'admin' yields Grafana Admin"
+
+user_jar=$(mktemp)
+oidc_login user user "$user_jar" \
+    || fail "OIDC authorization-code login as 'user' did not complete"
+viewer_user=$(gcurl -s -b "$user_jar" "${GRAFANA_URL}/api/user")
+echo "$viewer_user" | grep -q '"email":"user@gosignals.local"' \
+    || fail "Grafana /api/user after OIDC 'user' login unexpected: $viewer_user"
+# A Viewer must be denied an Admin-only endpoint.
+viewer_code=$(gcurl -s -o /dev/null -w '%{http_code}' -b "$user_jar" \
+    "${GRAFANA_URL}/api/org/users")
+[ "$viewer_code" = "403" ] \
+    || fail "OIDC 'user' is not restricted to Viewer (/api/org/users -> $viewer_code)"
+ok "OIDC login as 'user' yields Grafana Viewer"
+
+rm -f "$admin_jar" "$user_jar"
 
 echo ""
 echo "All observability acceptance criteria passed."

--- a/scripts/verify-observability.sh
+++ b/scripts/verify-observability.sh
@@ -22,6 +22,9 @@ ok() { echo "  OK: $1"; }
 
 LOKI_URL=${LOKI_URL:-https://localhost:3100}
 GRAFANA_URL=${GRAFANA_URL:-https://localhost:3000}
+# Grafana's interactive login form is disabled (SSO-only). API Basic Auth is a
+# separate setting and stays enabled — the sections below use it to inspect
+# Grafana's API without driving a full OIDC flow.
 GRAFANA_AUTH=${GRAFANA_AUTH:-admin:grafana}
 PROMETHEUS_URL=${PROMETHEUS_URL:-https://localhost:9090}
 CA_CERT=${CA_CERT:-config/certs/ca-cert.pem}
@@ -208,9 +211,19 @@ if curl -fsS "http://localhost:3000/api/health" >/dev/null 2>&1; then
 fi
 ok "Grafana serves HTTPS with a certificate signed by the dev CA"
 
-echo "14) Grafana OIDC login via Keycloak succeeds with role mapping (issue #78)..."
+echo "14) Grafana login is SSO-only and OIDC role mapping works (issue #78)..."
 wait_for "Grafana generic_oauth route" \
     "gcurl -fsS -o /dev/null ${GRAFANA_URL}/login/generic_oauth"
+
+# SSO-only: with GF_AUTH_DISABLE_LOGIN_FORM=true the interactive username/
+# password form is gone. POST /login with otherwise-valid admin credentials
+# must NOT yield a 200 — a successful form login means the form is still live.
+form_code=$(gcurl -s -o /dev/null -w '%{http_code}' -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"user":"admin","password":"grafana"}' "${GRAFANA_URL}/login")
+[ "$form_code" != "200" ] \
+    || fail "local password login form is still enabled (POST /login -> 200; expected SSO-only)"
+ok "local password login form is disabled — Keycloak SSO is the only interactive path"
 
 admin_jar=$(mktemp)
 oidc_login admin admin "$admin_jar" \

--- a/scripts/verify-observability.sh
+++ b/scripts/verify-observability.sh
@@ -20,7 +20,7 @@ fail() {
 
 ok() { echo "  OK: $1"; }
 
-LOKI_URL=${LOKI_URL:-http://localhost:3100}
+LOKI_URL=${LOKI_URL:-https://localhost:3100}
 GRAFANA_URL=${GRAFANA_URL:-https://localhost:3000}
 GRAFANA_AUTH=${GRAFANA_AUTH:-admin:grafana}
 PROMETHEUS_URL=${PROMETHEUS_URL:-http://localhost:9090}
@@ -28,8 +28,9 @@ CA_CERT=${CA_CERT:-config/certs/ca-cert.pem}
 KEYCLOAK_HOST=${KEYCLOAK_HOST:-keycloak:9080}
 WAIT_SECS=${WAIT_SECS:-90}
 
-# Grafana is served over TLS with the shared dev certificate; every call to it
-# must verify against the dev CA rather than skip verification.
+# Grafana and Loki are both served over TLS with the shared dev certificate;
+# every call to them must verify against the dev CA rather than skip
+# verification.
 gcurl() { curl --cacert "${CA_CERT}" "$@"; }
 
 # Drive a full OIDC authorization-code login against Keycloak from the host.
@@ -72,7 +73,7 @@ wait_for() {
 }
 
 echo "1) Loki readiness..."
-wait_for "Loki /ready" "curl -fsS ${LOKI_URL}/ready"
+wait_for "Loki /ready" "gcurl -fsS ${LOKI_URL}/ready"
 ok "Loki ready"
 
 echo "2) Grafana datasource provisioning includes Loki..."
@@ -95,8 +96,8 @@ ok "gosignals1 stdout JSON includes service, node_id, cluster_name=dev-local, ve
 echo "4) Loki exposes the expected goSignals label set..."
 expected_labels=(service node_id cluster_name component level version)
 wait_for "Loki label 'service'" \
-    "curl -fsS ${LOKI_URL}/loki/api/v1/labels | grep -q '\"service\"'"
-labels_json=$(curl -fsS "${LOKI_URL}/loki/api/v1/labels")
+    "gcurl -fsS ${LOKI_URL}/loki/api/v1/labels | grep -q '\"service\"'"
+labels_json=$(gcurl -fsS "${LOKI_URL}/loki/api/v1/labels")
 for lbl in "${expected_labels[@]}"; do
     echo "$labels_json" | grep -q "\"$lbl\"" \
         || fail "label '$lbl' not present in Loki labels: $labels_json"
@@ -115,7 +116,7 @@ echo "6) LogQL query for {service=\"gosignals\"} returns success..."
 end_ns=$(date +%s)000000000
 start_ns=$(( $(date +%s) - 600 ))000000000
 query='%7Bservice%3D%22gosignals%22%7D'
-resp=$(curl -fsS "${LOKI_URL}/loki/api/v1/query_range?query=${query}&limit=10&start=${start_ns}&end=${end_ns}")
+resp=$(gcurl -fsS "${LOKI_URL}/loki/api/v1/query_range?query=${query}&limit=10&start=${start_ns}&end=${end_ns}")
 echo "$resp" | grep -q '"status":"success"' \
     || fail "LogQL query did not return success: $resp"
 ok "LogQL query returns success"
@@ -147,15 +148,15 @@ done
 # Re-query label *values* rather than label *names* — names were checked
 # in section 4. Here we verify the SCIM peers produced lines with the
 # expected discriminators.
-service_values=$(curl -fsS "${LOKI_URL}/loki/api/v1/label/service/values")
+service_values=$(gcurl -fsS "${LOKI_URL}/loki/api/v1/label/service/values")
 echo "$service_values" | grep -q '"i2scim"' \
     || fail "service=i2scim not seen in Loki label values: $service_values"
-node_values=$(curl -fsS "${LOKI_URL}/loki/api/v1/label/node_id/values")
+node_values=$(gcurl -fsS "${LOKI_URL}/loki/api/v1/label/node_id/values")
 for n in scim_cluster1 scim_cluster2; do
     echo "$node_values" | grep -q "\"$n\"" \
         || fail "node_id=$n not seen in Loki: $node_values"
 done
-cluster_values=$(curl -fsS "${LOKI_URL}/loki/api/v1/label/cluster_name/values")
+cluster_values=$(gcurl -fsS "${LOKI_URL}/loki/api/v1/label/cluster_name/values")
 echo "$cluster_values" | grep -q '"dev-local"' \
     || fail "cluster_name=dev-local not seen in Loki: $cluster_values"
 ok "i2scim peers labelled with service/node_id/cluster_name"
@@ -164,7 +165,7 @@ echo "10) LogQL filter by SCIM node_id returns only that peer..."
 end_ns=$(date +%s)000000000
 start_ns=$(( $(date +%s) - 600 ))000000000
 query='%7Bnode_id%3D%22scim_cluster1%22%7D'
-resp=$(curl -fsS "${LOKI_URL}/loki/api/v1/query_range?query=${query}&limit=10&start=${start_ns}&end=${end_ns}")
+resp=$(gcurl -fsS "${LOKI_URL}/loki/api/v1/query_range?query=${query}&limit=10&start=${start_ns}&end=${end_ns}")
 echo "$resp" | grep -q '"status":"success"' \
     || fail "LogQL query for scim_cluster1 did not return success: $resp"
 # Negative check: response must not surface scim_cluster2 stream labels.
@@ -193,7 +194,7 @@ echo "12) Existing {service=\"gosignals\"} query still returns rows..."
 end_ns=$(date +%s)000000000
 start_ns=$(( $(date +%s) - 600 ))000000000
 query='%7Bservice%3D%22gosignals%22%7D'
-resp=$(curl -fsS "${LOKI_URL}/loki/api/v1/query_range?query=${query}&limit=10&start=${start_ns}&end=${end_ns}")
+resp=$(gcurl -fsS "${LOKI_URL}/loki/api/v1/query_range?query=${query}&limit=10&start=${start_ns}&end=${end_ns}")
 echo "$resp" | grep -q '"status":"success"' \
     || fail "regression: gosignals LogQL query did not return success: $resp"
 # Expect at least one stream in the result so we know existing logs still flow.
@@ -241,6 +242,28 @@ viewer_code=$(gcurl -s -o /dev/null -w '%{http_code}' -b "$user_jar" \
 ok "OIDC login as 'user' yields Grafana Viewer"
 
 rm -f "$admin_jar" "$user_jar"
+
+echo "15) Loki is served over TLS with a CA-verifiable certificate (issue #79)..."
+wait_for "Loki HTTPS" "gcurl -fsS ${LOKI_URL}/ready"
+gcurl -fsS "${LOKI_URL}/ready" >/dev/null \
+    || fail "Loki did not present a CA-verifiable certificate at ${LOKI_URL}"
+# Negative check: the TLS port must not also answer plaintext HTTP.
+if curl -fsS "http://localhost:3100/ready" >/dev/null 2>&1; then
+    fail "Loki still answers plaintext HTTP on :3100 (expected HTTPS only)"
+fi
+ok "Loki serves HTTPS with a certificate signed by the dev CA"
+
+echo "16) Logs still flow end to end over the TLS pipeline (issue #79)..."
+# Loki now listens HTTPS only, so any line queryable in Loki was pushed by
+# Alloy over the HTTPS loki.write hop. A fresh query returning streams proves
+# the Alloy -> Loki -> Grafana chain still works after the TLS switch.
+end_ns=$(date +%s)000000000
+start_ns=$(( $(date +%s) - 600 ))000000000
+query='%7Bservice%3D%22gosignals%22%7D'
+resp=$(gcurl -fsS "${LOKI_URL}/loki/api/v1/query_range?query=${query}&limit=10&start=${start_ns}&end=${end_ns}")
+echo "$resp" | grep -q '"stream":' \
+    || fail "no goSignals streams in Loki — Alloy HTTPS push to Loki may be failing"
+ok "Alloy ships logs to Loki over HTTPS; lines remain queryable"
 
 echo ""
 echo "All observability acceptance criteria passed."

--- a/scripts/verify-observability.sh
+++ b/scripts/verify-observability.sh
@@ -23,14 +23,14 @@ ok() { echo "  OK: $1"; }
 LOKI_URL=${LOKI_URL:-https://localhost:3100}
 GRAFANA_URL=${GRAFANA_URL:-https://localhost:3000}
 GRAFANA_AUTH=${GRAFANA_AUTH:-admin:grafana}
-PROMETHEUS_URL=${PROMETHEUS_URL:-http://localhost:9090}
+PROMETHEUS_URL=${PROMETHEUS_URL:-https://localhost:9090}
 CA_CERT=${CA_CERT:-config/certs/ca-cert.pem}
 KEYCLOAK_HOST=${KEYCLOAK_HOST:-keycloak:9080}
 WAIT_SECS=${WAIT_SECS:-90}
 
-# Grafana and Loki are both served over TLS with the shared dev certificate;
-# every call to them must verify against the dev CA rather than skip
-# verification.
+# Grafana, Loki and Prometheus are all served over TLS with the shared dev
+# certificate; every call to them must verify against the dev CA rather than
+# skip verification.
 gcurl() { curl --cacert "${CA_CERT}" "$@"; }
 
 # Drive a full OIDC authorization-code login against Keycloak from the host.
@@ -176,19 +176,15 @@ ok "node_id=scim_cluster1 query returns only that peer"
 
 echo "11) Prometheus scrapes both i2scim peers (issue #73)..."
 wait_for "Prometheus /api/v1/targets" \
-    "curl -fsS ${PROMETHEUS_URL}/api/v1/targets"
-targets_json=$(curl -fsS "${PROMETHEUS_URL}/api/v1/targets")
+    "gcurl -fsS ${PROMETHEUS_URL}/api/v1/targets"
+targets_json=$(gcurl -fsS "${PROMETHEUS_URL}/api/v1/targets")
 echo "$targets_json" | grep -q '"job":"i2scim"' \
     || fail "Prometheus has no i2scim scrape job: $targets_json"
 for peer in scim_cluster1 scim_cluster2; do
-    echo "$targets_json" | grep -qE "\"scrapeUrl\":\"http://${peer}:8080/q/metrics\"" \
-        || fail "i2scim job missing target ${peer}:8080/q/metrics"
+    echo "$targets_json" | grep -qE "\"scrapeUrl\":\"https://${peer}:8443/q/metrics\"" \
+        || fail "i2scim job missing HTTPS target ${peer}:8443/q/metrics"
 done
-# At least one of the two should be up=1 after warm-up. The script intentionally
-# does not demand both up since a slow SCIM container should not fail the run.
-echo "$targets_json" | grep -qE '"job":"i2scim".*"health":"up"' \
-    || fail "no i2scim target is health=up in Prometheus"
-ok "i2scim job present with both peers, at least one healthy"
+ok "i2scim job present with both peers scraped over HTTPS"
 
 echo "12) Existing {service=\"gosignals\"} query still returns rows..."
 end_ns=$(date +%s)000000000
@@ -264,6 +260,40 @@ resp=$(gcurl -fsS "${LOKI_URL}/loki/api/v1/query_range?query=${query}&limit=10&s
 echo "$resp" | grep -q '"stream":' \
     || fail "no goSignals streams in Loki — Alloy HTTPS push to Loki may be failing"
 ok "Alloy ships logs to Loki over HTTPS; lines remain queryable"
+
+echo "17) Prometheus is served over TLS with a CA-verifiable certificate (issue #80)..."
+wait_for "Prometheus HTTPS" "gcurl -fsS ${PROMETHEUS_URL}/-/ready"
+gcurl -fsS "${PROMETHEUS_URL}/-/ready" >/dev/null \
+    || fail "Prometheus did not present a CA-verifiable certificate at ${PROMETHEUS_URL}"
+# Negative check: the TLS port must not also answer plaintext HTTP.
+if curl -fsS "http://localhost:9090/-/ready" >/dev/null 2>&1; then
+    fail "Prometheus still answers plaintext HTTP on :9090 (expected HTTPS only)"
+fi
+ok "Prometheus serves HTTPS with a certificate signed by the dev CA"
+
+echo "18) Every Prometheus scrape target is up over HTTPS (issue #80)..."
+targets_json=$(gcurl -fsS "${PROMETHEUS_URL}/api/v1/targets")
+# Each active target must use the https scheme and report health=up. Parse the
+# JSON properly rather than grepping a single-line blob.
+python3 - "$targets_json" <<'PY' || fail "Prometheus scrape targets are not all up over HTTPS"
+import json, sys
+data = json.loads(sys.argv[1])
+targets = data["data"]["activeTargets"]
+bad = []
+for t in targets:
+    job = t["labels"].get("job", "?")
+    url = t.get("scrapeUrl", "")
+    health = t.get("health", "?")
+    if not url.startswith("https://"):
+        bad.append(f"{job} {url} is not HTTPS")
+    if health != "up":
+        bad.append(f"{job} {url} health={health} ({t.get('lastError','')})")
+if bad or not targets:
+    print("\n".join(bad) or "no active targets", file=sys.stderr)
+    sys.exit(1)
+print(f"  ({len(targets)} targets, all up over HTTPS)")
+PY
+ok "all Prometheus scrape jobs (self, i2gosignals, i2scim) up over HTTPS"
 
 echo ""
 echo "All observability acceptance criteria passed."


### PR DESCRIPTION
## Summary

Implements PRD #76: turn on server-side TLS for every network-facing
container in the observability/web tier across all compose stacks, and add
Grafana single sign-on against the `gosignals` Keycloak realm.

Closes #76, #77, #78, #79, #80.

## What's included

- **#77 — genTlsKeys SAN coverage + SAN-aware regeneration.** The shared dev
  certificate now covers every container hostname (`prometheus`, `loki`,
  `alloy`, `grafana`, `mongo1-3`, `postgres`, …). The regenerate-or-keep
  decision is extracted into a pure `certNeedsRegeneration` function with
  table-driven unit tests; adding a hostname now forces regeneration instead
  of silently reusing a stale cert.
- **#78 — Grafana over TLS with Keycloak SSO.** Grafana serves HTTPS and
  authenticates via a confidential `grafana` Keycloak client; client roles
  `admin/editor/viewer` map to Grafana org roles with a Viewer fallback.
- **#79 — Loki + Alloy log pipeline over TLS.** Loki serves HTTPS; Alloy
  pushes over HTTPS verifying the local CA; Grafana's Loki datasource queries
  over HTTPS.
- **#80 — Prometheus metrics over TLS.** Prometheus serves its UI/API over
  HTTPS and scrapes every target (including the self-scrape and i2scim on
  `:8443`) over HTTPS.
- **SSO-only follow-up.** The local Grafana password form is disabled
  (`GF_AUTH_DISABLE_LOGIN_FORM=true`) — Keycloak SSO ("Sign in with GoSignals
  Realm") is the only interactive login path. TLS + SSO config is applied
  uniformly to all six compose files, which also fixes a datasource
  provisioning regression in the `-cluster-dev`/`-spiffe`/`-spiffe-dev`
  stacks.

`docs/observability.md`, `README.md` (CA-trust + `/etc/hosts`), and
`DECISIONS_LOG.md` are updated. `scripts/verify-observability.sh` is extended
with TLS-handshake, OIDC-login, role-mapping, and SSO-only assertions.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./cmd/genTlsKeys/...` passes (SAN-aware regeneration unit tests)
- [ ] `make dev-up` then `scripts/verify-observability.sh` — full TLS/SSO
      acceptance run against a live stack
- [ ] Manual: log into Grafana at `https://localhost:3000` via "Sign in with
      GoSignals Realm" as `admin` (→ Admin) and `user` (→ Viewer); confirm the
      local password form is gone
- [ ] Manual: every Prometheus scrape target reports `up` over HTTPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)