### PR TITLE
feat(ssf): SSF subject filtering — Add/Remove Subject (§8.1.3) [PRD #89]

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -151,6 +151,208 @@ Replaces the `WriteHook` / `SetWriteHook` / `afterWrite` /
 `notifyWrite` plumbing previously threaded through ~25 BaseProvider
 methods.
 
+## Subject filtering vocabulary
+
+Terms emerging from the `docs/subject_processing.md` design (SSF §8.1.3).
+
+### Subject
+
+The principal an event is about, identified per **RFC9493** Subject
+Identifiers — the same vocabulary SSF §8.1.3 and SCIM Events (RFC9967)
+use. Formats: `account`, `email`, `iss_sub`, `opaque`, `phone_number`,
+`did`, `uri`, `aliases`, plus **complex subjects** (user / group /
+device / session / tenant / org_unit). A Subject is not necessarily a
+person — it may be a device, session, or org unit.
+_Avoid_: treating "user" or "account" as synonyms for Subject.
+
+### Subject matching
+
+The SSF §8.1.3.1 predicate that decides whether two Subjects are "the
+same" for filtering purposes — distinct from `EventService.MatchesStream`
+(which is iss/aud/event-type routing). Rules:
+
+- **Simple Subjects** match iff they are exactly identical.
+- **Complex Subjects** match field-wise: for every field (user, group,
+  device, …) at least one side may leave it undefined (wildcard); a
+  match requires every field that *is* defined on both sides to be
+  identical.
+
+Consequence: a receiver can subscribe broadly (few fields specified)
+and still receive narrower, more-specific events. Because the two
+kinds match differently, the subject filter is stored *split* by
+kind — simple Subjects hash-indexed on their canonical key (O(1)
+membership), complex Subjects held in a small field-wise-scanned
+list. A filter may legitimately reach millions of entries; see
+`docs/adr/0003-split-subject-filter-storage.md`.
+
+### defaultSubjects
+
+A per-transmitter-stream setting (goSignals extension, not an SSF
+stream-config field) expressing the **default delivery policy** a
+receiver sees — not a guarantee:
+
+- **`ALL`** — Subjects are delivered by default; the receiver narrows
+  by *removing* Subjects.
+- **`NONE`** — no Subject is delivered by default; the receiver opts
+  in by *adding* Subjects.
+
+It is only a *default*. Per SSF a transmitter MAY ignore Add/Remove
+requests and MAY deliver a Subject out-of-band on its own policy (e.g.
+a user opt-in dialog at the transmitter). So a `NONE` upstream can
+still send Subjects goSignals never added, and an `ALL` upstream may
+withhold some.
+
+The stream's subject filter table holds only the non-default set.
+Changing `defaultSubjects` on a live stream is a deliberate reset: the
+filter table is cleared, because old entries carry the opposite
+meaning under the new baseline.
+
+### Provenance-independent downstream filtering
+
+Because upstream delivery is never guaranteed to track what goSignals
+subscribed for, goSignals must tolerate receiving events for Subjects
+it never added. The downstream transmitter filter is therefore applied
+to **whatever arrives**, judged purely on that downstream stream's own
+`defaultSubjects` + filter table — never on how or why the event
+arrived. Inbound subscription state and outbound delivery policy are
+decoupled.
+
+### Subject filtering mode
+
+A setting on a goSignals **receiver stream** giving the operator
+explicit control over how Add/Remove Subject requests arriving at the
+fed downstream transmitter streams are handled:
+
+- **`PASSTHRU`** — raw 1:1 relay of Add/Remove to the upstream
+  transmitter; no reference counting, no local filtering. Downstream
+  streams share one upstream subscription and share fate: one
+  downstream's Remove removes the Subject for all. That bluntness is
+  the feature.
+- **`LOCAL`** — filter locally, independently per downstream
+  transmitter stream; never touch the upstream.
+- **`HYBRID`** — reference-counted relay *and* local fan-out
+  filtering, so each downstream sees only the Subjects it asked for.
+  goSignals tracks, per Subject handler + Subject, the **set** of
+  interested downstream streams; it relays an `add` upstream when the
+  set goes 0→1 and a `remove` only when it goes 1→0. `HYBRID` relays
+  **only against a `defaultSubjects=NONE` upstream** — against an
+  `ALL` upstream everything already arrives, so it behaves as pure
+  local filtering (relaying a `remove` could starve a not-yet-created
+  downstream). `HYBRID` is mandatory for a `NONE` upstream fanning
+  out to multiple selective downstreams — such a stream cannot be
+  filtered `LOCAL`-only because the event never arrives.
+
+`PASSTHRU` and `HYBRID` require (a) the upstream to advertise
+`add_subject_endpoint` / `remove_subject_endpoint` in its SSF
+discovery metadata, and (b) an unambiguous relay target — see
+**Event source** and **Subject handler**.
+
+### Event source
+
+How a transmitter stream selects the events it sends. A new axis,
+distinct from `RouteMode` (IM/FW/PB):
+
+- **Direct** — no routed source; events arrive in Mongo by other
+  means (e.g. direct POST). Relay is impossible → `LOCAL` only.
+- **Audience-routed** — events matched in by `iss`/`aud`/event-type
+  (the current behavior). For relay, the feeding receiver stream is
+  found by matching the transmitter stream's `iss` to a receiver
+  stream's `iss`.
+- **Explicit (SID) source** — the transmitter stream names the
+  specific source stream SID(s) it forwards/republishes from.
+
+### Subject handler
+
+The single receiver stream designated to receive relayed Add/Remove
+Subject requests for a given issuer. When an Audience-routed
+transmitter stream's `iss` matches exactly one receiver stream, that
+receiver is the subject handler automatically. When several receiver
+streams share the issuer (e.g. a cluster of nodes all transmitting to
+goSignals on common audiences), the ambiguity MUST be resolved **at
+configuration time** by designating one explicitly via Explicit (SID)
+source — otherwise stream configuration is rejected.
+
+Publish-mode `iss`/`aud` rewriting is a deferred enhancement and is
+out of scope; it will later interact with subject filtering because
+rewriting `iss` changes the canonical key of `iss_sub` Subjects.
+
+### Add Subject / Remove Subject
+
+Receiver-initiated requests (SSF §8.1.3.2 / §8.1.3.3) telling a
+transmitter stream whether to deliver events for a given Subject. Add
+Subject POST returns 200; Remove Subject POST returns 204. Carry
+`stream_id`, `subject`, and (Add only) an optional `verified` boolean.
+A transmitter MAY silently ignore them. goSignals stores `verified`
+for audit and relays it verbatim upstream, but it does not influence
+filtering — goSignals is not an identity verifier.
+
+The endpoints are gated by a server-wide `I2SIG_SUBJECT_FILTERING`
+setting (`DISABLED` default / `ENABLED`). When `DISABLED` they are
+omitted from SSF discovery and return 404.
+
+Add/Remove take effect for **future events only** — they do not
+replay a Subject's event history. A receiver that wants history uses
+the existing `ResetDate` / `ResetJti` replay mechanism instead.
+
+goSignals applies the subject filter at **delivery time**, not at
+routing time. `MatchesStream` and `HandleEvent` are untouched — an
+event still enters the stream's pending buffer. The filter is
+consulted when the buffer is drained:
+
+- **PUSH** — in `runPushLoop` on the node holding the
+  `push-transmitter:<sid>` lease. A filtered-out JTI is **discarded
+  (acked), not pushed**, so the pending list still drains and stays
+  bounded. The filter is cached in that node's memory; an Add/Remove
+  arriving on any node looks up the lease owner and notifies it (the
+  same point-to-point pattern as the event wake-up) to reload.
+- **POLL** — at poll-response time on whichever node serves the poll;
+  the filter is read straight from Mongo (polls are cold and batched).
+
+This is why routing-time filtering was rejected: routing runs on an
+arbitrary ingest node, so it would force every node to hold every
+stream's filter, with no existing channel to keep them consistent.
+Delivery-time filtering pins the hot path (PUSH) to the single lease
+owner, which the wake-up scheme already addresses.
+
+Operational events (`Operational=true` — verify, stream-updated)
+carry no Subject and always pass the filter, just as they already
+bypass `MatchesStream`.
+
+### Removal grace period
+
+A configurable interval (SSF §9.3, "Malicious Subject Removal") during
+which a Subject whose delivery was just *stopped* continues to be
+delivered, so a malicious or coerced receiver cannot instantly blind a
+downstream by quietly removing a victim Subject.
+
+- It gates the **effect**, not the SSF verb: any operation that *stops*
+  delivery for a Subject is deferred by the grace period; any operation
+  that *starts or resumes* delivery takes effect immediately. A re-Add
+  during the window cancels the pending removal.
+- It is a per-transmitter-stream setting with a server-wide default;
+  `0` means immediate enforcement. It applies only where goSignals is
+  itself the filtering transmitter — **`LOCAL`** and **`HYBRID`** local
+  fan-out. Under **`PASSTHRU`** the upstream transmitter applies its own
+  §9.3, so goSignals adds no grace.
+- It covers receiver-issued stop-delivery requests on a *live* stream
+  only. A `defaultSubjects` flip is a deliberate operator action, not
+  the §9.3 threat, so the flip clears the filter table immediately and
+  bypasses grace.
+
+### Example dialogue
+
+> **Dev:** The SCIM demo cluster has several i2scim nodes, each
+> transmitting to goSignals on the *same* set of audiences. A
+> downstream receiver removes a Subject — where does the Remove go?
+> **Domain expert:** i2scim doesn't speak SSF, so there's no upstream
+> Add/Remove endpoint to relay to. goSignals filters `LOCAL`.
+> **Dev:** And if i2scim later supported SSF?
+> **Domain expert:** The cluster would synchronize Subjects internally,
+> so you'd relay to just one node. You'd pick one cluster stream as
+> the **Subject handler** via Explicit (SID) source — issuer matching
+> alone is ambiguous across the cluster, so config would reject it
+> otherwise.
+
 ## What got deleted
 
 - **`DbProviderInterface`** (`internal/providers/dbProviders/provider_interface.go`)

--- a/DECISIONS_LOG.md
+++ b/DECISIONS_LOG.md
@@ -1,5 +1,49 @@
 # Architectural Decision & Regression Log
 
+## [2026-05-18] SSF subject filtering — delivery-time filter (issues #92, #93)
+
+### Change
+Implemented end-to-end SSF §8.1.3 subject filtering for `LOCAL` single-node PUSH
+streams (#92) and POLL streams (#93): a `SubjectFilterDAO` (memory + mongo), the
+`SubjectFilterService` (`Allows`/`AddSubject`/`RemoveSubject`/`ClearFilter`), the
+Add/Remove Subject handlers, the `defaultSubjects`-flip filter clear, and
+delivery-time filtering in `runPushLoop`/`prepareAndSendEvent` and
+`PollStreamHandler`.
+
+### Decisions
+*   **The filter stores only the non-default set, so Add/Remove are
+    baseline-aware.** A stored entry always means "the opposite of the stream
+    baseline" — an inclusion on a `NONE` stream, an exclusion on an `ALL`
+    stream. `SubjectFilterService.AddSubject`/`RemoveSubject` therefore take the
+    `*StreamStateRecord` and insert or delete the entry depending on the
+    baseline (NONE+Add and ALL+Remove insert; the other two delete).
+*   **`matches` does an indexed Get then a bounded complex/aliases scan on
+    miss**, rather than ADR-0003's strict dispatch-by-event-kind. A simple
+    subject that *is* in the filter still resolves in O(1) (early Get hit); only
+    a Get miss pays the O(complexCount) scan of the small complex/aliases list.
+    This keeps simple-subject membership indexed *and* lets a simple event still
+    match an aliases entry that contains it.
+*   **A filtered-out event is discarded (acked), not just skipped** — PUSH acks
+    it in `prepareAndSendEvent` and returns a no-op `Accepted` classification;
+    POLL acks it via `discardPolledEvent`. This keeps the pending buffer bounded
+    (ADR-0002) for a `NONE` stream with few/no subjects.
+*   **The match-result cache is invalidated per stream on any filter change.**
+    `AddSubject`/`RemoveSubject`/`ClearFilter` drop all cached decisions for the
+    stream; a short TTL bounds staleness on nodes that did not originate the
+    change (the cross-node invalidation notification is a later slice).
+
+### Invariants
+*   A `SubjectFilterEntry` is only ever present for a subject whose delivery
+    differs from the stream's `defaultSubjects` baseline.
+*   Operational events (`Operational=true`) and a server-wide disabled feature
+    always pass `Allows`.
+*   Filtered-out JTIs must be acked, never left pending, so buffers stay bounded.
+
+### Regression Verification
+*   `go test ./internal/services/ ./internal/dao/... ./internal/eventRouter/...`
+*   `go test -run TestSubjectFilteringSuite ./internal/server/test/`
+*   Mongo DAO parity: `go test -run TestSubjectFilterDAOMongoSuite ./internal/dao/mongo/`
+
 ## [2026-05-16] Grafana login is SSO-only — local password form disabled
 
 ### Change

--- a/DECISIONS_LOG.md
+++ b/DECISIONS_LOG.md
@@ -1007,3 +1007,39 @@ Service clients `goSignalsAdminService` and `goSignalsClient` were not receiving
 1.  Verify `config/keycloak/realm/gosignals-realm.json` has `fullScopeAllowed: true` for the affected clients.
 2.  Verify `defaultClientScopes` includes `roles`, `profile`, and `email` for these clients.
 
+## [2026-05-19] PASSTHRU subject relay + event-source / relay-target validation (PRD #89, issue #95)
+
+### Problem
+goSignals is both a receiver and a transmitter. A downstream receiver that calls
+Add/Remove Subject on a goSignals transmitter stream may want that change relayed
+1:1 to the upstream transmitter (PASSTHRU) rather than filtered locally. Relaying
+needs an unambiguous upstream — the receiver stream that feeds the transmitter
+stream — and the upstream must actually support subject filtering.
+
+### Solution
+New pure module `internal/services/subject_relay.go`:
+- `ResolveRelayTarget` finds the feeding receiver stream. An explicitly named
+  Subject handler SID (`EventSource.SourceStreamIds`) wins; otherwise an
+  AUDIENCE-routed stream is matched by issuer equality. Several issuer matches
+  are `ErrRelayTargetAmbiguous`; none is `ErrRelayTargetNotFound`.
+- `ClassifyUpstreamSupport` reads add/remove-subject endpoints from upstream
+  discovery: an upstream advertising neither does not support subject filtering,
+  so PASSTHRU/HYBRID is rejected and LOCAL earns a WARN (it still runs).
+- `SubjectRelayService` composes resolution + classification: `ValidateConfig`
+  is called at config time by `CreateStream`/`UpdateStream`; `Relay` posts the
+  Add/Remove to the upstream at request time. The upstream connection is fetched
+  through an injected `UpstreamResolver` so the logic is testable without a live
+  upstream; the default resolver uses `oauthClient` + `wellKnownSupport`.
+- `handleSubjectChange` short-circuits a PASSTHRU stream: it relays and applies
+  no local filter.
+
+### Invariants
+*   `EventSource.SourceStreamIds` doubles as the explicit relay-target SID — no
+    separate model field; reused for both EXPLICIT sources and AUDIENCE
+    disambiguation.
+*   PASSTHRU/HYBRID config is rejected when the relay target is unresolved /
+    ambiguous, or the upstream advertises no subject endpoints. LOCAL is never
+    rejected at config time.
+*   A PASSTHRU subject change writes no local subject filter entry.
+*   HYBRID's refcounted upstream relay is issue #96; #95 only validates HYBRID.
+

--- a/DECISIONS_LOG.md
+++ b/DECISIONS_LOG.md
@@ -1079,3 +1079,36 @@ New pure module `internal/services/subject_relay.go`:
 *   A PASSTHRU subject change writes no local subject filter entry.
 *   HYBRID's refcounted upstream relay is issue #96; #95 only validates HYBRID.
 
+
+## [2026-05-19] ListComplex must not scan the whole filter (PRD #89, issue #92, QA)
+
+### Problem
+QA of PRD #89 found delivery-time subject filtering was O(total filter size)
+per event, not O(1) for a simple subject as ADR-0003 and #92 AC10 require. A
+scaling test measured a 200,000-entry filter ~220x slower than a 1,000-entry
+one — a linear scan.
+
+Root cause: `SubjectFilterService.computeMatch` calls `dao.ListComplex` on every
+cache miss (correct — a simple event can still match an `aliases` entry), but
+both DAOs implemented `ListComplex` by scanning every entry to find the
+non-simple subset: the memory DAO via `StateManager.FindAll`, the mongo DAO via
+a `kind: {$ne: simple}` query with no index covering `kind`.
+
+### Solution
+Make `ListComplex` O(non-simple count), so the indexed simple-subject `Get`
+governs the per-event cost:
+- Memory DAO keeps a secondary `nonSimple` index (stream_id -> set of canonical
+  keys for complex/aliases entries), maintained in lock-step by Add/Remove/
+  ClearForStream. `ListComplex` visits only that small subset.
+- Mongo DAO gains a `(stream_id, kind)` index; `ListComplex` queries
+  `kind: {$in: [complex, aliases]}` so it rides the index instead of scanning.
+
+`computeMatch` is unchanged — it is correct once `ListComplex` is cheap.
+
+### Invariants
+*   `ListComplex` must never cost O(total filter size); a stream may hold
+    millions of simple entries.
+*   The memory `nonSimple` index must stay consistent with `store` — Add is an
+    upsert, so a kind change on re-Add must update the index in both directions.
+*   Regression guard: `TestSubjectFilterService_SimpleMembershipScalesConstantly`
+    fails if the simple-subject path regresses to an O(N) scan.

--- a/DECISIONS_LOG.md
+++ b/DECISIONS_LOG.md
@@ -1,5 +1,41 @@
 # Architectural Decision & Regression Log
 
+## [2026-05-19] SSF subject filtering — HYBRID refcounted upstream relay (issue #96)
+
+### Change
+`HYBRID` subject-filtering mode: a downstream transmitter stream filters
+locally per-stream (the `LOCAL` path) *and* relays subject changes to the
+upstream transmitter. `SubjectRelayService.RelayHybrid` decides whether to
+relay; `handleSubjectChange` calls it after the local filter is written.
+
+### Decisions
+*   **The interested-set is derived, not stored.** The "set of downstream
+    streams interested in (subject handler, subject)" is not a new persisted
+    structure — it is computed from the existing per-stream subject filters:
+    the HYBRID downstreams fed by the same relay-target receiver whose filter
+    still `Selects` the subject. This is drift-free and cluster-correct with no
+    new DAO. The relay fires on the 0↔1 boundary: after the caller applies the
+    downstream's own change, `RelayHybrid` counts the *other* interested HYBRID
+    siblings — zero means an add went 0→1 or a remove went 1→0.
+*   **Relay engaged only against a `defaultSubjects=NONE` upstream.** Against an
+    `ALL` upstream `HYBRID` is pure local filtering — relaying a remove could
+    starve a not-yet-created downstream. The upstream baseline is read from the
+    relay-target receiver stream's `DefaultSubjects`.
+*   **A HYBRID upstream relay failure is tolerated, not surfaced.** The local
+    filter write is the primary outcome; a failed relay is logged at WARN and
+    the handler still returns 200/204. This differs from PASSTHRU (502 on relay
+    failure) because PASSTHRU has no local fallback.
+*   **`SubjectFilterService.Selects`** extracted from `Allows` — the
+    membership predicate (Allows minus the event/operational wrapper), reused
+    as the HYBRID interested-set test.
+
+### Invariants
+*   `RelayHybrid` is called only for `SubjectFilterModeHybrid` streams, only
+    after the local filter change is applied (self is excluded from the
+    sibling count by stream id).
+*   The asymmetric variant (relay adds but not removes, or vice-versa) is not
+    built.
+
 ## [2026-05-18] SSF subject filtering — cluster cache invalidation (issue #94)
 
 ### Change

--- a/DECISIONS_LOG.md
+++ b/DECISIONS_LOG.md
@@ -1,5 +1,41 @@
 # Architectural Decision & Regression Log
 
+## [2026-05-18] SSF subject filtering — cluster cache invalidation (issue #94)
+
+### Change
+A subject filter change (Add/Remove Subject) can land on any cluster node, but
+the match-result cache that governs PUSH delivery lives on the node holding the
+`push-transmitter:<sid>` lease. Added a cluster reload notification so a change
+processed on a non-owner node invalidates the owner's cache:
+`SubjectFilterService.InvalidateCache`, `EventRouter.NotifySubjectFilterChange`,
+and a `reason` field on the existing cluster wake-up call.
+
+### Decisions
+*   **The notification reuses `/_cluster/wake-transmitter`, not a new endpoint.**
+    `WakeRequest` gains an optional `reason` field; `reason: "filter-change"`
+    invalidates the stream's match-result cache instead of waking a delivery
+    buffer. This reuses the existing route, HMAC/SPIFFE auth, and internal-server
+    wiring. The wire constant is `eventRouter.ReasonFilterChange`.
+*   **`handleSubjectChange` always calls `NotifySubjectFilterChange`.** The router
+    looks up the `push-transmitter:<sid>` lease: a local (or unowned) owner is
+    invalidated directly with no network hop; a remote owner is sent the
+    filter-change wake-up. The local invalidate in `applySubjectChange` is kept —
+    it keeps the originating node's own cache self-consistent.
+*   **The wake-up coalescing key includes the reason** (`sid:mode:reason`) on
+    both the inbound (`recentWakes`) and outbound (`recentOutboundWakes`) sides,
+    so a filter-change invalidation is never coalesced away by an ordinary
+    buffer wake-up for the same stream.
+
+### Invariants
+*   A filter change processed on any node must reach the PUSH lease owner's
+    match-result cache (invalidation), or be bounded by the short cache TTL.
+*   `reason: "filter-change"` carries `mode: "push"`; the owner lookup is always
+    the `push-transmitter:<sid>` lease.
+
+### Regression Verification
+*   `go test -race ./internal/services/ ./internal/eventRouter/ ./internal/server/...`
+*   `go test -run 'TestNotifySubjectFilterChange|TestWakeTransmitter_FilterChange|TestAddSubjectNotifiesRemoteLeaseOwner' ./internal/...`
+
 ## [2026-05-18] SSF subject filtering — delivery-time filter (issues #92, #93)
 
 ### Change
@@ -30,7 +66,7 @@ delivery-time filtering in `runPushLoop`/`prepareAndSendEvent` and
 *   **The match-result cache is invalidated per stream on any filter change.**
     `AddSubject`/`RemoveSubject`/`ClearFilter` drop all cached decisions for the
     stream; a short TTL bounds staleness on nodes that did not originate the
-    change (the cross-node invalidation notification is a later slice).
+    change (the cross-node invalidation notification was added in #94).
 
 ### Invariants
 *   A `SubjectFilterEntry` is only ever present for a subject whose delivery

--- a/cmd/genTlsKeys/keySupport.go
+++ b/cmd/genTlsKeys/keySupport.go
@@ -198,7 +198,7 @@ func (config *KeyConfig) InitializeCa() error {
 // server certificate must cover when SERVER_DNS_NAME is not set.
 func defaultServerDNSNames() []string {
 	return []string{
-		"goSignals1", "goSignals2", "goSsfServer",
+		"goSignals1", "goSignals2", "goSsfServer", "goSignalsAdmin",
 		"scim_cluster1", "scim_cluster2", "keycloak",
 		"prometheus", "loki", "alloy", "grafana",
 		"mongo1", "mongo2", "mongo3", "postgres",

--- a/config/keycloak/realm/gosignals-realm.json
+++ b/config/keycloak/realm/gosignals-realm.json
@@ -32,7 +32,9 @@
       "serviceAccountsEnabled": false,
       "redirectUris": [
         "http://localhost:8899/*",
-        "http://localhost:5173/*"
+        "http://localhost:5173/*",
+        "http://localhost:8080/*",
+        "http://gosignalsadmin:8080/*"
       ],
       "webOrigins": [
         "http://localhost:8899",

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -475,13 +475,33 @@ services:
       KC_DB_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_HTTP_HOST: 0.0.0.0
     ports:
-      - 9080:9080
+      - "9080:9080"
     depends_on:
       - postgres
     volumes:
       - "./config/keycloak/realm:/opt/keycloak/data/import"
       - "./config/keycloak/themes/gosignals-mui:/opt/keycloak/themes/gosignals-mui"
       - "./config/certs:/opt/keycloak/certs"
+  goSignalsAdmin:
+    image: independentid/gosignalsadmin:latest
+    container_name: gosignalsadmin
+    hostname: gosignalsadmin
+    networks:
+      - frontend
+      - backend
+    depends_on:
+      mongo1:
+        condition: service_healthy
+      mongo-init:
+        condition: service_completed_successfully
+      goSignals1:
+        condition: service_healthy
+    env_file:
+      - ./config/admin/admin.env
+    volumes:
+      - "./config/certs:/app/certs"
+    ports:
+      - "8080:8080"
 
 networks:
   frontend:

--- a/docs/configuration_properties.md
+++ b/docs/configuration_properties.md
@@ -101,6 +101,7 @@ understands. They are documented in their natural section below.
 |-------------------------------------------|--------------------------------------------------------------------------------------------|---------|
 | `I2SIG_STREAM_MIN_VERIFICATION_INTERVAL`  | Minimum interval, in seconds, between verification requests a receiver may demand.         | `300`   |
 | `I2SIG_STREAM_MAX_INACTIVITY_TIMEOUT`     | Maximum inactivity timeout, in seconds, before a stream connection is considered idle.     | `3600`  |
+| `I2SIG_SUBJECT_FILTERING`                 | Enables SSF subject filtering (Add/Remove Subject, §8.1.3) server-wide. `ENABLED` advertises the `add_subject_endpoint` / `remove_subject_endpoint` in SSF discovery and makes the per-stream `defaultSubjects` knob settable; `DISABLED` omits both endpoints, returns `404` from the Add/Remove Subject handlers, and silently ignores `defaultSubjects`. | `DISABLED` |
 
 ## Issuer
 

--- a/internal/dao/interfaces/dao_interfaces.go
+++ b/internal/dao/interfaces/dao_interfaces.go
@@ -63,6 +63,17 @@ type SubjectFilterDAO interface {
     Add(ctx context.Context, entry *model.SubjectFilterEntry) error
     // Get returns the entry for a stream + canonical key, or ErrNotFound.
     Get(ctx context.Context, streamID, canonicalKey string) (*model.SubjectFilterEntry, error)
+    // Remove deletes the entry for a stream + canonical key. Removing an entry
+    // that does not exist is not an error.
+    Remove(ctx context.Context, streamID, canonicalKey string) error
+    // ClearForStream deletes every subject filter entry for the given stream.
+    // It is the storage side of the defaultSubjects-flip filter clear.
+    ClearForStream(ctx context.Context, streamID string) error
+    // ListComplex returns the non-simple (complex and aliases) entries for a
+    // stream. Simple entries are deliberately excluded — they are reached by
+    // indexed Get; the complex/aliases entries need the field-wise scan path
+    // (ADR-0003).
+    ListComplex(ctx context.Context, streamID string) ([]*model.SubjectFilterEntry, error)
 }
 
 // KeyDAO handles cryptographic key data access

--- a/internal/dao/interfaces/dao_interfaces.go
+++ b/internal/dao/interfaces/dao_interfaces.go
@@ -55,6 +55,16 @@ type EventDAO interface {
     WatchPending(ctx context.Context, callback func(jti string, streamID string)) error
 }
 
+// SubjectFilterDAO handles per-stream SSF §8.1.3 subject filter entries. The
+// store is keyed by (stream_id, canonical_key) so simple-subject membership is
+// an indexed point lookup, never a collection scan (ADR-0003).
+type SubjectFilterDAO interface {
+    // Add inserts or replaces the subject entry for its (stream, canonical key).
+    Add(ctx context.Context, entry *model.SubjectFilterEntry) error
+    // Get returns the entry for a stream + canonical key, or ErrNotFound.
+    Get(ctx context.Context, streamID, canonicalKey string) (*model.SubjectFilterEntry, error)
+}
+
 // KeyDAO handles cryptographic key data access
 type KeyDAO interface {
     Insert(ctx context.Context, keyRec *JwkKeyRec) error

--- a/internal/dao/memory/subject_filter_dao.go
+++ b/internal/dao/memory/subject_filter_dao.go
@@ -1,0 +1,44 @@
+package memory
+
+import (
+    "context"
+
+    "github.com/i2-open/i2goSignals/internal/dao/interfaces"
+    model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+)
+
+// SubjectFilterDAOMemory is the file-backed in-memory SubjectFilterDAO. Entries
+// are keyed by (stream_id, canonical_key); see ADR-0003.
+type SubjectFilterDAOMemory struct {
+    store *StateManager[string, model.SubjectFilterEntry]
+}
+
+// NewSubjectFilterDAO constructs an in-memory SubjectFilterDAO.
+func NewSubjectFilterDAO() interfaces.SubjectFilterDAO {
+    return &SubjectFilterDAOMemory{
+        store: NewStateManager[string, model.SubjectFilterEntry](copySubjectFilterEntry),
+    }
+}
+
+// sfKey is the composite store key for a (stream, canonical key) pair. The NUL
+// separator cannot occur in either component.
+func sfKey(streamID, canonicalKey string) string {
+    return streamID + "\x00" + canonicalKey
+}
+
+func copySubjectFilterEntry(e *model.SubjectFilterEntry) *model.SubjectFilterEntry {
+    cp := *e
+    return &cp
+}
+
+func (d *SubjectFilterDAOMemory) Add(_ context.Context, entry *model.SubjectFilterEntry) error {
+    d.store.Set(sfKey(entry.StreamId, entry.CanonicalKey), entry)
+    return nil
+}
+
+func (d *SubjectFilterDAOMemory) Get(_ context.Context, streamID, canonicalKey string) (*model.SubjectFilterEntry, error) {
+    if e, ok := d.store.Get(sfKey(streamID, canonicalKey)); ok {
+        return e, nil
+    }
+    return nil, interfaces.ErrNotFound
+}

--- a/internal/dao/memory/subject_filter_dao.go
+++ b/internal/dao/memory/subject_filter_dao.go
@@ -2,6 +2,7 @@ package memory
 
 import (
     "context"
+    "sync"
 
     "github.com/i2-open/i2goSignals/internal/dao/interfaces"
     model "github.com/i2-open/i2goSignals/pkg/ssfModels"
@@ -9,14 +10,27 @@ import (
 
 // SubjectFilterDAOMemory is the file-backed in-memory SubjectFilterDAO. Entries
 // are keyed by (stream_id, canonical_key); see ADR-0003.
+//
+// Per ADR-0003 the filter splits by subject kind: simple-subject membership is
+// an O(1) indexed Get, and the complex/aliases subset is a small linear scan.
+// A secondary nonSimple index records which entries are complex or aliases so
+// ListComplex visits only that small subset — never a full-store scan, which
+// would make every delivery-time filter decision O(total filter size).
 type SubjectFilterDAOMemory struct {
     store *StateManager[string, model.SubjectFilterEntry]
+
+    // nonSimple maps stream_id -> set of canonical keys whose entry is complex
+    // or aliases. Guarded by mu; kept in lock-step with store by Add/Remove/
+    // ClearForStream.
+    mu        sync.Mutex
+    nonSimple map[string]map[string]struct{}
 }
 
 // NewSubjectFilterDAO constructs an in-memory SubjectFilterDAO.
 func NewSubjectFilterDAO() interfaces.SubjectFilterDAO {
     return &SubjectFilterDAOMemory{
-        store: NewStateManager[string, model.SubjectFilterEntry](copySubjectFilterEntry),
+        store:     NewStateManager[string, model.SubjectFilterEntry](copySubjectFilterEntry),
+        nonSimple: make(map[string]map[string]struct{}),
     }
 }
 
@@ -33,6 +47,21 @@ func copySubjectFilterEntry(e *model.SubjectFilterEntry) *model.SubjectFilterEnt
 
 func (d *SubjectFilterDAOMemory) Add(_ context.Context, entry *model.SubjectFilterEntry) error {
     d.store.Set(sfKey(entry.StreamId, entry.CanonicalKey), entry)
+
+    // Add is an upsert: keep the nonSimple index consistent in both directions
+    // so a kind change on re-Add never leaves a stale entry.
+    d.mu.Lock()
+    if entry.Kind != model.SubjectKindSimple {
+        set := d.nonSimple[entry.StreamId]
+        if set == nil {
+            set = make(map[string]struct{})
+            d.nonSimple[entry.StreamId] = set
+        }
+        set[entry.CanonicalKey] = struct{}{}
+    } else if set := d.nonSimple[entry.StreamId]; set != nil {
+        delete(set, entry.CanonicalKey)
+    }
+    d.mu.Unlock()
     return nil
 }
 
@@ -45,6 +74,15 @@ func (d *SubjectFilterDAOMemory) Get(_ context.Context, streamID, canonicalKey s
 
 func (d *SubjectFilterDAOMemory) Remove(_ context.Context, streamID, canonicalKey string) error {
     d.store.Delete(sfKey(streamID, canonicalKey))
+
+    d.mu.Lock()
+    if set := d.nonSimple[streamID]; set != nil {
+        delete(set, canonicalKey)
+        if len(set) == 0 {
+            delete(d.nonSimple, streamID)
+        }
+    }
+    d.mu.Unlock()
     return nil
 }
 
@@ -54,11 +92,30 @@ func (d *SubjectFilterDAOMemory) ClearForStream(_ context.Context, streamID stri
     }) {
         d.store.Delete(sfKey(e.StreamId, e.CanonicalKey))
     }
+
+    d.mu.Lock()
+    delete(d.nonSimple, streamID)
+    d.mu.Unlock()
     return nil
 }
 
+// ListComplex returns the complex and aliases entries for streamID. It visits
+// only the stream's nonSimple index, so the cost is O(non-simple count) for the
+// stream — never O(total filter size) — keeping delivery-time filtering O(1)
+// for a simple event subject (ADR-0003).
 func (d *SubjectFilterDAOMemory) ListComplex(_ context.Context, streamID string) ([]*model.SubjectFilterEntry, error) {
-    return d.store.FindAll(func(e *model.SubjectFilterEntry) bool {
-        return e.StreamId == streamID && e.Kind != model.SubjectKindSimple
-    }), nil
+    d.mu.Lock()
+    keys := make([]string, 0, len(d.nonSimple[streamID]))
+    for k := range d.nonSimple[streamID] {
+        keys = append(keys, k)
+    }
+    d.mu.Unlock()
+
+    results := make([]*model.SubjectFilterEntry, 0, len(keys))
+    for _, canonicalKey := range keys {
+        if e, ok := d.store.Get(sfKey(streamID, canonicalKey)); ok {
+            results = append(results, e)
+        }
+    }
+    return results, nil
 }

--- a/internal/dao/memory/subject_filter_dao.go
+++ b/internal/dao/memory/subject_filter_dao.go
@@ -42,3 +42,23 @@ func (d *SubjectFilterDAOMemory) Get(_ context.Context, streamID, canonicalKey s
     }
     return nil, interfaces.ErrNotFound
 }
+
+func (d *SubjectFilterDAOMemory) Remove(_ context.Context, streamID, canonicalKey string) error {
+    d.store.Delete(sfKey(streamID, canonicalKey))
+    return nil
+}
+
+func (d *SubjectFilterDAOMemory) ClearForStream(_ context.Context, streamID string) error {
+    for _, e := range d.store.FindAll(func(e *model.SubjectFilterEntry) bool {
+        return e.StreamId == streamID
+    }) {
+        d.store.Delete(sfKey(e.StreamId, e.CanonicalKey))
+    }
+    return nil
+}
+
+func (d *SubjectFilterDAOMemory) ListComplex(_ context.Context, streamID string) ([]*model.SubjectFilterEntry, error) {
+    return d.store.FindAll(func(e *model.SubjectFilterEntry) bool {
+        return e.StreamId == streamID && e.Kind != model.SubjectKindSimple
+    }), nil
+}

--- a/internal/dao/memory/subject_filter_dao_test.go
+++ b/internal/dao/memory/subject_filter_dao_test.go
@@ -1,0 +1,90 @@
+package memory
+
+import (
+    "context"
+    "errors"
+    "testing"
+
+    "github.com/i2-open/i2goSignals/internal/dao/interfaces"
+    model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+)
+
+// simpleEntry builds a simple-kind SubjectFilterEntry for the given stream and
+// canonical key.
+func simpleEntry(streamID, key string) *model.SubjectFilterEntry {
+    return &model.SubjectFilterEntry{StreamId: streamID, CanonicalKey: key, Kind: model.SubjectKindSimple}
+}
+
+// TestSubjectFilterDAOMemory_RemoveDeletesEntry verifies Remove deletes the
+// entry for a (stream, canonical key) so a subsequent Get reports ErrNotFound.
+func TestSubjectFilterDAOMemory_RemoveDeletesEntry(t *testing.T) {
+    ctx := context.Background()
+    dao := NewSubjectFilterDAO()
+
+    if err := dao.Add(ctx, simpleEntry("stream-1", "email:alice@example.com")); err != nil {
+        t.Fatalf("Add: %v", err)
+    }
+    if err := dao.Remove(ctx, "stream-1", "email:alice@example.com"); err != nil {
+        t.Fatalf("Remove: %v", err)
+    }
+
+    _, err := dao.Get(ctx, "stream-1", "email:alice@example.com")
+    if !errors.Is(err, interfaces.ErrNotFound) {
+        t.Fatalf("after Remove, Get must report ErrNotFound, got %v", err)
+    }
+}
+
+// TestSubjectFilterDAOMemory_ClearForStreamWipesOnlyThatStream verifies
+// ClearForStream removes every entry for the named stream and leaves other
+// streams' entries untouched.
+func TestSubjectFilterDAOMemory_ClearForStreamWipesOnlyThatStream(t *testing.T) {
+    ctx := context.Background()
+    dao := NewSubjectFilterDAO()
+
+    _ = dao.Add(ctx, simpleEntry("stream-1", "email:alice@example.com"))
+    _ = dao.Add(ctx, simpleEntry("stream-1", "email:bob@example.com"))
+    _ = dao.Add(ctx, simpleEntry("stream-2", "email:carol@example.com"))
+
+    if err := dao.ClearForStream(ctx, "stream-1"); err != nil {
+        t.Fatalf("ClearForStream: %v", err)
+    }
+
+    if _, err := dao.Get(ctx, "stream-1", "email:alice@example.com"); !errors.Is(err, interfaces.ErrNotFound) {
+        t.Fatalf("stream-1 entry alice must be cleared, got %v", err)
+    }
+    if _, err := dao.Get(ctx, "stream-1", "email:bob@example.com"); !errors.Is(err, interfaces.ErrNotFound) {
+        t.Fatalf("stream-1 entry bob must be cleared, got %v", err)
+    }
+    if _, err := dao.Get(ctx, "stream-2", "email:carol@example.com"); err != nil {
+        t.Fatalf("stream-2 entry must survive ClearForStream(stream-1), got %v", err)
+    }
+}
+
+// TestSubjectFilterDAOMemory_ListComplexReturnsOnlyNonSimpleForStream verifies
+// ListComplex returns the complex and aliases entries for one stream and never
+// the simple entries (which are reached by indexed Get, per ADR-0003).
+func TestSubjectFilterDAOMemory_ListComplexReturnsOnlyNonSimpleForStream(t *testing.T) {
+    ctx := context.Background()
+    dao := NewSubjectFilterDAO()
+
+    _ = dao.Add(ctx, simpleEntry("stream-1", "email:alice@example.com"))
+    _ = dao.Add(ctx, &model.SubjectFilterEntry{StreamId: "stream-1", CanonicalKey: "complex:[user=email:u]", Kind: model.SubjectKindComplex})
+    _ = dao.Add(ctx, &model.SubjectFilterEntry{StreamId: "stream-1", CanonicalKey: "aliases:[email:a]", Kind: model.SubjectKindAliases})
+    _ = dao.Add(ctx, &model.SubjectFilterEntry{StreamId: "stream-2", CanonicalKey: "complex:[user=email:v]", Kind: model.SubjectKindComplex})
+
+    got, err := dao.ListComplex(ctx, "stream-1")
+    if err != nil {
+        t.Fatalf("ListComplex: %v", err)
+    }
+    if len(got) != 2 {
+        t.Fatalf("ListComplex(stream-1) must return the 2 non-simple entries, got %d", len(got))
+    }
+    for _, e := range got {
+        if e.Kind == model.SubjectKindSimple {
+            t.Fatalf("ListComplex must never return a simple entry, got kind %q", e.Kind)
+        }
+        if e.StreamId != "stream-1" {
+            t.Fatalf("ListComplex(stream-1) must only return stream-1 entries, got %q", e.StreamId)
+        }
+    }
+}

--- a/internal/dao/mongo/subject_filter_dao.go
+++ b/internal/dao/mongo/subject_filter_dao.go
@@ -38,15 +38,26 @@ func (d *SubjectFilterDAOMongo) SetCollection(c *mongo.Collection) {
     d.ensureIndex(c)
 }
 
-// ensureIndex creates the compound unique index on (stream_id, canonical_key).
-// It is idempotent and best-effort: a failure is logged, not fatal.
+// ensureIndex creates the subject_filters indexes. It is idempotent and
+// best-effort: a failure is logged, not fatal.
+//
+//   - (stream_id, canonical_key) unique — simple-subject membership is an
+//     indexed point lookup.
+//   - (stream_id, kind) — ListComplex selects only the small complex/aliases
+//     subset without scanning the stream's (potentially millions of) simple
+//     entries (ADR-0003).
 func (d *SubjectFilterDAOMongo) ensureIndex(c *mongo.Collection) {
     if c == nil {
         return
     }
-    _, err := c.Indexes().CreateOne(context.Background(), mongo.IndexModel{
-        Keys:    bson.D{{Key: "stream_id", Value: 1}, {Key: "canonical_key", Value: 1}},
-        Options: options.Index().SetUnique(true),
+    _, err := c.Indexes().CreateMany(context.Background(), []mongo.IndexModel{
+        {
+            Keys:    bson.D{{Key: "stream_id", Value: 1}, {Key: "canonical_key", Value: 1}},
+            Options: options.Index().SetUnique(true),
+        },
+        {
+            Keys: bson.D{{Key: "stream_id", Value: 1}, {Key: "kind", Value: 1}},
+        },
     })
     if err != nil {
         sfLog.Warn("Error creating subject_filters index", "error", err)
@@ -117,12 +128,15 @@ func (d *SubjectFilterDAOMongo) ClearForStream(ctx context.Context, streamID str
     return nil
 }
 
+// ListComplex returns the complex and aliases entries for streamID. The
+// kind: $in predicate rides the (stream_id, kind) index, so it selects only the
+// small non-simple subset and never scans the stream's simple entries (ADR-0003).
 func (d *SubjectFilterDAOMongo) ListComplex(ctx context.Context, streamID string) ([]*model.SubjectFilterEntry, error) {
     c, err := d.col()
     if err != nil {
         return nil, err
     }
-    filter := bson.M{"stream_id": streamID, "kind": bson.M{"$ne": model.SubjectKindSimple}}
+    filter := bson.M{"stream_id": streamID, "kind": bson.M{"$in": bson.A{model.SubjectKindComplex, model.SubjectKindAliases}}}
     cursor, err := c.Find(ctx, filter)
     if err != nil {
         sfLog.Error("Error listing complex subject filter entries", "sid", streamID, "error", err)

--- a/internal/dao/mongo/subject_filter_dao.go
+++ b/internal/dao/mongo/subject_filter_dao.go
@@ -1,0 +1,137 @@
+package mongo
+
+import (
+    "context"
+    "errors"
+
+    "github.com/i2-open/i2goSignals/internal/dao/interfaces"
+    "github.com/i2-open/i2goSignals/pkg/logger"
+    model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+    "go.mongodb.org/mongo-driver/v2/bson"
+    "go.mongodb.org/mongo-driver/v2/mongo"
+    "go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+var sfLog = logger.Sub("SUBJECT_FILTER_DAO")
+
+var errSubjectFilterNotInit = errors.New("mongo collection not initialized")
+
+// SubjectFilterDAOMongo is the MongoDB-backed SubjectFilterDAO. Entries live in
+// the subject_filters collection, one document per (stream_id, canonical_key);
+// a compound index on that pair makes simple-subject membership an indexed
+// point lookup rather than a collection scan (ADR-0003).
+type SubjectFilterDAOMongo struct {
+    ref collectionRef
+}
+
+// NewSubjectFilterDAO constructs a MongoDB SubjectFilterDAO over collection and
+// ensures the (stream_id, canonical_key) index exists.
+func NewSubjectFilterDAO(collection *mongo.Collection) interfaces.SubjectFilterDAO {
+    d := &SubjectFilterDAOMongo{}
+    d.ref.set(collection)
+    d.ensureIndex(collection)
+    return d
+}
+
+func (d *SubjectFilterDAOMongo) SetCollection(c *mongo.Collection) {
+    d.ref.set(c)
+    d.ensureIndex(c)
+}
+
+// ensureIndex creates the compound unique index on (stream_id, canonical_key).
+// It is idempotent and best-effort: a failure is logged, not fatal.
+func (d *SubjectFilterDAOMongo) ensureIndex(c *mongo.Collection) {
+    if c == nil {
+        return
+    }
+    _, err := c.Indexes().CreateOne(context.Background(), mongo.IndexModel{
+        Keys:    bson.D{{Key: "stream_id", Value: 1}, {Key: "canonical_key", Value: 1}},
+        Options: options.Index().SetUnique(true),
+    })
+    if err != nil {
+        sfLog.Warn("Error creating subject_filters index", "error", err)
+    }
+}
+
+func (d *SubjectFilterDAOMongo) col() (*mongo.Collection, error) {
+    c := d.ref.load()
+    if c == nil {
+        return nil, errSubjectFilterNotInit
+    }
+    return c, nil
+}
+
+func (d *SubjectFilterDAOMongo) Add(ctx context.Context, entry *model.SubjectFilterEntry) error {
+    c, err := d.col()
+    if err != nil {
+        return err
+    }
+    filter := bson.M{"stream_id": entry.StreamId, "canonical_key": entry.CanonicalKey}
+    _, err = c.ReplaceOne(ctx, filter, entry, options.Replace().SetUpsert(true))
+    if err != nil {
+        sfLog.Error("Error adding subject filter entry", "sid", entry.StreamId, "error", err)
+    }
+    return err
+}
+
+func (d *SubjectFilterDAOMongo) Get(ctx context.Context, streamID, canonicalKey string) (*model.SubjectFilterEntry, error) {
+    c, err := d.col()
+    if err != nil {
+        return nil, err
+    }
+    filter := bson.M{"stream_id": streamID, "canonical_key": canonicalKey}
+    var entry model.SubjectFilterEntry
+    err = c.FindOne(ctx, filter).Decode(&entry)
+    if err != nil {
+        err = HandleFindError(err, interfaces.ErrNotFound)
+        if !errors.Is(err, interfaces.ErrNotFound) {
+            sfLog.Error("Error finding subject filter entry", "sid", streamID, "error", err)
+        }
+        return nil, err
+    }
+    return &entry, nil
+}
+
+func (d *SubjectFilterDAOMongo) Remove(ctx context.Context, streamID, canonicalKey string) error {
+    c, err := d.col()
+    if err != nil {
+        return err
+    }
+    filter := bson.M{"stream_id": streamID, "canonical_key": canonicalKey}
+    if _, err = c.DeleteOne(ctx, filter); err != nil {
+        sfLog.Error("Error removing subject filter entry", "sid", streamID, "error", err)
+        return err
+    }
+    return nil
+}
+
+func (d *SubjectFilterDAOMongo) ClearForStream(ctx context.Context, streamID string) error {
+    c, err := d.col()
+    if err != nil {
+        return err
+    }
+    if _, err = c.DeleteMany(ctx, bson.M{"stream_id": streamID}); err != nil {
+        sfLog.Error("Error clearing subject filter for stream", "sid", streamID, "error", err)
+        return err
+    }
+    return nil
+}
+
+func (d *SubjectFilterDAOMongo) ListComplex(ctx context.Context, streamID string) ([]*model.SubjectFilterEntry, error) {
+    c, err := d.col()
+    if err != nil {
+        return nil, err
+    }
+    filter := bson.M{"stream_id": streamID, "kind": bson.M{"$ne": model.SubjectKindSimple}}
+    cursor, err := c.Find(ctx, filter)
+    if err != nil {
+        sfLog.Error("Error listing complex subject filter entries", "sid", streamID, "error", err)
+        return nil, err
+    }
+    var entries []*model.SubjectFilterEntry
+    if err = cursor.All(ctx, &entries); err != nil {
+        sfLog.Error("Error decoding complex subject filter entries", "sid", streamID, "error", err)
+        return nil, err
+    }
+    return entries, nil
+}

--- a/internal/dao/mongo/subject_filter_dao_test.go
+++ b/internal/dao/mongo/subject_filter_dao_test.go
@@ -1,0 +1,129 @@
+package mongo
+
+import (
+    "context"
+    "errors"
+    "testing"
+
+    "github.com/i2-open/i2goSignals/internal/dao/interfaces"
+    model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+    "github.com/stretchr/testify/suite"
+    "go.mongodb.org/mongo-driver/v2/mongo"
+    "go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+// SubjectFilterDAOMongoSuite exercises the MongoDB SubjectFilterDAO adapter and
+// confirms it behaves identically to the memory adapter (PRD #89, #92 AC 9).
+type SubjectFilterDAOMongoSuite struct {
+    suite.Suite
+    client     *mongo.Client
+    collection *mongo.Collection
+    dao        interfaces.SubjectFilterDAO
+}
+
+func (suite *SubjectFilterDAOMongoSuite) SetupSuite() {
+    opts := options.Client().ApplyURI(TestDbUrl)
+    client, err := mongo.Connect(opts)
+    if err != nil {
+        suite.T().Skip("Mongo connection error: " + err.Error())
+        return
+    }
+    if err = client.Ping(context.Background(), nil); err != nil {
+        suite.T().Skip("Mongo ping error: " + err.Error())
+        return
+    }
+    suite.client = client
+    suite.collection = client.Database("test_db").Collection("subject_filters")
+    suite.dao = NewSubjectFilterDAO(suite.collection)
+}
+
+func (suite *SubjectFilterDAOMongoSuite) TearDownSuite() {
+    if suite.client != nil {
+        _ = suite.client.Disconnect(context.Background())
+    }
+}
+
+func (suite *SubjectFilterDAOMongoSuite) SetupTest() {
+    _ = suite.collection.Drop(context.Background())
+    suite.dao.(*SubjectFilterDAOMongo).ensureIndex(suite.collection)
+}
+
+func TestSubjectFilterDAOMongoSuite(t *testing.T) {
+    suite.Run(t, new(SubjectFilterDAOMongoSuite))
+}
+
+func mSimpleEntry(streamID, key string) *model.SubjectFilterEntry {
+    return &model.SubjectFilterEntry{StreamId: streamID, CanonicalKey: key, Kind: model.SubjectKindSimple}
+}
+
+// TestAddGet verifies an added entry is read back by its (stream, canonical key).
+func (suite *SubjectFilterDAOMongoSuite) TestAddGet() {
+    ctx := context.Background()
+    suite.NoError(suite.dao.Add(ctx, mSimpleEntry("stream-1", "email:alice@example.com")))
+
+    got, err := suite.dao.Get(ctx, "stream-1", "email:alice@example.com")
+    suite.NoError(err)
+    suite.Equal("stream-1", got.StreamId)
+    suite.Equal("email:alice@example.com", got.CanonicalKey)
+}
+
+// TestAddIsUpsert verifies Add on an existing (stream, key) replaces rather
+// than duplicating — the same insert-or-replace contract as the memory adapter.
+func (suite *SubjectFilterDAOMongoSuite) TestAddIsUpsert() {
+    ctx := context.Background()
+    suite.NoError(suite.dao.Add(ctx, &model.SubjectFilterEntry{StreamId: "stream-1", CanonicalKey: "email:a@example.com", Kind: model.SubjectKindSimple, Verified: false}))
+    suite.NoError(suite.dao.Add(ctx, &model.SubjectFilterEntry{StreamId: "stream-1", CanonicalKey: "email:a@example.com", Kind: model.SubjectKindSimple, Verified: true}))
+
+    got, err := suite.dao.Get(ctx, "stream-1", "email:a@example.com")
+    suite.NoError(err)
+    suite.True(got.Verified, "Add must replace the existing entry")
+}
+
+// TestRemoveDeletesEntry verifies Remove deletes the entry so Get reports ErrNotFound.
+func (suite *SubjectFilterDAOMongoSuite) TestRemoveDeletesEntry() {
+    ctx := context.Background()
+    suite.NoError(suite.dao.Add(ctx, mSimpleEntry("stream-1", "email:alice@example.com")))
+    suite.NoError(suite.dao.Remove(ctx, "stream-1", "email:alice@example.com"))
+
+    _, err := suite.dao.Get(ctx, "stream-1", "email:alice@example.com")
+    suite.True(errors.Is(err, interfaces.ErrNotFound), "Get after Remove must report ErrNotFound")
+}
+
+// TestRemoveMissingIsNotError verifies removing a non-existent entry is a no-op.
+func (suite *SubjectFilterDAOMongoSuite) TestRemoveMissingIsNotError() {
+    suite.NoError(suite.dao.Remove(context.Background(), "stream-1", "email:nobody@example.com"))
+}
+
+// TestClearForStreamWipesOnlyThatStream verifies ClearForStream removes every
+// entry for the named stream and leaves other streams untouched.
+func (suite *SubjectFilterDAOMongoSuite) TestClearForStreamWipesOnlyThatStream() {
+    ctx := context.Background()
+    _ = suite.dao.Add(ctx, mSimpleEntry("stream-1", "email:alice@example.com"))
+    _ = suite.dao.Add(ctx, mSimpleEntry("stream-1", "email:bob@example.com"))
+    _ = suite.dao.Add(ctx, mSimpleEntry("stream-2", "email:carol@example.com"))
+
+    suite.NoError(suite.dao.ClearForStream(ctx, "stream-1"))
+
+    _, err := suite.dao.Get(ctx, "stream-1", "email:alice@example.com")
+    suite.True(errors.Is(err, interfaces.ErrNotFound), "stream-1 entry must be cleared")
+    _, err = suite.dao.Get(ctx, "stream-2", "email:carol@example.com")
+    suite.NoError(err, "stream-2 entry must survive ClearForStream(stream-1)")
+}
+
+// TestListComplexReturnsOnlyNonSimpleForStream verifies ListComplex returns the
+// complex and aliases entries for one stream and never the simple entries.
+func (suite *SubjectFilterDAOMongoSuite) TestListComplexReturnsOnlyNonSimpleForStream() {
+    ctx := context.Background()
+    _ = suite.dao.Add(ctx, mSimpleEntry("stream-1", "email:alice@example.com"))
+    _ = suite.dao.Add(ctx, &model.SubjectFilterEntry{StreamId: "stream-1", CanonicalKey: "complex:[user=email:u]", Kind: model.SubjectKindComplex})
+    _ = suite.dao.Add(ctx, &model.SubjectFilterEntry{StreamId: "stream-1", CanonicalKey: "aliases:[email:a]", Kind: model.SubjectKindAliases})
+    _ = suite.dao.Add(ctx, &model.SubjectFilterEntry{StreamId: "stream-2", CanonicalKey: "complex:[user=email:v]", Kind: model.SubjectKindComplex})
+
+    got, err := suite.dao.ListComplex(ctx, "stream-1")
+    suite.NoError(err)
+    suite.Len(got, 2, "ListComplex must return the 2 non-simple stream-1 entries")
+    for _, e := range got {
+        suite.NotEqual(model.SubjectKindSimple, e.Kind, "ListComplex must never return a simple entry")
+        suite.Equal("stream-1", e.StreamId)
+    }
+}

--- a/internal/eventRouter/delivery/http_test.go
+++ b/internal/eventRouter/delivery/http_test.go
@@ -221,7 +221,7 @@ func TestHTTPAdapter_RemoteAddressPersistedToStreamService(t *testing.T) {
 
 	cfg := newForwardStream(receiver.URL + "/events").StreamConfiguration
 	ctx := context.WithValue(context.Background(), authUtil.AuthContextKey, authUtil.ConvertProject(projectId))
-	created, err := persistence.StreamService.CreateStream(ctx, cfg, projectId, nil)
+	created, err := persistence.StreamService.CreateStream(ctx, model.StreamStateRecord{StreamConfiguration: cfg}, projectId, nil)
 	require.NoError(t, err)
 	stream, err := persistence.StreamService.GetStreamState(context.Background(), created.Id)
 	require.NoError(t, err)
@@ -265,7 +265,7 @@ func TestHTTPAdapter_SamePeerSecondPushDoesNotChangeRemoteAddress(t *testing.T) 
 
 	cfg := newForwardStream(receiver.URL + "/events").StreamConfiguration
 	ctx := context.WithValue(context.Background(), authUtil.AuthContextKey, authUtil.ConvertProject(projectId))
-	created, err := persistence.StreamService.CreateStream(ctx, cfg, projectId, nil)
+	created, err := persistence.StreamService.CreateStream(ctx, model.StreamStateRecord{StreamConfiguration: cfg}, projectId, nil)
 	require.NoError(t, err)
 	stream, err := persistence.StreamService.GetStreamState(context.Background(), created.Id)
 	require.NoError(t, err)

--- a/internal/eventRouter/event_router.go
+++ b/internal/eventRouter/event_router.go
@@ -847,33 +847,49 @@ func (r *router) PollStreamHandler(sid string, params model.PollParameters) (map
 	var err error
 	if jtiSize > 0 {
 		sets := make(map[string]string, jtiSize)
-		if forwardMode {
-			jtis := *jtiSlice
-			for _, jti := range jtis {
-				eventRecord := r.eventService.GetEventRecord(r.ctx, jti)
-				if eventRecord == nil {
-					eventLogger.Warn("POLL-SRV: JTI Not found", "sid", sid, "jti", jti)
-					continue
-				}
-				sets[jti] = eventRecord.Original
+		for _, jti := range *jtiSlice {
+			eventRecord := r.eventService.GetEventRecord(r.ctx, jti)
+			if eventRecord == nil {
+				eventLogger.Warn("POLL-SRV: JTI Not found", "sid", sid, "jti", jti)
+				continue
 			}
-		} else {
-			tokens := r.eventService.GetEvents(r.ctx, *jtiSlice)
-			for _, token := range tokens {
-				token.Issuer = state.StreamConfiguration.Iss
-				token.Audience = state.StreamConfiguration.Aud
-				token.IssuedAt = jwt.NewNumericDate(time.Now())
-				token.Kid = kid
+			// SSF §8.1.3 delivery-time subject filtering for POLL. Any node may
+			// serve a poll, so the filter is consulted here at poll-response
+			// time; a filtered-out event is discarded (acked) rather than
+			// returned, so the poll buffer stays bounded (ADR-0002).
+			if r.subjectFilterService != nil && !r.subjectFilterService.Allows(r.ctx, &state, eventRecord) {
+				r.discardPolledEvent(sid, jti, pollBuffer)
+				eventLogger.Debug("POLL-SRV: event filtered out by subject filter, discarded", "sid", sid, "jti", jti)
+				continue
+			}
+			if forwardMode {
+				sets[jti] = eventRecord.Original
+				continue
+			}
+			token := &eventRecord.Event
+			token.Issuer = state.StreamConfiguration.Iss
+			token.Audience = state.StreamConfiguration.Aud
+			token.IssuedAt = jwt.NewNumericDate(time.Now())
+			token.Kid = kid
 
-				sets[token.ID], err = token.JWS(jwt.SigningMethodRS256, key)
-				if err != nil {
-					eventLogger.Error("POLL-SRV: Error signing", "sid", sid, "error", err)
-				}
+			sets[jti], err = token.JWS(jwt.SigningMethodRS256, key)
+			if err != nil {
+				eventLogger.Error("POLL-SRV: Error signing", "sid", sid, "error", err)
 			}
 		}
 		return sets, more, http.StatusOK
 	}
 	return map[string]string{}, false, http.StatusOK
+}
+
+// discardPolledEvent drops a filtered-out event from a poll stream: it is acked
+// in the poll buffer and the provider so it is neither returned now nor on a
+// later poll, keeping the pending buffer bounded.
+func (r *router) discardPolledEvent(sid, jti string, pollBuffer *buffer.EventPollBuffer) {
+	pollBuffer.AckEvents([]string{jti})
+	if err := r.eventService.AckEvent(r.ctx, jti, sid, 0); err != nil {
+		eventLogger.Error("POLL-SRV: Error discarding filtered-out event", "sid", sid, "jti", jti, "error", err)
+	}
 }
 
 // PushStreamHandler manages the lifecycle of a push stream, including lease handling and event transmission.

--- a/internal/eventRouter/event_router.go
+++ b/internal/eventRouter/event_router.go
@@ -58,6 +58,11 @@ type EventRouter interface {
 	SetStatsHandler(stats interface{})
 	ResetStream(sid string)
 	WakeTransmitter(sid string, mode string)
+	// NotifySubjectFilterChange propagates an Add/Remove Subject change to the
+	// node whose match-result cache governs delivery for the stream, so a
+	// subject filter change processed on any cluster node takes effect on the
+	// push-transmitter lease owner (issue #94).
+	NotifySubjectFilterChange(sid string)
 }
 
 type router struct {
@@ -636,7 +641,7 @@ func (r *router) HandleEvent(eventToken *goSet.SecurityEventToken, rawEvent stri
 				r.pushBuffers[stream.StreamConfiguration.Id].SubmitEvent(event.Jti)
 			} else {
 				// Remote owner, send wake-up
-				go r.sendWakeup(stream.StreamConfiguration.Id, "push", ownerNodeId)
+				go r.sendWakeup(stream.StreamConfiguration.Id, "push", ownerNodeId, "")
 			}
 		}
 	}
@@ -695,7 +700,7 @@ func (r *router) SubmitOperationalEvent(sid string, eventToken *goSet.SecurityEv
 		if ownerNodeId == "" || ownerNodeId == r.nodeId {
 			pushBuf.SubmitEvent(rec.Jti)
 		} else {
-			go r.sendWakeup(sid, "push", ownerNodeId)
+			go r.sendWakeup(sid, "push", ownerNodeId, "")
 		}
 		eventLogger.Info("ROUTER: Operational event submitted (push)", "sid", sid, "jti", rec.Jti, "types", rec.Types)
 		return rec, nil
@@ -711,9 +716,34 @@ func (r *router) SubmitOperationalEvent(sid string, eventToken *goSet.SecurityEv
 	return rec, nil
 }
 
-func (r *router) sendWakeup(sid, mode, ownerNodeId string) {
-	// Rate limiting / Coalescing
-	key := sid + ":" + mode
+// ReasonFilterChange is the WakeRequest reason that turns a cluster wake-up
+// call into a subject-filter match-result cache invalidation (issue #94).
+const ReasonFilterChange = "filter-change"
+
+// NotifySubjectFilterChange propagates an Add/Remove Subject change to the node
+// whose match-result cache governs PUSH delivery for sid. The
+// push-transmitter lease owner holds that cache; when the owner is the local
+// node (or the stream is unleased) the cache is invalidated directly with no
+// network hop, otherwise a cluster wake-up call carrying reason "filter-change"
+// is sent to the owner so it drops the affected entries (issue #94, ADR-0003).
+func (r *router) NotifySubjectFilterChange(sid string) {
+	if r.subjectFilterService == nil {
+		return
+	}
+	resource := fmt.Sprintf("push-transmitter:%s", sid)
+	ownerNodeId, _, _, _ := r.coordinator.GetLeaseOwner(resource)
+	if ownerNodeId == "" || ownerNodeId == r.nodeId {
+		r.subjectFilterService.InvalidateCache(sid)
+		return
+	}
+	go r.sendWakeup(sid, "push", ownerNodeId, ReasonFilterChange)
+}
+
+func (r *router) sendWakeup(sid, mode, ownerNodeId, reason string) {
+	// Rate limiting / Coalescing. The reason is part of the key so a
+	// filter-change notification is never coalesced away by a buffer wake-up
+	// (or vice versa) that happens to target the same stream.
+	key := sid + ":" + mode + ":" + reason
 	r.outboundWakesMu.Lock()
 	lastWake, exists := r.recentOutboundWakes[key]
 	if exists && time.Since(lastWake) < 250*time.Millisecond {
@@ -734,16 +764,20 @@ func (r *router) sendWakeup(sid, mode, ownerNodeId string) {
 		return
 	}
 
-	r.callWakeupAPI(node.Address, sid, mode)
+	r.callWakeupAPI(node.Address, sid, mode, reason)
 }
 
-func (r *router) callWakeupAPI(address, sid, mode string) {
+func (r *router) callWakeupAPI(address, sid, mode, reason string) {
 	url := strings.TrimSuffix(address, "/") + "/_cluster/wake-transmitter"
 
-	reqBody, _ := json.Marshal(map[string]string{
+	body := map[string]string{
 		"sid":  sid,
 		"mode": mode,
-	})
+	}
+	if reason != "" {
+		body["reason"] = reason
+	}
+	reqBody, _ := json.Marshal(body)
 
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(reqBody))
 	if err != nil {

--- a/internal/eventRouter/event_router.go
+++ b/internal/eventRouter/event_router.go
@@ -61,24 +61,25 @@ type EventRouter interface {
 }
 
 type router struct {
-	mu                  sync.RWMutex
-	pushStreams         map[string]model.StreamStateRecord // These are transmitters
-	pollStreams         map[string]model.StreamStateRecord
-	ctx                 context.Context
-	cancel              context.CancelFunc
-	enabled             bool
-	nodeId              string
-	issuerKeys          map[string]*rsa.PrivateKey
-	issuerKids          map[string]string
-	pollBuffers         map[string]*buffer.EventPollBuffer
-	pushBuffers         map[string]*buffer.EventPushBuffer
-	coordinator         cluster.ClusterCoordinator
-	streamService       *services.StreamService
-	keyService          *services.KeyService
-	eventService        *services.EventService
-	pushDelivery        delivery.PushDelivery
-	eventsIn, eventsOut *prometheus.CounterVec
-	stats               statsTracker
+	mu                   sync.RWMutex
+	pushStreams          map[string]model.StreamStateRecord // These are transmitters
+	pollStreams          map[string]model.StreamStateRecord
+	ctx                  context.Context
+	cancel               context.CancelFunc
+	enabled              bool
+	nodeId               string
+	issuerKeys           map[string]*rsa.PrivateKey
+	issuerKids           map[string]string
+	pollBuffers          map[string]*buffer.EventPollBuffer
+	pushBuffers          map[string]*buffer.EventPushBuffer
+	coordinator          cluster.ClusterCoordinator
+	streamService        *services.StreamService
+	keyService           *services.KeyService
+	eventService         *services.EventService
+	subjectFilterService *services.SubjectFilterService
+	pushDelivery         delivery.PushDelivery
+	eventsIn, eventsOut  *prometheus.CounterVec
+	stats                statsTracker
 
 	httpClient          *http.Client
 	clusterSecret       string
@@ -152,28 +153,32 @@ type RouterDeps struct {
 	// deterministic outcomes. If nil, NewRouter constructs a default HTTPAdapter
 	// wired to the router as KeyReloader.
 	PushDelivery delivery.PushDelivery
+	// SubjectFilterService applies SSF §8.1.3 subject filtering at delivery
+	// time. When nil (or the feature is disabled) every event passes.
+	SubjectFilterService *services.SubjectFilterService
 }
 
 func NewRouter(deps RouterDeps, nodeId string) EventRouter {
 	ctx, cancel := context.WithCancel(context.Background())
 	router := &router{
-		coordinator:         deps.Coordinator,
-		streamService:       deps.StreamService,
-		keyService:          deps.KeyService,
-		eventService:        deps.EventService,
-		nodeId:              nodeId,
-		pushStreams:         map[string]model.StreamStateRecord{},
-		pollStreams:         map[string]model.StreamStateRecord{},
-		pushBuffers:         map[string]*buffer.EventPushBuffer{},
-		pollBuffers:         map[string]*buffer.EventPollBuffer{},
-		issuerKeys:          map[string]*rsa.PrivateKey{},
-		issuerKids:          map[string]string{},
-		enabled:             false,
-		ctx:                 ctx,
-		cancel:              cancel,
-		httpClient:          &http.Client{Timeout: 5 * time.Second},
-		clusterSecret:       os.Getenv("I2SIG_CLUSTER_INTERNAL_TOKEN"),
-		recentOutboundWakes: make(map[string]time.Time),
+		coordinator:          deps.Coordinator,
+		streamService:        deps.StreamService,
+		keyService:           deps.KeyService,
+		eventService:         deps.EventService,
+		subjectFilterService: deps.SubjectFilterService,
+		nodeId:               nodeId,
+		pushStreams:          map[string]model.StreamStateRecord{},
+		pollStreams:          map[string]model.StreamStateRecord{},
+		pushBuffers:          map[string]*buffer.EventPushBuffer{},
+		pollBuffers:          map[string]*buffer.EventPollBuffer{},
+		issuerKeys:           map[string]*rsa.PrivateKey{},
+		issuerKids:           map[string]string{},
+		enabled:              false,
+		ctx:                  ctx,
+		cancel:               cancel,
+		httpClient:           &http.Client{Timeout: 5 * time.Second},
+		clusterSecret:        os.Getenv("I2SIG_CLUSTER_INTERNAL_TOKEN"),
+		recentOutboundWakes:  make(map[string]time.Time),
 	}
 
 	if deps.PushDelivery != nil {
@@ -1216,6 +1221,21 @@ func (r *router) prepareAndSendEvent(jti string, config *model.StreamStateRecord
 		return goSetPush.Classification{Class: goSetPush.ClassAccepted}, rsaKey, kid
 	}
 
+	sid := config.StreamConfiguration.Id
+
+	// SSF §8.1.3 delivery-time subject filtering. A filtered-out event is acked
+	// and discarded rather than pushed, so the pending buffer stays bounded
+	// (ADR-0002); the no-op success classification advances the push loop
+	// exactly as a stale/deleted JTI does. Operational events and a disabled
+	// feature always pass — Allows handles both internally.
+	if r.subjectFilterService != nil && !r.subjectFilterService.Allows(r.ctx, config, eventRecord) {
+		if err := r.eventService.AckEvent(r.ctx, jti, sid, fencingToken); err != nil {
+			eventLogger.Error("PUSH-SRV: Error acking filtered-out event", "sid", sid, "jti", jti, "error", err)
+		}
+		eventLogger.Debug("PUSH-SRV: event filtered out by subject filter, discarded", "sid", sid, "jti", jti)
+		return goSetPush.Classification{Class: goSetPush.ClassAccepted}, rsaKey, kid
+	}
+
 	outcome := r.pushDelivery.Deliver(r.ctx, delivery.PushRequest{
 		Stream: config,
 		Event:  eventRecord,
@@ -1225,7 +1245,6 @@ func (r *router) prepareAndSendEvent(jti string, config *model.StreamStateRecord
 	cls := outcome.Classification
 	rsaKey, kid = outcome.Key, outcome.Kid
 
-	sid := config.StreamConfiguration.Id
 	isVerifyPush := isOperationalVerify(eventRecord)
 
 	if cls.Class == goSetPush.ClassAccepted {

--- a/internal/eventRouter/event_router_test.go
+++ b/internal/eventRouter/event_router_test.go
@@ -154,7 +154,7 @@ func TestNewRouter_PollBufferUsesEnvTimeoutValues(t *testing.T) {
         },
     }
     ctx := context.WithValue(context.Background(), authUtil.AuthContextKey, authUtil.ConvertProject(projectId))
-    created, err := persistence.StreamService.CreateStream(ctx, cfg, projectId, nil)
+    created, err := persistence.StreamService.CreateStream(ctx, model.StreamStateRecord{StreamConfiguration: cfg}, projectId, nil)
     require.NoError(t, err)
     state, err := persistence.StreamService.GetStreamState(context.Background(), created.Id)
     require.NoError(t, err)

--- a/internal/eventRouter/push_state_test.go
+++ b/internal/eventRouter/push_state_test.go
@@ -58,7 +58,7 @@ func mustCreateTestStream(t *testing.T, h *testHarness, projectId string) *model
 		},
 	}
 	ctx := context.WithValue(context.Background(), authUtil.AuthContextKey, authUtil.ConvertProject(projectId))
-	created, err := h.streamService.CreateStream(ctx, cfg, projectId, nil)
+	created, err := h.streamService.CreateStream(ctx, model.StreamStateRecord{StreamConfiguration: cfg}, projectId, nil)
 	require.NoError(t, err)
 	state, err := h.streamService.GetStreamState(context.Background(), created.Id)
 	require.NoError(t, err)

--- a/internal/eventRouter/subject_filter_cluster_test.go
+++ b/internal/eventRouter/subject_filter_cluster_test.go
@@ -1,0 +1,191 @@
+package eventRouter
+
+import (
+    "context"
+    "encoding/json"
+    "fmt"
+    "io"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+    "time"
+
+    "github.com/i2-open/i2goSignals/internal/authUtil"
+    "github.com/i2-open/i2goSignals/internal/dao/memory"
+    "github.com/i2-open/i2goSignals/internal/providers/dbProviders"
+    "github.com/i2-open/i2goSignals/internal/services"
+    "github.com/i2-open/i2goSignals/pkg/authSupport"
+    "github.com/i2-open/i2goSignals/pkg/goSet"
+    model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// clusterFilterHarness wires a router whose SubjectFilterService shares its
+// subject-filter DAO with a peerFilter service. The peer stands in for another
+// cluster node: a change applied through peerFilter updates the shared filter
+// store but leaves the router's match-result cache stale — the exact condition
+// the issue #94 cluster reload notification must repair.
+type clusterFilterHarness struct {
+    router        *router
+    streamService *services.StreamService
+    keyService    *services.KeyService
+    routerFilter  *services.SubjectFilterService
+    peerFilter    *services.SubjectFilterService
+}
+
+func newClusterFilterHarness(t *testing.T, nodeId string) *clusterFilterHarness {
+    t.Helper()
+    t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+    t.Setenv("I2SIG_STORE_MEM_DIRECTORY", t.TempDir())
+    persistence, err := dbProviders.OpenPersistence("memorydb:", "subject_filter_cluster_test")
+    require.NoError(t, err)
+    t.Cleanup(func() {
+        if persistence.Storage != nil {
+            _ = persistence.Storage.Close()
+        }
+    })
+
+    dao := memory.NewSubjectFilterDAO()
+    routerFilter := services.NewSubjectFilterService(dao)
+    peerFilter := services.NewSubjectFilterService(dao)
+
+    r := NewRouter(RouterDeps{
+        StreamService:        persistence.StreamService,
+        KeyService:           persistence.KeyService,
+        EventService:         persistence.EventService,
+        Coordinator:          persistence.Coordinator,
+        SubjectFilterService: routerFilter,
+    }, nodeId).(*router)
+    t.Cleanup(r.Shutdown)
+
+    return &clusterFilterHarness{
+        router:        r,
+        streamService: persistence.StreamService,
+        keyService:    persistence.KeyService,
+        routerFilter:  routerFilter,
+        peerFilter:    peerFilter,
+    }
+}
+
+// createNoneStream creates a NONE-baseline PUSH transmitter stream.
+func (h *clusterFilterHarness) createNoneStream(t *testing.T) *model.StreamStateRecord {
+    t.Helper()
+    projectId := projectIdFromHarness(t, &testHarness{
+        router:        h.router,
+        streamService: h.streamService,
+        keyService:    h.keyService,
+    })
+    cfg := model.StreamConfiguration{
+        Iss:             "DEFAULT",
+        Aud:             []string{"https://receiver.example.com"},
+        EventsDelivered: []string{"https://schemas.openid.net/secevent/risc/event-type/account-disabled"},
+        Delivery: &model.OneOfStreamConfigurationDelivery{
+            PushTransmitMethod: &model.PushTransmitMethod{
+                Method:      model.DeliveryPush,
+                EndpointUrl: "https://receiver.example.com/events",
+            },
+        },
+    }
+    ctx := context.WithValue(context.Background(), authUtil.AuthContextKey, authUtil.ConvertProject(projectId))
+    created, err := h.streamService.CreateStream(ctx, model.StreamStateRecord{
+        StreamConfiguration: cfg,
+        DefaultSubjects:     model.DefaultSubjectsNone,
+    }, projectId, nil)
+    require.NoError(t, err)
+    state, err := h.streamService.GetStreamState(context.Background(), created.Id)
+    require.NoError(t, err)
+    return state
+}
+
+// TestNotifySubjectFilterChange_LocalOwnerInvalidatesWithoutHop verifies issue
+// #94 acceptance criterion 4: when the push-transmitter lease is held by the
+// local node, NotifySubjectFilterChange invalidates the match-result cache
+// directly, with no cluster wake-up call.
+func TestNotifySubjectFilterChange_LocalOwnerInvalidatesWithoutHop(t *testing.T) {
+    h := newClusterFilterHarness(t, "node-A")
+    stream := h.createNoneStream(t)
+    sid := stream.StreamConfiguration.Id
+    ctx := context.Background()
+
+    // node-A owns the push-transmitter lease for this stream.
+    resource := fmt.Sprintf("push-transmitter:%s", sid)
+    acquired, _, err := h.router.coordinator.TryAcquireOrRenewLease(resource, "node-A", 30*time.Second)
+    require.NoError(t, err)
+    require.True(t, acquired)
+
+    subject := emailSubjectFor("alice@example.com")
+    event := &model.AgEventRecord{Event: goSet.SecurityEventToken{SubjectId: subject}}
+
+    // The owner caches a "drop" decision (NONE stream, empty filter).
+    require.False(t, h.routerFilter.Allows(ctx, stream, event),
+        "precondition: NONE stream with an empty filter must not deliver")
+
+    // A peer node processes the Add Subject: the shared filter changes but the
+    // owner's cache is left stale.
+    require.NoError(t, h.peerFilter.AddSubject(ctx, stream, subject, false))
+    require.False(t, h.routerFilter.Allows(ctx, stream, event),
+        "precondition: the owner's cached decision is expected to be stale")
+
+    h.router.NotifySubjectFilterChange(sid)
+
+    assert.True(t, h.routerFilter.Allows(ctx, stream, event),
+        "a local-owner notification must invalidate the cache so the change takes effect")
+    assert.Empty(t, h.router.recentOutboundWakes,
+        "a local-owner notification must not send a cluster wake-up call")
+}
+
+// capturedWake is one inbound /_cluster/wake-transmitter request observed by a
+// stub peer node.
+type capturedWake struct {
+    body map[string]string
+    auth string
+}
+
+// TestNotifySubjectFilterChange_RemoteOwnerSendsFilterChangeWake verifies issue
+// #94 acceptance criteria 1 and 3: when the push-transmitter lease is held by a
+// remote node, NotifySubjectFilterChange sends that node a wake-transmitter
+// call carrying reason "filter-change" and the existing cluster auth token.
+func TestNotifySubjectFilterChange_RemoteOwnerSendsFilterChangeWake(t *testing.T) {
+    t.Setenv("I2SIG_CLUSTER_INTERNAL_TOKEN", "test-secret")
+    h := newClusterFilterHarness(t, "node-A")
+    stream := h.createNoneStream(t)
+    sid := stream.StreamConfiguration.Id
+
+    // Stub peer node: captures the inbound wake-transmitter request.
+    wakes := make(chan capturedWake, 1)
+    peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        raw, _ := io.ReadAll(r.Body)
+        var body map[string]string
+        _ = json.Unmarshal(raw, &body)
+        wakes <- capturedWake{body: body, auth: r.Header.Get("Authorization")}
+        w.WriteHeader(http.StatusAccepted)
+    }))
+    defer peer.Close()
+
+    // node-B owns the push-transmitter lease and is reachable at the stub.
+    require.NoError(t, h.router.coordinator.RegisterNode(model.ClusterNode{
+        Id:      "node-B",
+        Address: peer.URL,
+    }))
+    resource := fmt.Sprintf("push-transmitter:%s", sid)
+    acquired, _, err := h.router.coordinator.TryAcquireOrRenewLease(resource, "node-B", 30*time.Second)
+    require.NoError(t, err)
+    require.True(t, acquired)
+
+    h.router.NotifySubjectFilterChange(sid)
+
+    select {
+    case got := <-wakes:
+        assert.Equal(t, sid, got.body["sid"], "the wake-up must target the changed stream")
+        assert.Equal(t, "push", got.body["mode"])
+        assert.Equal(t, "filter-change", got.body["reason"],
+            "a remote-owner notification must carry the filter-change reason")
+        require.True(t, len(got.auth) > 7 && got.auth[:7] == "Bearer ",
+            "the wake-up must reuse the cluster bearer-token scheme")
+        assert.True(t, authSupport.ValidateClusterToken("test-secret", got.auth[7:], sid, "push", 30*time.Second),
+            "the wake-up token must validate under the existing cluster auth scheme")
+    case <-time.After(3 * time.Second):
+        t.Fatal("a remote-owner notification must send a wake-transmitter call")
+    }
+}

--- a/internal/eventRouter/subject_filter_poll_test.go
+++ b/internal/eventRouter/subject_filter_poll_test.go
@@ -1,0 +1,126 @@
+package eventRouter
+
+import (
+    "context"
+    "testing"
+    "time"
+
+    "github.com/i2-open/i2goSignals/internal/authUtil"
+    model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// createPollStream creates a forward-mode POLL transmitter stream carrying the
+// given defaultSubjects baseline and registers it with the router so
+// PollStreamHandler can serve it.
+func (h *filterPushHarness) createPollStream(t *testing.T, defaultSubjects string) *model.StreamStateRecord {
+    t.Helper()
+    projectId := projectIdFromHarness(t, &testHarness{
+        router:        h.router,
+        streamService: h.streamService,
+        keyService:    h.keyService,
+    })
+    cfg := model.StreamConfiguration{
+        Iss:             "DEFAULT",
+        Aud:             []string{"https://receiver.example.com"},
+        EventsDelivered: []string{"https://schemas.openid.net/secevent/risc/event-type/account-disabled"},
+        RouteMode:       model.RouteModeForward,
+        Delivery: &model.OneOfStreamConfigurationDelivery{
+            PollTransmitMethod: &model.PollTransmitMethod{
+                Method:      model.DeliveryPoll,
+                EndpointUrl: "https://transmitter.example.com/events",
+            },
+        },
+    }
+    ctx := context.WithValue(context.Background(), authUtil.AuthContextKey, authUtil.ConvertProject(projectId))
+    created, err := h.streamService.CreateStream(ctx, model.StreamStateRecord{
+        StreamConfiguration: cfg,
+        DefaultSubjects:     defaultSubjects,
+    }, projectId, nil)
+    require.NoError(t, err)
+    state, err := h.streamService.GetStreamState(context.Background(), created.Id)
+    require.NoError(t, err)
+    h.router.UpdateStreamState(state)
+    return state
+}
+
+// loadPollBuffer submits the given JTIs to the stream's poll buffer and waits
+// until they are drained into the readable buffer, so a subsequent
+// ReturnImmediately poll observes them deterministically.
+func (h *filterPushHarness) loadPollBuffer(t *testing.T, sid string, jtis ...string) {
+    t.Helper()
+    h.router.mu.RLock()
+    buf := h.router.pollBuffers[sid]
+    h.router.mu.RUnlock()
+    require.NotNil(t, buf, "poll buffer must exist for stream %s", sid)
+    buf.SubmitEvents(jtis)
+    require.Eventually(t, func() bool { return buf.Cnt() == len(jtis) }, 2*time.Second, 5*time.Millisecond,
+        "submitted JTIs must drain into the poll buffer")
+}
+
+// pollImmediate serves a single non-blocking poll request for the stream.
+func (h *filterPushHarness) pollImmediate(sid string) (map[string]string, int) {
+    sets, _, status := h.router.PollStreamHandler(sid, model.PollParameters{
+        MaxEvents:         100,
+        ReturnImmediately: true,
+    })
+    return sets, status
+}
+
+// TestPollFilter_NoneStreamReturnsOnlyAddedSubjects verifies a poll response on
+// a NONE stream returns only events for subjects that have been added to the
+// filter (#93 acceptance criterion 1).
+func TestPollFilter_NoneStreamReturnsOnlyAddedSubjects(t *testing.T) {
+    t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+    h := newFilterPushRouter(t)
+    stream := h.createPollStream(t, model.DefaultSubjectsNone)
+    sid := stream.StreamConfiguration.Id
+
+    require.NoError(t, h.subjectFilter.AddSubject(context.Background(), stream, emailSubjectFor("alice@example.com"), false))
+
+    addedJti := h.addPendingEvent(t, sid, emailSubjectFor("alice@example.com"), false)
+    omittedJti := h.addPendingEvent(t, sid, emailSubjectFor("bob@example.com"), false)
+    h.loadPollBuffer(t, sid, addedJti, omittedJti)
+
+    sets, status := h.pollImmediate(sid)
+    assert.Equal(t, 200, status)
+    assert.Contains(t, sets, addedJti, "an added subject's event must be in the poll response")
+    assert.NotContains(t, sets, omittedJti, "an unmatched subject's event must not be in the poll response")
+}
+
+// TestPollFilter_AllStreamOmitsRemovedSubjects verifies a poll response on an
+// ALL stream omits events for subjects that have been removed (#93 criterion 2).
+func TestPollFilter_AllStreamOmitsRemovedSubjects(t *testing.T) {
+    t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+    h := newFilterPushRouter(t)
+    stream := h.createPollStream(t, model.DefaultSubjectsAll)
+    sid := stream.StreamConfiguration.Id
+
+    require.NoError(t, h.subjectFilter.RemoveSubject(context.Background(), stream, emailSubjectFor("bob@example.com")))
+
+    keptJti := h.addPendingEvent(t, sid, emailSubjectFor("alice@example.com"), false)
+    removedJti := h.addPendingEvent(t, sid, emailSubjectFor("bob@example.com"), false)
+    h.loadPollBuffer(t, sid, keptJti, removedJti)
+
+    sets, status := h.pollImmediate(sid)
+    assert.Equal(t, 200, status)
+    assert.Contains(t, sets, keptJti, "an ALL stream still delivers subjects that were not removed")
+    assert.NotContains(t, sets, removedJti, "a removed subject's event must be omitted from the poll response")
+}
+
+// TestPollFilter_OperationalEventAlwaysReturned verifies operational events are
+// returned by a poll regardless of the filter (#93 acceptance criterion 3).
+func TestPollFilter_OperationalEventAlwaysReturned(t *testing.T) {
+    t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+    h := newFilterPushRouter(t)
+    stream := h.createPollStream(t, model.DefaultSubjectsNone)
+    sid := stream.StreamConfiguration.Id
+
+    opJti := h.addPendingEvent(t, sid, emailSubjectFor("alice@example.com"), true)
+    h.loadPollBuffer(t, sid, opJti)
+
+    sets, status := h.pollImmediate(sid)
+    assert.Equal(t, 200, status)
+    assert.Contains(t, sets, opJti, "operational events must always be returned by a poll")
+}

--- a/internal/eventRouter/subject_filter_push_test.go
+++ b/internal/eventRouter/subject_filter_push_test.go
@@ -1,0 +1,186 @@
+package eventRouter
+
+import (
+    "context"
+    "fmt"
+    "testing"
+
+    "github.com/i2-open/i2goSignals/internal/authUtil"
+    "github.com/i2-open/i2goSignals/internal/eventRouter/delivery"
+    "github.com/i2-open/i2goSignals/internal/providers/dbProviders"
+    "github.com/i2-open/i2goSignals/internal/services"
+    "github.com/i2-open/i2goSignals/pkg/goSet"
+    "github.com/i2-open/i2goSignals/pkg/goSetPush"
+    model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// filterPushHarness bundles a router wired with a deterministic MemoryAdapter
+// push seam and a live SubjectFilterService, for exercising PUSH delivery-time
+// subject filtering (#92).
+type filterPushHarness struct {
+    router        *router
+    streamService *services.StreamService
+    keyService    *services.KeyService
+    eventService  *services.EventService
+    subjectFilter *services.SubjectFilterService
+    adapter       *delivery.MemoryAdapter
+    jtiSeq        int
+}
+
+func newFilterPushRouter(t *testing.T) *filterPushHarness {
+    t.Helper()
+    t.Setenv("I2SIG_STORE_MEM_DIRECTORY", t.TempDir())
+    persistence, err := dbProviders.OpenPersistence("memorydb:", "subject_filter_push_test")
+    require.NoError(t, err)
+    t.Cleanup(func() {
+        if persistence.Storage != nil {
+            _ = persistence.Storage.Close()
+        }
+    })
+
+    // Every Deliver call reports 202 Accepted, so a non-zero call count means
+    // the router chose to push rather than discard.
+    adapter := delivery.NewMemoryAdapter(delivery.PushOutcome{
+        Classification: goSetPush.Classification{Class: goSetPush.ClassAccepted},
+    })
+
+    r := NewRouter(RouterDeps{
+        StreamService:        persistence.StreamService,
+        KeyService:           persistence.KeyService,
+        EventService:         persistence.EventService,
+        Coordinator:          persistence.Coordinator,
+        SubjectFilterService: persistence.SubjectFilterService,
+        PushDelivery:         adapter,
+    }, "node-filter-push").(*router)
+    t.Cleanup(r.Shutdown)
+
+    return &filterPushHarness{
+        router:        r,
+        streamService: persistence.StreamService,
+        keyService:    persistence.KeyService,
+        eventService:  persistence.EventService,
+        subjectFilter: persistence.SubjectFilterService,
+        adapter:       adapter,
+    }
+}
+
+// createPushStream creates a PUSH transmitter stream carrying the given
+// defaultSubjects baseline.
+func (h *filterPushHarness) createPushStream(t *testing.T, defaultSubjects string) *model.StreamStateRecord {
+    t.Helper()
+    projectId := projectIdFromHarness(t, &testHarness{
+        router:        h.router,
+        streamService: h.streamService,
+        keyService:    h.keyService,
+    })
+    cfg := model.StreamConfiguration{
+        Iss:             "DEFAULT",
+        Aud:             []string{"https://receiver.example.com"},
+        EventsDelivered: []string{"https://schemas.openid.net/secevent/risc/event-type/account-disabled"},
+        Delivery: &model.OneOfStreamConfigurationDelivery{
+            PushTransmitMethod: &model.PushTransmitMethod{
+                Method:      model.DeliveryPush,
+                EndpointUrl: "https://receiver.example.com/events",
+            },
+        },
+    }
+    ctx := context.WithValue(context.Background(), authUtil.AuthContextKey, authUtil.ConvertProject(projectId))
+    created, err := h.streamService.CreateStream(ctx, model.StreamStateRecord{
+        StreamConfiguration: cfg,
+        DefaultSubjects:     defaultSubjects,
+    }, projectId, nil)
+    require.NoError(t, err)
+    state, err := h.streamService.GetStreamState(context.Background(), created.Id)
+    require.NoError(t, err)
+    return state
+}
+
+// addPendingEvent persists an event carrying subject and adds it to the
+// stream's pending list, returning its JTI.
+func (h *filterPushHarness) addPendingEvent(t *testing.T, sid string, subject *goSet.SubjectIdentifier, operational bool) string {
+    t.Helper()
+    h.jtiSeq++
+    token := &goSet.SecurityEventToken{}
+    token.ID = fmt.Sprintf("jti-%d", h.jtiSeq)
+    token.SubjectId = subject
+
+    ctx := context.Background()
+    var rec *model.AgEventRecord
+    var err error
+    if operational {
+        rec, err = h.eventService.AddOperationalEvent(ctx, token, sid, "")
+    } else {
+        rec, err = h.eventService.AddEvent(ctx, token, sid, "")
+    }
+    require.NoError(t, err)
+    require.NoError(t, h.eventService.AddEventToStream(ctx, rec.Jti, sid))
+    return rec.Jti
+}
+
+// pendingCount reports how many JTIs are still pending delivery for a stream.
+func (h *filterPushHarness) pendingCount(sid string) int {
+    jtis, _ := h.eventService.GetEventIds(context.Background(), sid, model.PollParameters{
+        MaxEvents:         100,
+        ReturnImmediately: true,
+    })
+    return len(jtis)
+}
+
+func emailSubjectFor(addr string) *goSet.SubjectIdentifier {
+    s := &goSet.SubjectIdentifier{Format: "email"}
+    return s.AddEmail(addr)
+}
+
+// TestPushFilter_NoneStreamDiscardsUnmatchedEvent verifies that on a NONE PUSH
+// stream with an empty filter an event is not pushed and its JTI is discarded
+// (acked), so the pending buffer stays bounded (#92 acceptance criteria 6, 1).
+func TestPushFilter_NoneStreamDiscardsUnmatchedEvent(t *testing.T) {
+    t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+    h := newFilterPushRouter(t)
+    stream := h.createPushStream(t, model.DefaultSubjectsNone)
+
+    jti := h.addPendingEvent(t, stream.StreamConfiguration.Id, emailSubjectFor("alice@example.com"), false)
+    require.Equal(t, 1, h.pendingCount(stream.StreamConfiguration.Id), "precondition: event is pending")
+
+    cls, _, _ := h.router.prepareAndSendEvent(jti, stream, nil, "", 0)
+
+    assert.Equal(t, 0, h.adapter.Calls(), "a filtered-out event must not be pushed")
+    assert.Equal(t, goSetPush.ClassAccepted, cls.Class, "a discarded event advances the loop as a no-op success")
+    assert.Equal(t, 0, h.pendingCount(stream.StreamConfiguration.Id),
+        "a filtered-out JTI must be discarded (acked) so the buffer stays bounded")
+}
+
+// TestPushFilter_OperationalEventBypassesFilter verifies an operational event is
+// always pushed, even on a NONE stream with an empty filter (#92 criterion 7).
+func TestPushFilter_OperationalEventBypassesFilter(t *testing.T) {
+    t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+    h := newFilterPushRouter(t)
+    stream := h.createPushStream(t, model.DefaultSubjectsNone)
+
+    jti := h.addPendingEvent(t, stream.StreamConfiguration.Id, emailSubjectFor("alice@example.com"), true)
+
+    cls, _, _ := h.router.prepareAndSendEvent(jti, stream, nil, "", 0)
+
+    assert.Equal(t, 1, h.adapter.Calls(), "operational events must always be pushed regardless of the filter")
+    assert.Equal(t, goSetPush.ClassAccepted, cls.Class)
+}
+
+// TestPushFilter_NoneStreamDeliversAfterAddSubject verifies that once a subject
+// is added to a NONE stream's filter, a matching event is pushed (#92 criterion 1).
+func TestPushFilter_NoneStreamDeliversAfterAddSubject(t *testing.T) {
+    t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+    h := newFilterPushRouter(t)
+    stream := h.createPushStream(t, model.DefaultSubjectsNone)
+
+    subject := emailSubjectFor("alice@example.com")
+    require.NoError(t, h.subjectFilter.AddSubject(context.Background(), stream, subject, false))
+
+    jti := h.addPendingEvent(t, stream.StreamConfiguration.Id, emailSubjectFor("alice@example.com"), false)
+
+    cls, _, _ := h.router.prepareAndSendEvent(jti, stream, nil, "", 0)
+
+    assert.Equal(t, 1, h.adapter.Calls(), "after Add Subject a matching event must be pushed")
+    assert.Equal(t, goSetPush.ClassAccepted, cls.Class)
+}

--- a/internal/providers/dbProviders/factory.go
+++ b/internal/providers/dbProviders/factory.go
@@ -29,6 +29,7 @@ type Persistence struct {
 	ServerService        *services.ServerService
 	TokenService         *services.TokenService
 	SubjectFilterService *services.SubjectFilterService
+	SubjectRelayService  *services.SubjectRelayService
 
 	Coordinator cluster.ClusterCoordinator
 	Storage     storage.Storage
@@ -55,6 +56,7 @@ func (p *Persistence) Refresh() {
 	p.ServerService = p.src.GetServerService()
 	p.TokenService = p.src.GetTokenService()
 	p.SubjectFilterService = p.src.GetSubjectFilterService()
+	p.SubjectRelayService = p.src.GetSubjectRelayService()
 }
 
 // serviceSource is the accessor surface present on both *MemoryProvider and
@@ -69,6 +71,7 @@ type serviceSource interface {
 	GetServerService() *services.ServerService
 	GetTokenService() *services.TokenService
 	GetSubjectFilterService() *services.SubjectFilterService
+	GetSubjectRelayService() *services.SubjectRelayService
 }
 
 // OpenPersistence detects the database URL and returns the Persistence record
@@ -118,6 +121,7 @@ func persistenceFromMemory(mp *memory_provider.MemoryProvider) *Persistence {
 		ServerService:        mp.GetServerService(),
 		TokenService:         mp.GetTokenService(),
 		SubjectFilterService: mp.GetSubjectFilterService(),
+		SubjectRelayService:  mp.GetSubjectRelayService(),
 		Coordinator:          mp.Coordinator(),
 		Storage:              memory_provider.NewMemoryStorage(mp),
 		src:                  mp,
@@ -134,6 +138,7 @@ func persistenceFromMongo(mp *mongo_provider.MongoProvider) *Persistence {
 		ServerService:        svcSrc.GetServerService(),
 		TokenService:         svcSrc.GetTokenService(),
 		SubjectFilterService: svcSrc.GetSubjectFilterService(),
+		SubjectRelayService:  svcSrc.GetSubjectRelayService(),
 		Coordinator:          mp.Coordinator(),
 		Storage:              mongo_provider.NewMongoStorage(mp),
 		src:                  mp,

--- a/internal/providers/dbProviders/factory.go
+++ b/internal/providers/dbProviders/factory.go
@@ -22,12 +22,13 @@ var factoryLog = logger.Sub("dbProviders")
 // Callers that only need one concern should depend on the narrowest type
 // available (one service, or Coordinator, or Storage).
 type Persistence struct {
-	StreamService *services.StreamService
-	KeyService    *services.KeyService
-	EventService  *services.EventService
-	ClientService *services.ClientService
-	ServerService *services.ServerService
-	TokenService  *services.TokenService
+	StreamService        *services.StreamService
+	KeyService           *services.KeyService
+	EventService         *services.EventService
+	ClientService        *services.ClientService
+	ServerService        *services.ServerService
+	TokenService         *services.TokenService
+	SubjectFilterService *services.SubjectFilterService
 
 	Coordinator cluster.ClusterCoordinator
 	Storage     storage.Storage
@@ -53,6 +54,7 @@ func (p *Persistence) Refresh() {
 	p.ClientService = p.src.GetClientService()
 	p.ServerService = p.src.GetServerService()
 	p.TokenService = p.src.GetTokenService()
+	p.SubjectFilterService = p.src.GetSubjectFilterService()
 }
 
 // serviceSource is the accessor surface present on both *MemoryProvider and
@@ -66,6 +68,7 @@ type serviceSource interface {
 	GetClientService() *services.ClientService
 	GetServerService() *services.ServerService
 	GetTokenService() *services.TokenService
+	GetSubjectFilterService() *services.SubjectFilterService
 }
 
 // OpenPersistence detects the database URL and returns the Persistence record
@@ -108,29 +111,31 @@ func OpenPersistence(mongoUrl string, dbName string) (*Persistence, error) {
 
 func persistenceFromMemory(mp *memory_provider.MemoryProvider) *Persistence {
 	return &Persistence{
-		StreamService: mp.GetStreamService(),
-		KeyService:    mp.GetKeyService(),
-		EventService:  mp.GetEventService(),
-		ClientService: mp.GetClientService(),
-		ServerService: mp.GetServerService(),
-		TokenService:  mp.GetTokenService(),
-		Coordinator:   mp.Coordinator(),
-		Storage:       memory_provider.NewMemoryStorage(mp),
-		src:           mp,
+		StreamService:        mp.GetStreamService(),
+		KeyService:           mp.GetKeyService(),
+		EventService:         mp.GetEventService(),
+		ClientService:        mp.GetClientService(),
+		ServerService:        mp.GetServerService(),
+		TokenService:         mp.GetTokenService(),
+		SubjectFilterService: mp.GetSubjectFilterService(),
+		Coordinator:          mp.Coordinator(),
+		Storage:              memory_provider.NewMemoryStorage(mp),
+		src:                  mp,
 	}
 }
 
 func persistenceFromMongo(mp *mongo_provider.MongoProvider) *Persistence {
 	var svcSrc serviceSource = mp
 	return &Persistence{
-		StreamService: svcSrc.GetStreamService(),
-		KeyService:    svcSrc.GetKeyService(),
-		EventService:  svcSrc.GetEventService(),
-		ClientService: svcSrc.GetClientService(),
-		ServerService: svcSrc.GetServerService(),
-		TokenService:  svcSrc.GetTokenService(),
-		Coordinator:   mp.Coordinator(),
-		Storage:       mongo_provider.NewMongoStorage(mp),
-		src:           mp,
+		StreamService:        svcSrc.GetStreamService(),
+		KeyService:           svcSrc.GetKeyService(),
+		EventService:         svcSrc.GetEventService(),
+		ClientService:        svcSrc.GetClientService(),
+		ServerService:        svcSrc.GetServerService(),
+		TokenService:         svcSrc.GetTokenService(),
+		SubjectFilterService: svcSrc.GetSubjectFilterService(),
+		Coordinator:          mp.Coordinator(),
+		Storage:              mongo_provider.NewMongoStorage(mp),
+		src:                  mp,
 	}
 }

--- a/internal/providers/dbProviders/factory_test.go
+++ b/internal/providers/dbProviders/factory_test.go
@@ -20,6 +20,7 @@ func TestOpenPersistence_Memory(t *testing.T) {
 	assert.NotNil(t, p.ClientService, "ClientService must be set")
 	assert.NotNil(t, p.ServerService, "ServerService must be set")
 	assert.NotNil(t, p.TokenService, "TokenService must be set")
+	assert.NotNil(t, p.SubjectFilterService, "SubjectFilterService must be set")
 	assert.NotNil(t, p.Coordinator, "Coordinator must be set")
 	assert.NotNil(t, p.Storage, "Storage must be set")
 

--- a/internal/providers/dbProviders/factory_test.go
+++ b/internal/providers/dbProviders/factory_test.go
@@ -21,6 +21,7 @@ func TestOpenPersistence_Memory(t *testing.T) {
 	assert.NotNil(t, p.ServerService, "ServerService must be set")
 	assert.NotNil(t, p.TokenService, "TokenService must be set")
 	assert.NotNil(t, p.SubjectFilterService, "SubjectFilterService must be set")
+	assert.NotNil(t, p.SubjectRelayService, "SubjectRelayService must be set")
 	assert.NotNil(t, p.Coordinator, "Coordinator must be set")
 	assert.NotNil(t, p.Storage, "Storage must be set")
 

--- a/internal/providers/dbProviders/memory_provider/persistence_test.go
+++ b/internal/providers/dbProviders/memory_provider/persistence_test.go
@@ -30,7 +30,7 @@ func TestPersistence(t *testing.T) {
 	}
 	authCtx := authUtil.ConvertProject("test-project")
 	ctx := context.WithValue(context.Background(), authUtil.AuthContextKey, authCtx)
-	createdStream, err := provider.streamService.CreateStream(ctx, streamReq, authCtx.ProjectId, nil)
+	createdStream, err := provider.streamService.CreateStream(ctx, model.StreamStateRecord{StreamConfiguration: streamReq}, authCtx.ProjectId, nil)
 	assert.NoError(t, err)
 	streamID := createdStream.Id
 

--- a/internal/providers/dbProviders/memory_provider/provider.go
+++ b/internal/providers/dbProviders/memory_provider/provider.go
@@ -60,6 +60,7 @@ type MemoryProvider struct {
     serverService        *services.ServerService
     tokenService         *services.TokenService
     subjectFilterService *services.SubjectFilterService
+    subjectRelayService  *services.SubjectRelayService
 
     // Direct references to the raw memory DAOs. Services see notifyingDAO
     // wrappers around these for after-mutation persistence triggering (#44);
@@ -103,6 +104,9 @@ func (m *MemoryProvider) GetTokenService() *services.TokenService   { return m.t
 func (m *MemoryProvider) GetSubjectFilterService() *services.SubjectFilterService {
     return m.subjectFilterService
 }
+func (m *MemoryProvider) GetSubjectRelayService() *services.SubjectRelayService {
+    return m.subjectRelayService
+}
 
 func (m *MemoryProvider) StoreExternalKey(keyName string, kids []string, streamID string, use string, jwksUri string) error {
     // TODO implement me
@@ -136,6 +140,14 @@ func (m *MemoryProvider) buildServices() {
     m.streamService.SetServerService(m.serverService)
     // A defaultSubjects baseline change clears the stream's subject filter.
     m.streamService.SetSubjectFilterService(m.subjectFilterService)
+
+    // PRD #89 #95: the relay service validates subject-filter modes at config
+    // time and relays PASSTHRU subject changes to the upstream transmitter.
+    m.subjectRelayService = services.NewSubjectRelayService(
+        m.streamService.ListReceiverStreams,
+        services.NewDefaultUpstreamResolver(m.serverService),
+    )
+    m.streamService.SetSubjectRelayService(m.subjectRelayService)
 }
 
 func (m *MemoryProvider) initialize() {

--- a/internal/providers/dbProviders/memory_provider/provider.go
+++ b/internal/providers/dbProviders/memory_provider/provider.go
@@ -53,12 +53,13 @@ type MemoryProvider struct {
     // Services — the live business surface. Pointers so that ResetDb(true)
     // can swap them and the Persistence.Refresh() helper can rehydrate the
     // composition root without callers caching stale references.
-    streamService *services.StreamService
-    keyService    *services.KeyService
-    eventService  *services.EventService
-    clientService *services.ClientService
-    serverService *services.ServerService
-    tokenService  *services.TokenService
+    streamService        *services.StreamService
+    keyService           *services.KeyService
+    eventService         *services.EventService
+    clientService        *services.ClientService
+    serverService        *services.ServerService
+    tokenService         *services.TokenService
+    subjectFilterService *services.SubjectFilterService
 
     // Direct references to the raw memory DAOs. Services see notifyingDAO
     // wrappers around these for after-mutation persistence triggering (#44);
@@ -99,6 +100,9 @@ func (m *MemoryProvider) GetEventService() *services.EventService   { return m.e
 func (m *MemoryProvider) GetClientService() *services.ClientService { return m.clientService }
 func (m *MemoryProvider) GetServerService() *services.ServerService { return m.serverService }
 func (m *MemoryProvider) GetTokenService() *services.TokenService   { return m.tokenService }
+func (m *MemoryProvider) GetSubjectFilterService() *services.SubjectFilterService {
+    return m.subjectFilterService
+}
 
 func (m *MemoryProvider) StoreExternalKey(keyName string, kids []string, streamID string, use string, jwksUri string) error {
     // TODO implement me
@@ -126,9 +130,12 @@ func (m *MemoryProvider) buildServices() {
     m.eventService = services.NewEventService(eventDAO)
     m.clientService = services.NewClientService(clientDAO, m.keyService)
     m.serverService = services.NewServerService(serverDAO)
+    m.subjectFilterService = services.NewSubjectFilterService(memory.NewSubjectFilterDAO())
 
     // StreamService.CreateStream needs ServerService to resolve tx_alias.
     m.streamService.SetServerService(m.serverService)
+    // A defaultSubjects baseline change clears the stream's subject filter.
+    m.streamService.SetSubjectFilterService(m.subjectFilterService)
 }
 
 func (m *MemoryProvider) initialize() {

--- a/internal/providers/dbProviders/memory_provider/provider.go
+++ b/internal/providers/dbProviders/memory_provider/provider.go
@@ -141,10 +141,13 @@ func (m *MemoryProvider) buildServices() {
     // A defaultSubjects baseline change clears the stream's subject filter.
     m.streamService.SetSubjectFilterService(m.subjectFilterService)
 
-    // PRD #89 #95: the relay service validates subject-filter modes at config
-    // time and relays PASSTHRU subject changes to the upstream transmitter.
+    // PRD #89 #95 #96: the relay service validates subject-filter modes at
+    // config time, relays PASSTHRU subject changes 1:1 to the upstream, and
+    // relays HYBRID changes on the interested-set 0↔1 boundary.
     m.subjectRelayService = services.NewSubjectRelayService(
         m.streamService.ListReceiverStreams,
+        m.streamService.ListTransmitterStreams,
+        m.subjectFilterService.Selects,
         services.NewDefaultUpstreamResolver(m.serverService),
     )
     m.streamService.SetSubjectRelayService(m.subjectRelayService)

--- a/internal/providers/dbProviders/memory_provider/provider_dao_test.go
+++ b/internal/providers/dbProviders/memory_provider/provider_dao_test.go
@@ -15,7 +15,7 @@ import (
 func createStreamHelper(p *MemoryProvider, cfg model.StreamConfiguration, projectId string) (model.StreamConfiguration, error) {
 	authCtx := authUtil.ConvertProject(projectId)
 	ctx := context.WithValue(context.Background(), authUtil.AuthContextKey, authCtx)
-	return p.streamService.CreateStream(ctx, cfg, authCtx.ProjectId, nil)
+	return p.streamService.CreateStream(ctx, model.StreamStateRecord{StreamConfiguration: cfg}, authCtx.ProjectId, nil)
 }
 
 func TestMemoryProviderDAOOpen(t *testing.T) {

--- a/internal/providers/dbProviders/mongo_provider/provider.go
+++ b/internal/providers/dbProviders/mongo_provider/provider.go
@@ -151,10 +151,13 @@ func (m *MongoProvider) initServices() {
 	// A defaultSubjects baseline change clears the stream's subject filter.
 	m.streamService.SetSubjectFilterService(m.subjectFilterService)
 
-	// PRD #89 #95: the relay service validates subject-filter modes at config
-	// time and relays PASSTHRU subject changes to the upstream transmitter.
+	// PRD #89 #95 #96: the relay service validates subject-filter modes at
+	// config time, relays PASSTHRU subject changes 1:1 to the upstream, and
+	// relays HYBRID changes on the interested-set 0↔1 boundary.
 	m.subjectRelayService = services.NewSubjectRelayService(
 		m.streamService.ListReceiverStreams,
+		m.streamService.ListTransmitterStreams,
+		m.subjectFilterService.Selects,
 		services.NewDefaultUpstreamResolver(m.serverService),
 	)
 	m.streamService.SetSubjectRelayService(m.subjectRelayService)

--- a/internal/providers/dbProviders/mongo_provider/provider.go
+++ b/internal/providers/dbProviders/mongo_provider/provider.go
@@ -84,6 +84,7 @@ type MongoProvider struct {
 	serverService        *services.ServerService
 	tokenService         *services.TokenService
 	subjectFilterService *services.SubjectFilterService
+	subjectRelayService  *services.SubjectRelayService
 
 	// dbInit is a flag confirming a valid SSEF database is connected and initialized
 	dbInit bool
@@ -150,6 +151,14 @@ func (m *MongoProvider) initServices() {
 	// A defaultSubjects baseline change clears the stream's subject filter.
 	m.streamService.SetSubjectFilterService(m.subjectFilterService)
 
+	// PRD #89 #95: the relay service validates subject-filter modes at config
+	// time and relays PASSTHRU subject changes to the upstream transmitter.
+	m.subjectRelayService = services.NewSubjectRelayService(
+		m.streamService.ListReceiverStreams,
+		services.NewDefaultUpstreamResolver(m.serverService),
+	)
+	m.streamService.SetSubjectRelayService(m.subjectRelayService)
+
 	if m.coordinator == nil {
 		m.coordinator = NewMongoCoordinator()
 	}
@@ -166,6 +175,9 @@ func (m *MongoProvider) GetServerService() *services.ServerService { return m.se
 func (m *MongoProvider) GetTokenService() *services.TokenService   { return m.tokenService }
 func (m *MongoProvider) GetSubjectFilterService() *services.SubjectFilterService {
 	return m.subjectFilterService
+}
+func (m *MongoProvider) GetSubjectRelayService() *services.SubjectRelayService {
+	return m.subjectRelayService
 }
 
 // GetKeyDAO returns the underlying KeyDAO. Used by rebind tests in

--- a/internal/providers/dbProviders/mongo_provider/provider.go
+++ b/internal/providers/dbProviders/mongo_provider/provider.go
@@ -34,6 +34,7 @@ const CDbLeases = "cluster_leases"
 const CDbNodes = "cluster_nodes"
 const CDbServers = "servers"
 const CDbTokens = "tokens"
+const CDbSubjectFilters = "subject_filters"
 
 const CSubjectFmt = "opaque"
 const CDefIssuer = "DEFAULT"
@@ -66,21 +67,23 @@ type MongoProvider struct {
 	// rebound in initialize() after each (re)connect via SetCollection. The
 	// concrete *mongodao.* types are needed for the rebind path; the
 	// interfaces.* references satisfy the service constructors.
-	streamDAO *mongodao.StreamDAOMongo
-	eventDAO  *mongodao.EventDAOMongo
-	keyDAO    *mongodao.KeyDAOMongo
-	clientDAO *mongodao.ClientDAOMongo
-	serverDAO *mongodao.ServerDAOMongo
-	tokenDAO  *mongodao.TokenDAOMongo
+	streamDAO        *mongodao.StreamDAOMongo
+	eventDAO         *mongodao.EventDAOMongo
+	keyDAO           *mongodao.KeyDAOMongo
+	clientDAO        *mongodao.ClientDAOMongo
+	serverDAO        *mongodao.ServerDAOMongo
+	tokenDAO         *mongodao.TokenDAOMongo
+	subjectFilterDAO *mongodao.SubjectFilterDAOMongo
 
 	// Services — long-lived, never swapped after Open returns. Reconnects
 	// only rebind DAO collections in place (rebindable-collection pattern).
-	streamService *services.StreamService
-	keyService    *services.KeyService
-	eventService  *services.EventService
-	clientService *services.ClientService
-	serverService *services.ServerService
-	tokenService  *services.TokenService
+	streamService        *services.StreamService
+	keyService           *services.KeyService
+	eventService         *services.EventService
+	clientService        *services.ClientService
+	serverService        *services.ServerService
+	tokenService         *services.TokenService
+	subjectFilterService *services.SubjectFilterService
 
 	// dbInit is a flag confirming a valid SSEF database is connected and initialized
 	dbInit bool
@@ -95,8 +98,9 @@ type MongoProvider struct {
 	clientCol    *mongo.Collection
 	leaseCol     *mongo.Collection
 	nodeCol      *mongo.Collection
-	serverCol    *mongo.Collection
-	tokenCol     *mongo.Collection
+	serverCol        *mongo.Collection
+	tokenCol         *mongo.Collection
+	subjectFilterCol *mongo.Collection
 
 	DefaultIssuer string
 	TokenIssuer   string
@@ -131,6 +135,7 @@ func (m *MongoProvider) initServices() {
 	m.clientDAO = mongodao.NewClientDAO(nil).(*mongodao.ClientDAOMongo)
 	m.serverDAO = mongodao.NewServerDAO(nil).(*mongodao.ServerDAOMongo)
 	m.tokenDAO = mongodao.NewTokenDAO(nil).(*mongodao.TokenDAOMongo)
+	m.subjectFilterDAO = mongodao.NewSubjectFilterDAO(nil).(*mongodao.SubjectFilterDAOMongo)
 
 	m.tokenService = services.NewTokenService(m.tokenDAO)
 	m.keyService = services.NewKeyService(m.keyDAO, m.TokenIssuer, m.tokenService)
@@ -138,9 +143,12 @@ func (m *MongoProvider) initServices() {
 	m.eventService = services.NewEventService(m.eventDAO)
 	m.clientService = services.NewClientService(m.clientDAO, m.keyService)
 	m.serverService = services.NewServerService(m.serverDAO)
+	m.subjectFilterService = services.NewSubjectFilterService(m.subjectFilterDAO)
 
 	// StreamService.CreateStream needs ServerService to resolve tx_alias.
 	m.streamService.SetServerService(m.serverService)
+	// A defaultSubjects baseline change clears the stream's subject filter.
+	m.streamService.SetSubjectFilterService(m.subjectFilterService)
 
 	if m.coordinator == nil {
 		m.coordinator = NewMongoCoordinator()
@@ -156,6 +164,9 @@ func (m *MongoProvider) GetEventService() *services.EventService   { return m.ev
 func (m *MongoProvider) GetClientService() *services.ClientService { return m.clientService }
 func (m *MongoProvider) GetServerService() *services.ServerService { return m.serverService }
 func (m *MongoProvider) GetTokenService() *services.TokenService   { return m.tokenService }
+func (m *MongoProvider) GetSubjectFilterService() *services.SubjectFilterService {
+	return m.subjectFilterService
+}
 
 // GetKeyDAO returns the underlying KeyDAO. Used by rebind tests in
 // internal/providers/dbProviders/mongo_provider/test/rebind_test.go to assert
@@ -202,6 +213,7 @@ func (m *MongoProvider) initialize(dbName string, ctx context.Context) error {
 	m.leaseCol = m.ssefDb.Collection(CDbLeases)
 	m.nodeCol = m.ssefDb.Collection(CDbNodes)
 	m.tokenCol = m.ssefDb.Collection(CDbTokens)
+	m.subjectFilterCol = m.ssefDb.Collection(CDbSubjectFilters)
 
 	if m.coordinator == nil {
 		m.coordinator = NewMongoCoordinator()
@@ -226,6 +238,7 @@ func (m *MongoProvider) initialize(dbName string, ctx context.Context) error {
     m.clientDAO.SetCollection(m.clientCol)
     m.serverDAO.SetCollection(m.serverCol)
     m.tokenDAO.SetCollection(m.tokenCol)
+    m.subjectFilterDAO.SetCollection(m.subjectFilterCol)
 
     // Initialize token keys against the existing keyService so a slow
     // reconnect doesn't leave the AuthIssuer with a nil PublicKey.

--- a/internal/providers/dbProviders/mongo_provider/test/provider_test.go
+++ b/internal/providers/dbProviders/mongo_provider/test/provider_test.go
@@ -414,3 +414,58 @@ func (s *MongoProviderSuite) TestI_UpdateRemoteAddress() {
 	s.Equal("10.0.1.5:443", state.RemoteAddress.IP)
 	s.Equal("203.0.113.42", state.RemoteAddress.Forwarded)
 }
+
+// TestZ_SubjectFilterFieldsRoundTrip verifies that the SSF subject-filtering
+// configuration fields (defaultSubjects, subjectFilterMode, and the event-source
+// descriptor) persist and read back intact through the MongoDB adapter on both
+// create and update. It mirrors the memory-adapter coverage in
+// internal/services/stream_service_subject_filter_test.go so #90 acceptance
+// criterion 4 ("on both the memory and mongo adapters") is exercised on Mongo.
+func (s *MongoProviderSuite) TestZ_SubjectFilterFieldsRoundTrip() {
+	s.T().Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+
+	authCtx := authUtil.ConvertProject(s.project)
+	ctx := context.WithValue(context.Background(), authUtil.AuthContextKey, authCtx)
+
+	req := model.StreamStateRecord{
+		StreamConfiguration: model.StreamConfiguration{
+			Aud:      []string{"test.example.com"},
+			Iss:      "test.com",
+			Delivery: &model.OneOfStreamConfigurationDelivery{PollTransmitMethod: &model.PollTransmitMethod{Method: model.DeliveryPoll}},
+		},
+		DefaultSubjects: model.DefaultSubjectsNone,
+		EventSource: &model.EventSource{
+			Type:            model.EventSourceExplicit,
+			SourceStreamIds: []string{"src-1"},
+		},
+	}
+
+	created, err := s.provider.GetStreamService().CreateStream(ctx, req, authCtx.ProjectId, nil)
+	s.Require().NoError(err, "CreateStream should succeed")
+
+	state, err := s.provider.GetStreamService().GetStreamState(ctx, created.Id)
+	s.Require().NoError(err, "GetStreamState after create should succeed")
+	s.Equal(model.DefaultSubjectsNone, state.DefaultSubjects, "defaultSubjects must round-trip through Mongo create")
+	s.Require().NotNil(state.EventSource, "event source must round-trip through Mongo create")
+	s.Equal(model.EventSourceExplicit, state.EventSource.Type)
+	s.Equal([]string{"src-1"}, state.EventSource.SourceStreamIds)
+
+	// Patch the subject-filtering fields and confirm they survive an update.
+	// LOCAL mode does no upstream relay, so it round-trips without requiring a
+	// resolvable relay target.
+	update := model.StreamStateRecord{
+		StreamConfiguration: model.StreamConfiguration{Id: created.Id},
+		DefaultSubjects:     model.DefaultSubjectsNone,
+		SubjectFilterMode:   model.SubjectFilterModeLocal,
+		EventSource:         &model.EventSource{Type: model.EventSourceAudience},
+	}
+	_, err = s.provider.GetStreamService().UpdateStream(ctx, created.Id, authCtx.ProjectId, update)
+	s.Require().NoError(err, "UpdateStream should succeed")
+
+	state, err = s.provider.GetStreamService().GetStreamState(ctx, created.Id)
+	s.Require().NoError(err, "GetStreamState after update should succeed")
+	s.Equal(model.DefaultSubjectsNone, state.DefaultSubjects, "defaultSubjects must round-trip through Mongo update")
+	s.Equal(model.SubjectFilterModeLocal, state.SubjectFilterMode, "subjectFilterMode must round-trip through Mongo update")
+	s.Require().NotNil(state.EventSource, "event source must round-trip through Mongo update")
+	s.Equal(model.EventSourceAudience, state.EventSource.Type)
+}

--- a/internal/providers/dbProviders/mongo_provider/test/provider_test.go
+++ b/internal/providers/dbProviders/mongo_provider/test/provider_test.go
@@ -92,7 +92,7 @@ func (s *MongoProviderSuite) InitStream(events []string) {
 	}
 	authCtx := authUtil.ConvertProject(s.project)
 	ctx := context.WithValue(context.Background(), authUtil.AuthContextKey, authCtx)
-	s.stream, _ = s.provider.GetStreamService().CreateStream(ctx, req, authCtx.ProjectId, nil)
+	s.stream, _ = s.provider.GetStreamService().CreateStream(ctx, model.StreamStateRecord{StreamConfiguration: req}, authCtx.ProjectId, nil)
 }
 
 func TestMongoProvider(t *testing.T) {
@@ -375,10 +375,10 @@ func (s *MongoProviderSuite) TestH_StreamManagement() {
 		Format:          orig.Format,
 	}
 
-	_, err := s.provider.GetStreamService().UpdateStream(context.Background(), "1234", s.project, config)
+	_, err := s.provider.GetStreamService().UpdateStream(context.Background(), "1234", s.project, model.StreamStateRecord{StreamConfiguration: config})
 	s.Error(err, "not found")
 
-	res, err := s.provider.GetStreamService().UpdateStream(context.Background(), sid, s.project, config)
+	res, err := s.provider.GetStreamService().UpdateStream(context.Background(), sid, s.project, model.StreamStateRecord{StreamConfiguration: config})
 	s.NoError(err, "Update should have no error")
 	s.Equal(orig.Aud, res.Aud, "Audience should not change")
 	s.Equal(orig.Iss, res.Iss, "Issuer should not change")
@@ -386,7 +386,7 @@ func (s *MongoProviderSuite) TestH_StreamManagement() {
 	s.Equal(0, len(res.EventsDelivered), "Should be no delivered events")
 
 	res.EventsRequested = res.EventsSupported // request all events
-	res2, err := s.provider.GetStreamService().UpdateStream(context.Background(), sid, s.project, *res)
+	res2, err := s.provider.GetStreamService().UpdateStream(context.Background(), sid, s.project, model.StreamStateRecord{StreamConfiguration: *res})
 	s.NoError(err, "2nd Update should have no error")
 	s.Equal(res.EventsSupported, res2.EventsDelivered, "All events enabled")
 

--- a/internal/server/api_cluster.go
+++ b/internal/server/api_cluster.go
@@ -14,14 +14,18 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffetls"
 	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 
+	"github.com/i2-open/i2goSignals/internal/eventRouter"
 	"github.com/i2-open/i2goSignals/pkg/authSupport"
 	"github.com/i2-open/i2goSignals/pkg/tlsSupport"
 )
 
-// WakeRequest is the body of a cluster wake-up call from a peer node.
+// WakeRequest is the body of a cluster wake-up call from a peer node. An empty
+// Reason is an ordinary buffer wake-up; Reason "filter-change" instead
+// invalidates the stream's subject-filter match-result cache (issue #94).
 type WakeRequest struct {
-	Sid  string `json:"sid"`
-	Mode string `json:"mode"`
+	Sid    string `json:"sid"`
+	Mode   string `json:"mode"`
+	Reason string `json:"reason,omitempty"`
 }
 
 var (
@@ -75,7 +79,9 @@ func (sa *SignalsApplication) WakeTransmitter(w http.ResponseWriter, r *http.Req
 	}
 
 	// --- Rate limiting / Coalescing ---
-	key := req.Sid + ":" + req.Mode
+	// The reason is part of the key so a filter-change invalidation is never
+	// coalesced away by an ordinary buffer wake-up for the same stream.
+	key := req.Sid + ":" + req.Mode + ":" + req.Reason
 	recentWakesMu.Lock()
 	lastWake, exists := recentWakes[key]
 	if exists && time.Since(lastWake) < 250*time.Millisecond {
@@ -94,6 +100,16 @@ func (sa *SignalsApplication) WakeTransmitter(w http.ResponseWriter, r *http.Req
 		}
 		recentWakesMu.Unlock()
 	}()
+
+	// A filter-change notification invalidates the stream's subject-filter
+	// match-result cache rather than waking a delivery buffer (issue #94).
+	if req.Reason == eventRouter.ReasonFilterChange {
+		if sa.SubjectFilterService != nil {
+			sa.SubjectFilterService.InvalidateCache(req.Sid)
+		}
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
 
 	sa.EventRouter.WakeTransmitter(req.Sid, req.Mode)
 	w.WriteHeader(http.StatusAccepted)

--- a/internal/server/api_stream_management.go
+++ b/internal/server/api_stream_management.go
@@ -21,20 +21,46 @@ import (
 	"github.com/i2-open/i2goSignals/internal/services"
 	"github.com/i2-open/i2goSignals/pkg/authSupport"
 	"github.com/i2-open/i2goSignals/pkg/constants"
+	"github.com/i2-open/i2goSignals/pkg/goSet"
 	"github.com/i2-open/i2goSignals/pkg/ssfModels"
+	"github.com/i2-open/i2goSignals/pkg/subjectid"
 
 	"github.com/gorilla/mux"
 )
 
-// AddSubject adds a subject to a stream. (Currently not implemented)
+// subjectRequest is the SSF §8.1.3.2/§8.1.3.3 Add/Remove Subject request body.
+// stream_id is accepted for spec conformance but the handler always operates on
+// the caller's authenticated stream. verified is meaningful for Add only.
+type subjectRequest struct {
+	StreamId string                   `json:"stream_id"`
+	Subject  *goSet.SubjectIdentifier `json:"subject"`
+	Verified bool                     `json:"verified,omitempty"`
+}
+
+// AddSubject opts a subject into delivery on the caller's stream (SSF §8.1.3.2).
+//
+// Inputs:
+//   - Authorization (header): token with the same scope set as GetStatus.
+//   - Body: { stream_id, subject, verified? }
 //
 // Return values:
-//   - 501 Not Implemented
+//   - 200 OK: subject added.
+//
+// Errors:
+//   - 400 Bad Request: missing or uncanonicalizable subject.
+//   - 401/403: unauthorized, or the body names a different stream.
+//   - 404 Not Found: subject filtering disabled, or stream not found.
 func (sa *SignalsApplication) AddSubject(w http.ResponseWriter, r *http.Request) {
 	AddSubjectHandler(sa, w, r)
 }
 
-func AddSubjectHandler(_ SsfApplicationInterface, w http.ResponseWriter, _ *http.Request) {
+func AddSubjectHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *http.Request) {
+	handleSubjectChange(sa, w, r, true)
+}
+
+// handleSubjectChange implements the shared Add/Remove Subject flow. add selects
+// the SSF semantics and the success status (Add -> 200, Remove -> 204).
+func handleSubjectChange(sa SsfApplicationInterface, w http.ResponseWriter, r *http.Request, add bool) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	if !services.SubjectFilteringEnabled() {
 		// Subject filtering is disabled server-wide: the endpoint is not
@@ -42,7 +68,61 @@ func AddSubjectHandler(_ SsfApplicationInterface, w http.ResponseWriter, _ *http
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
-	w.WriteHeader(http.StatusNotImplemented)
+
+	// Subject management is authorized with the same scope set as GetStatus.
+	authCtx, status := sa.GetAuth().ValidateAuthorizationAny(r, []string{authSupport.ScopeStreamMgmt, authSupport.ScopeEventDelivery, authSupport.ScopeStreamAdmin, authSupport.ScopeRoot})
+	if status != http.StatusOK {
+		w.WriteHeader(status)
+		return
+	}
+
+	var req subjectRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Subject == nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if req.StreamId == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	// When the token is bound to a specific stream it must match the request;
+	// the handler always operates on that stream (same rule as VerificationRequest).
+	if authCtx.StreamId != "" && authCtx.StreamId != req.StreamId {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+	if _, err := subjectid.CanonicalKey(req.Subject); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	stream, err := sa.GetStreamService().GetStreamState(r.Context(), req.StreamId)
+	if err != nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	filterSvc := sa.GetSubjectFilterService()
+	if filterSvc == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	if add {
+		err = filterSvc.AddSubject(r.Context(), stream, req.Subject, req.Verified)
+	} else {
+		err = filterSvc.RemoveSubject(r.Context(), stream, req.Subject)
+	}
+	if err != nil {
+		serverLog.Error("Subject filter change failed", "sid", req.StreamId, "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if add {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusNoContent)
+	}
 }
 
 // GetStatus retrieves the status of a stream.
@@ -99,23 +179,26 @@ func GetStatusHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *http
 	_, _ = w.Write(resp)
 }
 
-// RemoveSubject removes a subject from a stream. (Currently not implemented)
+// RemoveSubject opts a subject out of delivery on the caller's stream
+// (SSF §8.1.3.3).
+//
+// Inputs:
+//   - Authorization (header): token with the same scope set as GetStatus.
+//   - Body: { stream_id, subject }
 //
 // Return values:
-//   - 501 Not Implemented
+//   - 204 No Content: subject removed.
+//
+// Errors:
+//   - 400 Bad Request: missing or uncanonicalizable subject.
+//   - 401/403: unauthorized, or the body names a different stream.
+//   - 404 Not Found: subject filtering disabled, or stream not found.
 func (sa *SignalsApplication) RemoveSubject(w http.ResponseWriter, r *http.Request) {
 	RemoveSubjectHandler(sa, w, r)
 }
 
-func RemoveSubjectHandler(_ SsfApplicationInterface, w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-	if !services.SubjectFilteringEnabled() {
-		// Subject filtering is disabled server-wide: the endpoint is not
-		// advertised in discovery, so it must not be reachable either.
-		w.WriteHeader(http.StatusNotFound)
-		return
-	}
-	w.WriteHeader(http.StatusNotImplemented)
+func RemoveSubjectHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *http.Request) {
+	handleSubjectChange(sa, w, r, false)
 }
 
 // StreamDelete deletes an existing event stream.

--- a/internal/server/api_stream_management.go
+++ b/internal/server/api_stream_management.go
@@ -118,6 +118,13 @@ func handleSubjectChange(sa SsfApplicationInterface, w http.ResponseWriter, r *h
 		return
 	}
 
+	// The request may have landed on any cluster node; notify the stream's
+	// PUSH lease owner to invalidate its match-result cache so the change
+	// takes effect at delivery time (issue #94).
+	if router := sa.GetEventRouter(); router != nil {
+		router.NotifySubjectFilterChange(req.StreamId)
+	}
+
 	if add {
 		w.WriteHeader(http.StatusOK)
 	} else {

--- a/internal/server/api_stream_management.go
+++ b/internal/server/api_stream_management.go
@@ -148,6 +148,18 @@ func handleSubjectChange(sa SsfApplicationInterface, w http.ResponseWriter, r *h
 		router.NotifySubjectFilterChange(req.StreamId)
 	}
 
+	// PRD #89 #96: HYBRID also relays the change upstream, but only as the
+	// interested-set crosses the 0↔1 boundary. The local filter above is the
+	// primary outcome — an upstream relay failure is logged and tolerated, not
+	// surfaced to the caller.
+	if stream.SubjectFilterMode == model.SubjectFilterModeHybrid {
+		if relaySvc := sa.GetSubjectRelayService(); relaySvc != nil {
+			if relayErr := relaySvc.RelayHybrid(r.Context(), stream, req.Subject, req.Verified, add); relayErr != nil {
+				serverLog.Warn("HYBRID subject relay to upstream failed", "sid", req.StreamId, "error", relayErr)
+			}
+		}
+	}
+
 	if add {
 		w.WriteHeader(http.StatusOK)
 	} else {

--- a/internal/server/api_stream_management.go
+++ b/internal/server/api_stream_management.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/i2-open/i2goSignals/internal/authUtil"
 	"github.com/i2-open/i2goSignals/internal/providers/dbProviders/mongo_provider"
+	"github.com/i2-open/i2goSignals/internal/services"
 	"github.com/i2-open/i2goSignals/pkg/authSupport"
 	"github.com/i2-open/i2goSignals/pkg/constants"
 	"github.com/i2-open/i2goSignals/pkg/ssfModels"
@@ -35,6 +36,12 @@ func (sa *SignalsApplication) AddSubject(w http.ResponseWriter, r *http.Request)
 
 func AddSubjectHandler(_ SsfApplicationInterface, w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	if !services.SubjectFilteringEnabled() {
+		// Subject filtering is disabled server-wide: the endpoint is not
+		// advertised in discovery, so it must not be reachable either.
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -102,6 +109,12 @@ func (sa *SignalsApplication) RemoveSubject(w http.ResponseWriter, r *http.Reque
 
 func RemoveSubjectHandler(_ SsfApplicationInterface, w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	if !services.SubjectFilteringEnabled() {
+		// Subject filtering is disabled server-wide: the endpoint is not
+		// advertised in discovery, so it must not be reachable either.
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -295,7 +308,11 @@ func StreamCreateHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *h
 		w.WriteHeader(status)
 		return
 	}
-	var jsonRequest model.StreamConfiguration
+	// Decode into a StreamStateRecord (not a bare StreamConfiguration) so the
+	// goSignals-specific subject-filtering operator knobs ride alongside the
+	// SSF wire-format fields. The embedded StreamConfiguration is flattened by
+	// encoding/json, so existing request bodies decode unchanged.
+	var jsonRequest model.StreamStateRecord
 	err := json.NewDecoder(r.Body).Decode(&jsonRequest)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -366,7 +383,9 @@ func StreamUpdateHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *h
 		return
 	}
 
-	var jsonRequest model.StreamConfiguration
+	// Decode into a StreamStateRecord so subject-filtering operator knobs can
+	// be patched alongside the SSF wire-format fields (see StreamCreateHandler).
+	var jsonRequest model.StreamStateRecord
 	err := json.NewDecoder(r.Body).Decode(&jsonRequest)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -374,7 +393,7 @@ func StreamUpdateHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *h
 	}
 
 	// Because the PUT/PATCH request does not have a stream id parameter, we extract from payload and re-check
-	if authCtx.Eat != nil && !authCtx.Eat.IsAuthorized(jsonRequest.Id, []string{authSupport.ScopeStreamMgmt, authSupport.ScopeStreamAdmin}) {
+	if authCtx.Eat != nil && !authCtx.Eat.IsAuthorized(jsonRequest.StreamConfiguration.Id, []string{authSupport.ScopeStreamMgmt, authSupport.ScopeStreamAdmin}) {
 		http.Error(w, "Stream identifier not authorized", http.StatusForbidden)
 		return
 	}
@@ -550,8 +569,6 @@ func getTransmitterConfig(sa SsfApplicationInterface) *model.TransmitterConfigur
 	jwksUri, _ := baseUrl.Parse("/jwks.json")
 	configUri, _ := baseUrl.Parse("/stream")
 	statusUri, _ := baseUrl.Parse("/status")
-	addSubUri, _ := baseUrl.Parse("/add-subject")
-	remSubUri, _ := baseUrl.Parse("/remove-subject")
 	verifyUri, _ := baseUrl.Parse("/verify")
 	regUri, _ := baseUrl.Parse("/register")
 
@@ -574,27 +591,25 @@ func getTransmitterConfig(sa SsfApplicationInterface) *model.TransmitterConfigur
 		}
 	}
 
-	return &model.TransmitterConfiguration{
+	supportedScopes := map[string][]string{
+		"configuration_endpoint":       {authSupport.ScopeStreamAdmin, authSupport.ScopeStreamMgmt},
+		"status_endpoint":              {authSupport.ScopeStreamMgmt},
+		"events":                       {authSupport.ScopeEventDelivery},
+		"verification_endpoint":        {authSupport.ScopeEventDelivery, authSupport.ScopeStreamMgmt},
+		"poll":                         {authSupport.ScopeEventDelivery},
+		"client_registration_endpoint": {authSupport.ScopeRegister},
+	}
+
+	config := &model.TransmitterConfiguration{
 		Issuer:                     sa.GetDefIssuer(),
 		JwksUri:                    jwksUri.String(),
 		DeliveryMethodsSupported:   methods,
 		ConfigurationEndpoint:      configUri.String(),
 		StatusEndpoint:             statusUri.String(),
-		AddSubjectEndpoint:         addSubUri.String(),
-		RemoveSubjectEndpoint:      remSubUri.String(),
 		VerificationEndpoint:       verifyUri.String(),
 		CriticalSubjectMembers:     nil,
 		ClientRegistrationEndpoint: regUri.String(),
-		SupportedScopes: map[string][]string{
-			"configuration_endpoint":       {authSupport.ScopeStreamAdmin, authSupport.ScopeStreamMgmt},
-			"status_endpoint":              {authSupport.ScopeStreamMgmt},
-			"add_subject_endpoint":         {authSupport.ScopeStreamMgmt},
-			"remove_subject_endpoint":      {authSupport.ScopeStreamMgmt},
-			"events":                       {authSupport.ScopeEventDelivery},
-			"verification_endpoint":        {authSupport.ScopeEventDelivery, authSupport.ScopeStreamMgmt},
-			"poll":                         {authSupport.ScopeEventDelivery},
-			"client_registration_endpoint": {authSupport.ScopeRegister},
-		},
+		SupportedScopes:            supportedScopes,
 		AuthorizationSchemes: []model.AuthScheme{
 			{SpecUrn: constants.BearerAuth},
 			{SpecUrn: constants.RFC6749},
@@ -606,6 +621,20 @@ func getTransmitterConfig(sa SsfApplicationInterface) *model.TransmitterConfigur
 		GoSignalsVersion: goVersion,
 		SpecVersion:      constants.SSF_VERSION,
 	}
+
+	// SSF subject filtering (§8.1.3): advertise the Add/Remove Subject
+	// endpoints only when the feature is enabled server-wide, so discovery
+	// never advertises a capability the server will not honor.
+	if services.SubjectFilteringEnabled() {
+		addSubUri, _ := baseUrl.Parse("/add-subject")
+		remSubUri, _ := baseUrl.Parse("/remove-subject")
+		config.AddSubjectEndpoint = addSubUri.String()
+		config.RemoveSubjectEndpoint = remSubUri.String()
+		supportedScopes["add_subject_endpoint"] = []string{authSupport.ScopeStreamMgmt}
+		supportedScopes["remove_subject_endpoint"] = []string{authSupport.ScopeStreamMgmt}
+	}
+
+	return config
 }
 
 // WellKnownSsfConfigurationGet returns the default SSF transmitter configuration.

--- a/internal/server/api_stream_management.go
+++ b/internal/server/api_stream_management.go
@@ -101,6 +101,29 @@ func handleSubjectChange(sa SsfApplicationInterface, w http.ResponseWriter, r *h
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
+
+	// PRD #89 #95: in PASSTHRU mode the subject change is relayed 1:1 to the
+	// upstream transmitter and no local filter is applied — downstream streams
+	// share one upstream subscription.
+	if stream.SubjectFilterMode == model.SubjectFilterModePassthru {
+		relaySvc := sa.GetSubjectRelayService()
+		if relaySvc == nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if relayErr := relaySvc.Relay(r.Context(), stream, req.Subject, req.Verified, add); relayErr != nil {
+			serverLog.Warn("PASSTHRU subject relay to upstream failed", "sid", req.StreamId, "error", relayErr)
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		if add {
+			w.WriteHeader(http.StatusOK)
+		} else {
+			w.WriteHeader(http.StatusNoContent)
+		}
+		return
+	}
+
 	filterSvc := sa.GetSubjectFilterService()
 	if filterSvc == nil {
 		w.WriteHeader(http.StatusNotFound)

--- a/internal/server/application.go
+++ b/internal/server/application.go
@@ -46,36 +46,38 @@ type SsfApplicationInterface interface {
 	GetClientService() *services.ClientService
 	GetServerService() *services.ServerService
 	GetTokenService() *services.TokenService
+	GetSubjectFilterService() *services.SubjectFilterService
 	GetCoordinator() cluster.ClusterCoordinator
 	GetStorage() storage.Storage
 }
 
 type SignalsApplication struct {
-	Coordinator    cluster.ClusterCoordinator
-	Storage        storage.Storage
-	StreamService  *services.StreamService
-	KeyService     *services.KeyService
-	EventService   *services.EventService
-	ClientService  *services.ClientService
-	ServerService  *services.ServerService
-	TokenService   *services.TokenService
-	Server         *http.Server
-	Handler        http.Handler
-	EventRouter    eventRouter.EventRouter
-	BaseUrl        *url.URL
-	HostName       string
-	DefIssuer      string
-	AdminRole      string
-	Auth           *authUtil.AuthIssuer
-	pollClients    map[string]*ClientPollStream
-	pushClients    map[string]*ReceiverPushStream
-	pushReceivers  map[string]model.StreamStateRecord
-	mu             sync.RWMutex
-	Stats          *PrometheusHandler
-	NodeID         string
-	StartedAt      time.Time
-	stopSync       chan struct{}
-	InternalServer *http.Server
+	Coordinator          cluster.ClusterCoordinator
+	Storage              storage.Storage
+	StreamService        *services.StreamService
+	KeyService           *services.KeyService
+	EventService         *services.EventService
+	ClientService        *services.ClientService
+	ServerService        *services.ServerService
+	TokenService         *services.TokenService
+	SubjectFilterService *services.SubjectFilterService
+	Server               *http.Server
+	Handler              http.Handler
+	EventRouter          eventRouter.EventRouter
+	BaseUrl              *url.URL
+	HostName             string
+	DefIssuer            string
+	AdminRole            string
+	Auth                 *authUtil.AuthIssuer
+	pollClients          map[string]*ClientPollStream
+	pushClients          map[string]*ReceiverPushStream
+	pushReceivers        map[string]model.StreamStateRecord
+	mu                   sync.RWMutex
+	Stats                *PrometheusHandler
+	NodeID               string
+	StartedAt            time.Time
+	stopSync             chan struct{}
+	InternalServer       *http.Server
 }
 
 func (sa *SignalsApplication) Name() string {
@@ -89,12 +91,15 @@ func (sa *SignalsApplication) GetEventRouter() eventRouter.EventRouter {
 	return sa.EventRouter
 }
 
-func (sa *SignalsApplication) GetStreamService() *services.StreamService  { return sa.StreamService }
-func (sa *SignalsApplication) GetKeyService() *services.KeyService        { return sa.KeyService }
-func (sa *SignalsApplication) GetEventService() *services.EventService    { return sa.EventService }
-func (sa *SignalsApplication) GetClientService() *services.ClientService  { return sa.ClientService }
-func (sa *SignalsApplication) GetServerService() *services.ServerService  { return sa.ServerService }
-func (sa *SignalsApplication) GetTokenService() *services.TokenService    { return sa.TokenService }
+func (sa *SignalsApplication) GetStreamService() *services.StreamService { return sa.StreamService }
+func (sa *SignalsApplication) GetKeyService() *services.KeyService       { return sa.KeyService }
+func (sa *SignalsApplication) GetEventService() *services.EventService   { return sa.EventService }
+func (sa *SignalsApplication) GetClientService() *services.ClientService { return sa.ClientService }
+func (sa *SignalsApplication) GetServerService() *services.ServerService { return sa.ServerService }
+func (sa *SignalsApplication) GetTokenService() *services.TokenService   { return sa.TokenService }
+func (sa *SignalsApplication) GetSubjectFilterService() *services.SubjectFilterService {
+	return sa.SubjectFilterService
+}
 func (sa *SignalsApplication) GetCoordinator() cluster.ClusterCoordinator { return sa.Coordinator }
 func (sa *SignalsApplication) GetStorage() storage.Storage                { return sa.Storage }
 
@@ -169,21 +174,22 @@ func NewApplication(persistence *dbProviders.Persistence, baseUrlString string) 
 	nodeID := nodeid.Resolve()
 
 	sa := &SignalsApplication{
-		Coordinator:   persistence.Coordinator,
-		Storage:       persistence.Storage,
-		StreamService: persistence.StreamService,
-		KeyService:    persistence.KeyService,
-		EventService:  persistence.EventService,
-		ClientService: persistence.ClientService,
-		ServerService: persistence.ServerService,
-		TokenService:  persistence.TokenService,
-		AdminRole:     role,
-		pollClients:   map[string]*ClientPollStream{},
-		pushClients:   map[string]*ReceiverPushStream{},
-		pushReceivers: map[string]model.StreamStateRecord{},
-		NodeID:        nodeID,
-		StartedAt:     time.Now().UTC(),
-		stopSync:      make(chan struct{}),
+		Coordinator:          persistence.Coordinator,
+		Storage:              persistence.Storage,
+		StreamService:        persistence.StreamService,
+		KeyService:           persistence.KeyService,
+		EventService:         persistence.EventService,
+		ClientService:        persistence.ClientService,
+		ServerService:        persistence.ServerService,
+		TokenService:         persistence.TokenService,
+		SubjectFilterService: persistence.SubjectFilterService,
+		AdminRole:            role,
+		pollClients:          map[string]*ClientPollStream{},
+		pushClients:          map[string]*ReceiverPushStream{},
+		pushReceivers:        map[string]model.StreamStateRecord{},
+		NodeID:               nodeID,
+		StartedAt:            time.Now().UTC(),
+		stopSync:             make(chan struct{}),
 	}
 
 	// Initialize Auth if available
@@ -198,10 +204,11 @@ func NewApplication(persistence *dbProviders.Persistence, baseUrlString string) 
 	sa.Handler = httpRouter.router
 
 	sa.EventRouter = eventRouter.NewRouter(eventRouter.RouterDeps{
-		StreamService: persistence.StreamService,
-		KeyService:    persistence.KeyService,
-		EventService:  persistence.EventService,
-		Coordinator:   persistence.Coordinator,
+		StreamService:        persistence.StreamService,
+		KeyService:           persistence.KeyService,
+		EventService:         persistence.EventService,
+		Coordinator:          persistence.Coordinator,
+		SubjectFilterService: persistence.SubjectFilterService,
 		// The HTTP push adapter is wired at the composition root. NewRouter
 		// late-binds itself as the KeyReloader so the adapter can drive the
 		// RFC8935 jws_signature_failed rotate-and-retry sub-policy.

--- a/internal/server/application.go
+++ b/internal/server/application.go
@@ -47,6 +47,7 @@ type SsfApplicationInterface interface {
 	GetServerService() *services.ServerService
 	GetTokenService() *services.TokenService
 	GetSubjectFilterService() *services.SubjectFilterService
+	GetSubjectRelayService() *services.SubjectRelayService
 	GetCoordinator() cluster.ClusterCoordinator
 	GetStorage() storage.Storage
 }
@@ -61,6 +62,7 @@ type SignalsApplication struct {
 	ServerService        *services.ServerService
 	TokenService         *services.TokenService
 	SubjectFilterService *services.SubjectFilterService
+	SubjectRelayService  *services.SubjectRelayService
 	Server               *http.Server
 	Handler              http.Handler
 	EventRouter          eventRouter.EventRouter
@@ -99,6 +101,9 @@ func (sa *SignalsApplication) GetServerService() *services.ServerService { retur
 func (sa *SignalsApplication) GetTokenService() *services.TokenService   { return sa.TokenService }
 func (sa *SignalsApplication) GetSubjectFilterService() *services.SubjectFilterService {
 	return sa.SubjectFilterService
+}
+func (sa *SignalsApplication) GetSubjectRelayService() *services.SubjectRelayService {
+	return sa.SubjectRelayService
 }
 func (sa *SignalsApplication) GetCoordinator() cluster.ClusterCoordinator { return sa.Coordinator }
 func (sa *SignalsApplication) GetStorage() storage.Storage                { return sa.Storage }
@@ -183,6 +188,7 @@ func NewApplication(persistence *dbProviders.Persistence, baseUrlString string) 
 		ServerService:        persistence.ServerService,
 		TokenService:         persistence.TokenService,
 		SubjectFilterService: persistence.SubjectFilterService,
+		SubjectRelayService:  persistence.SubjectRelayService,
 		AdminRole:            role,
 		pollClients:          map[string]*ClientPollStream{},
 		pushClients:          map[string]*ReceiverPushStream{},

--- a/internal/server/poll_recovery_test.go
+++ b/internal/server/poll_recovery_test.go
@@ -45,7 +45,7 @@ func TestClientPollStream_Recovery(t *testing.T) {
 	// Create the stream via the StreamService.
 	atx := authUtil.ConvertProject("test-project")
 	createCtx := context.WithValue(context.Background(), authUtil.AuthContextKey, atx)
-	created, _ := persistence.StreamService.CreateStream(createCtx, streamConfig, atx.ProjectId, nil)
+	created, _ := persistence.StreamService.CreateStream(createCtx, model.StreamStateRecord{StreamConfiguration: streamConfig}, atx.ProjectId, nil)
 	sid = created.Id
 
 	streamState := &model.StreamStateRecord{

--- a/internal/server/push_monitoring_test.go
+++ b/internal/server/push_monitoring_test.go
@@ -183,7 +183,7 @@ func TestReceiverPushStream_Recovery(t *testing.T) {
 	// Create the stream via the StreamService so UpdateStreamStatus doesn't fail
 	atx := authUtil.ConvertProject("test-project")
 	createCtx := context.WithValue(context.Background(), authUtil.AuthContextKey, atx)
-	created, _ := persistence.StreamService.CreateStream(createCtx, streamConfig, atx.ProjectId, nil)
+	created, _ := persistence.StreamService.CreateStream(createCtx, model.StreamStateRecord{StreamConfiguration: streamConfig}, atx.ProjectId, nil)
 	sid = created.Id
 
 	streamState := &model.StreamStateRecord{

--- a/internal/server/test/subject_filter_cluster_test.go
+++ b/internal/server/test/subject_filter_cluster_test.go
@@ -1,0 +1,91 @@
+package test
+
+import (
+    "context"
+    "encoding/json"
+    "io"
+    "net/http"
+    "net/http/httptest"
+    "strings"
+    "testing"
+    "time"
+
+    "github.com/i2-open/i2goSignals/internal/authUtil"
+    model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// TestAddSubjectNotifiesRemoteLeaseOwner verifies issue #94 acceptance criteria
+// 1 and 5: an Add Subject request processed on a node that does not hold the
+// stream's push-transmitter lease notifies the lease owner with a
+// filter-change cluster wake-up, so the change takes effect on the owner.
+func TestAddSubjectNotifiesRemoteLeaseOwner(t *testing.T) {
+    t.Setenv("I2SIG_CLUSTER_INTERNAL_TOKEN", "test-secret")
+    t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+
+    instance, err := createServer(t, "subject_filter_cluster_test", true)
+    require.NoError(t, err)
+    defer instance.app.Shutdown()
+    defer instance.ts.Close()
+
+    // Stub lease-owner node: captures the inbound wake-transmitter request.
+    wakes := make(chan map[string]string, 1)
+    owner := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        raw, _ := io.ReadAll(r.Body)
+        var body map[string]string
+        _ = json.Unmarshal(raw, &body)
+        wakes <- body
+        w.WriteHeader(http.StatusAccepted)
+    }))
+    defer owner.Close()
+
+    // Create a PUSH transmitter stream and a stream-scoped bearer token.
+    ctx := context.WithValue(context.Background(), authUtil.AuthContextKey,
+        &authUtil.AuthContext{ProjectId: instance.projectId})
+    created, err := instance.streamSvc().CreateStream(ctx, model.StreamStateRecord{
+        StreamConfiguration: model.StreamConfiguration{
+            Iss: "DEFAULT",
+            Aud: []string{"https://receiver.example.com"},
+            Delivery: &model.OneOfStreamConfigurationDelivery{
+                PushTransmitMethod: &model.PushTransmitMethod{
+                    Method:      model.DeliveryPush,
+                    EndpointUrl: "https://receiver.example.com/events",
+                },
+            },
+        },
+        DefaultSubjects: model.DefaultSubjectsNone,
+    }, instance.projectId, nil)
+    require.NoError(t, err)
+    token, err := instance.GetAuthIssuer().IssueStreamToken(created.Id, instance.projectId, nil)
+    require.NoError(t, err)
+
+    // A different node owns the push-transmitter lease, reachable at the stub.
+    require.NoError(t, instance.app.Coordinator.RegisterNode(model.ClusterNode{
+        Id:      "remote-owner",
+        Address: owner.URL,
+    }))
+    acquired, _, err := instance.app.Coordinator.TryAcquireOrRenewLease(
+        "push-transmitter:"+created.Id, "remote-owner", 30*time.Second)
+    require.NoError(t, err)
+    require.True(t, acquired)
+
+    // The Add Subject request lands on this (non-owner) node.
+    body := `{"stream_id":"` + created.Id + `","subject":{"format":"email","email":"alice@example.com"}}`
+    req, _ := http.NewRequest(http.MethodPost, instance.ts.URL+"/add-subject", strings.NewReader(body))
+    req.Header.Set("Authorization", "Bearer "+token)
+    req.Header.Set("Content-Type", "application/json")
+    resp, err := instance.client.Do(req)
+    require.NoError(t, err)
+    require.Equal(t, http.StatusOK, resp.StatusCode, "Add Subject must succeed")
+
+    select {
+    case got := <-wakes:
+        assert.Equal(t, created.Id, got["sid"], "the wake-up must target the changed stream")
+        assert.Equal(t, "push", got["mode"])
+        assert.Equal(t, "filter-change", got["reason"],
+            "a non-owner node must notify the lease owner with a filter-change wake-up")
+    case <-time.After(3 * time.Second):
+        t.Fatal("an Add Subject on a non-owner node must notify the push-transmitter lease owner")
+    }
+}

--- a/internal/server/test/subject_filtering_test.go
+++ b/internal/server/test/subject_filtering_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -8,8 +9,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/i2-open/i2goSignals/internal/authUtil"
+	"github.com/i2-open/i2goSignals/pkg/goSet"
 	"github.com/i2-open/i2goSignals/pkg/ssfModels"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -82,4 +86,89 @@ func (suite *SubjectFilteringSuite) TestSubjectHandlersReturn404WhenDisabled() {
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), http.StatusNotFound, resp.StatusCode, "handler %s must return 404 when filtering disabled", path)
 	}
+}
+
+// newFilterTestStream creates a transmitter stream with the given baseline and
+// returns its id together with a stream-scoped bearer token.
+func (suite *SubjectFilteringSuite) newFilterTestStream(defaultSubjects string) (string, string) {
+	t := suite.T()
+	instance := suite.instance
+	ctx := context.WithValue(context.Background(), authUtil.AuthContextKey,
+		&authUtil.AuthContext{ProjectId: instance.projectId})
+
+	created, err := instance.streamSvc().CreateStream(ctx, model.StreamStateRecord{
+		StreamConfiguration: model.StreamConfiguration{
+			Iss: "DEFAULT",
+			Aud: []string{"https://receiver.example.com"},
+			Delivery: &model.OneOfStreamConfigurationDelivery{
+				PollTransmitMethod: &model.PollTransmitMethod{Method: model.DeliveryPoll},
+			},
+		},
+		DefaultSubjects: defaultSubjects,
+	}, instance.projectId, nil)
+	require.NoError(t, err)
+
+	token, err := instance.GetAuthIssuer().IssueStreamToken(created.Id, instance.projectId, nil)
+	require.NoError(t, err)
+	return created.Id, token
+}
+
+// postSubject sends an Add/Remove Subject request for the given stream token.
+func (suite *SubjectFilteringSuite) postSubject(path, token, body string) *http.Response {
+	req, _ := http.NewRequest(http.MethodPost, suite.instance.ts.URL+path, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := suite.instance.client.Do(req)
+	require.NoError(suite.T(), err)
+	return resp
+}
+
+// TestAddSubjectReturns200 verifies Add Subject on the caller's authenticated
+// stream returns 200 and the subject becomes deliverable on a NONE stream
+// (#92 acceptance criteria 1, 3).
+func (suite *SubjectFilteringSuite) TestAddSubjectReturns200() {
+	_ = os.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+	defer func() { _ = os.Unsetenv("I2SIG_SUBJECT_FILTERING") }()
+	t := suite.T()
+	instance := suite.instance
+
+	sid, token := suite.newFilterTestStream(model.DefaultSubjectsNone)
+	body := `{"stream_id":"` + sid + `","subject":{"format":"email","email":"alice@example.com"}}`
+	resp := suite.postSubject("/add-subject", token, body)
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "Add Subject must return 200")
+
+	state, err := instance.GetStreamState(sid)
+	require.NoError(t, err)
+	subject := &goSet.SubjectIdentifier{Format: "email"}
+	subject.AddEmail("alice@example.com")
+	event := &model.AgEventRecord{Event: goSet.SecurityEventToken{SubjectId: subject}}
+	assert.True(t, instance.persistence.SubjectFilterService.Allows(context.Background(), state, event),
+		"after Add Subject the NONE stream must deliver the added subject")
+}
+
+// TestRemoveSubjectReturns204 verifies Remove Subject on the caller's
+// authenticated stream returns 204 (#92 acceptance criterion 3).
+func (suite *SubjectFilteringSuite) TestRemoveSubjectReturns204() {
+	_ = os.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+	defer func() { _ = os.Unsetenv("I2SIG_SUBJECT_FILTERING") }()
+	t := suite.T()
+
+	sid, token := suite.newFilterTestStream(model.DefaultSubjectsAll)
+	body := `{"stream_id":"` + sid + `","subject":{"format":"email","email":"bob@example.com"}}`
+	resp := suite.postSubject("/remove-subject", token, body)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode, "Remove Subject must return 204")
+}
+
+// TestAddSubjectMalformedSubjectReturns400 verifies a subject that cannot be
+// canonicalized is rejected with 400 rather than silently stored.
+func (suite *SubjectFilteringSuite) TestAddSubjectMalformedSubjectReturns400() {
+	_ = os.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+	defer func() { _ = os.Unsetenv("I2SIG_SUBJECT_FILTERING") }()
+	t := suite.T()
+
+	sid, token := suite.newFilterTestStream(model.DefaultSubjectsNone)
+	body := `{"stream_id":"` + sid + `","subject":{"format":"email"}}`
+	resp := suite.postSubject("/add-subject", token, body)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"an uncanonicalizable subject must return 400")
 }

--- a/internal/server/test/subject_filtering_test.go
+++ b/internal/server/test/subject_filtering_test.go
@@ -1,0 +1,85 @@
+package test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/i2-open/i2goSignals/pkg/ssfModels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+// SubjectFilteringSuite exercises the SSF subject-filtering configuration
+// surface: discovery gating and the Add/Remove Subject endpoints. The feature
+// is governed by the I2SIG_SUBJECT_FILTERING env var, read per request, so
+// each test sets the state it needs and restores the default afterward.
+type SubjectFilteringSuite struct {
+	suite.Suite
+	instance *ssfInstance
+}
+
+func (suite *SubjectFilteringSuite) SetupSuite() {
+	_ = os.Unsetenv("I2SIG_SUBJECT_FILTERING")
+	instance, err := createServer(suite.T(), "subject_filtering_test", true)
+	assert.NoError(suite.T(), err)
+	suite.instance = instance
+}
+
+func (suite *SubjectFilteringSuite) TearDownSuite() {
+	_ = os.Unsetenv("I2SIG_SUBJECT_FILTERING")
+	if suite.instance != nil {
+		suite.instance.app.Shutdown()
+		suite.instance.ts.Close()
+	}
+}
+
+func TestSubjectFilteringSuite(t *testing.T) {
+	suite.Run(t, new(SubjectFilteringSuite))
+}
+
+// getDiscovery fetches and decodes the SSF discovery document.
+func (suite *SubjectFilteringSuite) getDiscovery() model.TransmitterConfiguration {
+	resp, err := http.Get(suite.instance.ts.URL + "/.well-known/ssf-configuration")
+	assert.NoError(suite.T(), err)
+	body, _ := io.ReadAll(resp.Body)
+	var config model.TransmitterConfiguration
+	_ = json.Unmarshal(body, &config)
+	return config
+}
+
+// TestDiscoveryHidesSubjectEndpointsWhenDisabled verifies the SSF discovery
+// document omits the Add/Remove Subject endpoints while subject filtering is
+// disabled, so discovery never advertises a capability the server won't honor.
+func (suite *SubjectFilteringSuite) TestDiscoveryHidesSubjectEndpointsWhenDisabled() {
+	_ = os.Unsetenv("I2SIG_SUBJECT_FILTERING")
+	config := suite.getDiscovery()
+	assert.Empty(suite.T(), config.AddSubjectEndpoint, "add_subject_endpoint must be omitted when filtering disabled")
+	assert.Empty(suite.T(), config.RemoveSubjectEndpoint, "remove_subject_endpoint must be omitted when filtering disabled")
+}
+
+// TestDiscoveryShowsSubjectEndpointsWhenEnabled verifies the SSF discovery
+// document advertises the Add/Remove Subject endpoints once subject filtering
+// is enabled server-wide.
+func (suite *SubjectFilteringSuite) TestDiscoveryShowsSubjectEndpointsWhenEnabled() {
+	_ = os.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+	defer func() { _ = os.Unsetenv("I2SIG_SUBJECT_FILTERING") }()
+	config := suite.getDiscovery()
+	assert.Contains(suite.T(), config.AddSubjectEndpoint, "/add-subject", "add_subject_endpoint must be advertised when filtering enabled")
+	assert.Contains(suite.T(), config.RemoveSubjectEndpoint, "/remove-subject", "remove_subject_endpoint must be advertised when filtering enabled")
+}
+
+// TestSubjectHandlersReturn404WhenDisabled verifies the Add/Remove Subject
+// handlers return 404 while subject filtering is disabled, so "not advertised"
+// in discovery and "not reachable" at the endpoint agree.
+func (suite *SubjectFilteringSuite) TestSubjectHandlersReturn404WhenDisabled() {
+	_ = os.Unsetenv("I2SIG_SUBJECT_FILTERING")
+	for _, path := range []string{"/add-subject", "/remove-subject"} {
+		resp, err := http.Post(suite.instance.ts.URL+path, "application/json", strings.NewReader("{}"))
+		assert.NoError(suite.T(), err)
+		assert.Equal(suite.T(), http.StatusNotFound, resp.StatusCode, "handler %s must return 404 when filtering disabled", path)
+	}
+}

--- a/internal/server/test/subject_relay_test.go
+++ b/internal/server/test/subject_relay_test.go
@@ -11,6 +11,7 @@ import (
 
     "github.com/i2-open/i2goSignals/internal/authUtil"
     "github.com/i2-open/i2goSignals/internal/services"
+    "github.com/i2-open/i2goSignals/pkg/goSet"
     model "github.com/i2-open/i2goSignals/pkg/ssfModels"
     "github.com/stretchr/testify/assert"
     "github.com/stretchr/testify/require"
@@ -57,6 +58,8 @@ func TestPassthruRelaysAddSubjectToUpstream(t *testing.T) {
         func(context.Context) ([]model.StreamStateRecord, error) {
             return []model.StreamStateRecord{rxStream}, nil
         },
+        instance.streamSvc().ListTransmitterStreams,
+        func(context.Context, *model.StreamStateRecord, *goSet.SubjectIdentifier) bool { return false },
         func(context.Context, *model.StreamStateRecord) (*services.UpstreamConn, error) {
             return &services.UpstreamConn{Config: upstreamCfg, HttpClient: upstream.Client()}, nil
         },
@@ -97,4 +100,95 @@ func TestPassthruRelaysAddSubjectToUpstream(t *testing.T) {
     state, err := instance.GetStreamState(created.Id)
     require.NoError(t, err)
     assert.Equal(t, "", state.DefaultSubjects, "a PASSTHRU stream carries no local baseline")
+}
+
+// TestHybridRelaysAndFiltersLocally verifies the HYBRID path of issue #96 end
+// to end: an Add Subject on a HYBRID transmitter stream both writes the local
+// per-stream filter and — because it is the first interested downstream and
+// the upstream is a NONE baseline — relays the add upstream (the 0→1
+// transition).
+func TestHybridRelaysAndFiltersLocally(t *testing.T) {
+    _ = os.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+    defer func() { _ = os.Unsetenv("I2SIG_SUBJECT_FILTERING") }()
+
+    instance, err := createServer(t, "hybrid_relay_test", true)
+    require.NoError(t, err)
+    defer func() {
+        instance.app.Shutdown()
+        instance.ts.Close()
+    }()
+
+    const upstreamIss = "https://upstream.example"
+
+    // Fake upstream transmitter that records relayed Add Subject calls.
+    var relayed int32
+    upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        if r.URL.Path == "/add-subject" {
+            atomic.AddInt32(&relayed, 1)
+        }
+        w.WriteHeader(http.StatusOK)
+    }))
+    defer upstream.Close()
+    upstreamCfg := &model.TransmitterConfiguration{
+        Issuer:                upstreamIss,
+        AddSubjectEndpoint:    upstream.URL + "/add-subject",
+        RemoveSubjectEndpoint: upstream.URL + "/remove-subject",
+    }
+
+    // The relay-target receiver carries a NONE baseline, so HYBRID engages its
+    // upstream relay. listTransmitters and interested are wired to the real
+    // services so the interested-set 0↔1 decision runs against live state.
+    var rxStream model.StreamStateRecord
+    rxStream.StreamConfiguration.Id = "rx-upstream"
+    rxStream.StreamConfiguration.Iss = upstreamIss
+    rxStream.DefaultSubjects = model.DefaultSubjectsNone
+    fakeRelay := services.NewSubjectRelayService(
+        func(context.Context) ([]model.StreamStateRecord, error) {
+            return []model.StreamStateRecord{rxStream}, nil
+        },
+        instance.streamSvc().ListTransmitterStreams,
+        instance.app.SubjectFilterService.Selects,
+        func(context.Context, *model.StreamStateRecord) (*services.UpstreamConn, error) {
+            return &services.UpstreamConn{Config: upstreamCfg, HttpClient: upstream.Client()}, nil
+        },
+    )
+    instance.streamSvc().SetSubjectRelayService(fakeRelay)
+    instance.app.SubjectRelayService = fakeRelay
+
+    // Create a HYBRID NONE-baseline transmitter stream feeding from the upstream.
+    ctx := context.WithValue(context.Background(), authUtil.AuthContextKey,
+        &authUtil.AuthContext{ProjectId: instance.projectId})
+    created, err := instance.streamSvc().CreateStream(ctx, model.StreamStateRecord{
+        StreamConfiguration: model.StreamConfiguration{
+            Iss: upstreamIss,
+            Aud: []string{"https://receiver.example.com"},
+            Delivery: &model.OneOfStreamConfigurationDelivery{
+                PollTransmitMethod: &model.PollTransmitMethod{Method: model.DeliveryPoll},
+            },
+        },
+        DefaultSubjects:   model.DefaultSubjectsNone,
+        SubjectFilterMode: model.SubjectFilterModeHybrid,
+        EventSource:       &model.EventSource{Type: model.EventSourceAudience},
+    }, instance.projectId, nil)
+    require.NoError(t, err, "a HYBRID stream with a filtering-capable upstream must be accepted")
+
+    token, err := instance.GetAuthIssuer().IssueStreamToken(created.Id, instance.projectId, nil)
+    require.NoError(t, err)
+
+    body := `{"stream_id":"` + created.Id + `","subject":{"format":"email","email":"alice@example.com"}}`
+    req, _ := http.NewRequest(http.MethodPost, instance.ts.URL+"/add-subject", strings.NewReader(body))
+    req.Header.Set("Authorization", "Bearer "+token)
+    req.Header.Set("Content-Type", "application/json")
+    resp, err := instance.client.Do(req)
+    require.NoError(t, err)
+    assert.Equal(t, http.StatusOK, resp.StatusCode, "HYBRID Add Subject must return 200")
+    assert.Equal(t, int32(1), atomic.LoadInt32(&relayed), "the first interested downstream must relay the add upstream")
+
+    // The subject was also recorded in this stream's local filter: HYBRID
+    // filters locally per downstream, unlike PASSTHRU.
+    state, err := instance.GetStreamState(created.Id)
+    require.NoError(t, err)
+    subject := &goSet.SubjectIdentifier{Format: "email", EmailIdentifier: goSet.EmailIdentifier{Email: "alice@example.com"}}
+    assert.True(t, instance.app.SubjectFilterService.Selects(context.Background(), state, subject),
+        "a HYBRID Add Subject must also be written to the local per-stream filter")
 }

--- a/internal/server/test/subject_relay_test.go
+++ b/internal/server/test/subject_relay_test.go
@@ -1,0 +1,100 @@
+package test
+
+import (
+    "context"
+    "net/http"
+    "net/http/httptest"
+    "os"
+    "strings"
+    "sync/atomic"
+    "testing"
+
+    "github.com/i2-open/i2goSignals/internal/authUtil"
+    "github.com/i2-open/i2goSignals/internal/services"
+    model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// TestPassthruRelaysAddSubjectToUpstream verifies the PASSTHRU path of issue
+// #95 end to end: an Add Subject on a PASSTHRU transmitter stream produces the
+// corresponding relayed call to the upstream transmitter through the real HTTP
+// handler, and no local subject filter is applied.
+func TestPassthruRelaysAddSubjectToUpstream(t *testing.T) {
+    _ = os.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+    defer func() { _ = os.Unsetenv("I2SIG_SUBJECT_FILTERING") }()
+
+    instance, err := createServer(t, "passthru_relay_test", true)
+    require.NoError(t, err)
+    defer func() {
+        instance.app.Shutdown()
+        instance.ts.Close()
+    }()
+
+    const upstreamIss = "https://upstream.example"
+
+    // Fake upstream transmitter that records relayed Add Subject calls.
+    var relayed int32
+    upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        if r.URL.Path == "/add-subject" {
+            atomic.AddInt32(&relayed, 1)
+        }
+        w.WriteHeader(http.StatusOK)
+    }))
+    defer upstream.Close()
+    upstreamCfg := &model.TransmitterConfiguration{
+        Issuer:                upstreamIss,
+        AddSubjectEndpoint:    upstream.URL + "/add-subject",
+        RemoveSubjectEndpoint: upstream.URL + "/remove-subject",
+    }
+
+    // A relay service whose resolver feeds the fake upstream. It is shared by
+    // config-time validation (StreamService) and the runtime handler (app).
+    var rxStream model.StreamStateRecord
+    rxStream.StreamConfiguration.Id = "rx-upstream"
+    rxStream.StreamConfiguration.Iss = upstreamIss
+    fakeRelay := services.NewSubjectRelayService(
+        func(context.Context) ([]model.StreamStateRecord, error) {
+            return []model.StreamStateRecord{rxStream}, nil
+        },
+        func(context.Context, *model.StreamStateRecord) (*services.UpstreamConn, error) {
+            return &services.UpstreamConn{Config: upstreamCfg, HttpClient: upstream.Client()}, nil
+        },
+    )
+    instance.streamSvc().SetSubjectRelayService(fakeRelay)
+    instance.app.SubjectRelayService = fakeRelay
+
+    // Create a PASSTHRU transmitter stream feeding from the upstream issuer.
+    ctx := context.WithValue(context.Background(), authUtil.AuthContextKey,
+        &authUtil.AuthContext{ProjectId: instance.projectId})
+    created, err := instance.streamSvc().CreateStream(ctx, model.StreamStateRecord{
+        StreamConfiguration: model.StreamConfiguration{
+            Iss: upstreamIss,
+            Aud: []string{"https://receiver.example.com"},
+            Delivery: &model.OneOfStreamConfigurationDelivery{
+                PollTransmitMethod: &model.PollTransmitMethod{Method: model.DeliveryPoll},
+            },
+        },
+        SubjectFilterMode: model.SubjectFilterModePassthru,
+        EventSource:       &model.EventSource{Type: model.EventSourceAudience},
+    }, instance.projectId, nil)
+    require.NoError(t, err, "a PASSTHRU stream with a filtering-capable upstream must be accepted")
+
+    token, err := instance.GetAuthIssuer().IssueStreamToken(created.Id, instance.projectId, nil)
+    require.NoError(t, err)
+
+    body := `{"stream_id":"` + created.Id + `","subject":{"format":"email","email":"alice@example.com"}}`
+    req, _ := http.NewRequest(http.MethodPost, instance.ts.URL+"/add-subject", strings.NewReader(body))
+    req.Header.Set("Authorization", "Bearer "+token)
+    req.Header.Set("Content-Type", "application/json")
+    resp, err := instance.client.Do(req)
+    require.NoError(t, err)
+    assert.Equal(t, http.StatusOK, resp.StatusCode, "PASSTHRU Add Subject must return 200")
+    assert.Equal(t, int32(1), atomic.LoadInt32(&relayed), "Add Subject must be relayed 1:1 to the upstream")
+
+    // No local filter entry was written: a PASSTHRU stream filters nothing
+    // locally, so the upstream is the only place the subject is recorded.
+    state, err := instance.GetStreamState(created.Id)
+    require.NoError(t, err)
+    assert.Equal(t, "", state.DefaultSubjects, "a PASSTHRU stream carries no local baseline")
+}

--- a/internal/server/test/test_helpers.go
+++ b/internal/server/test/test_helpers.go
@@ -77,7 +77,7 @@ func (instance *ssfInstance) CreateStream(request model.StreamConfiguration, aut
 	if authCtx != nil {
 		projectId = authCtx.ProjectId
 	}
-	return instance.streamSvc().CreateStream(ctx, request, projectId, nil)
+	return instance.streamSvc().CreateStream(ctx, model.StreamStateRecord{StreamConfiguration: request}, projectId, nil)
 }
 
 func (instance *ssfInstance) GetStream(id string) (*model.StreamConfiguration, error) {

--- a/internal/server/wake_transmitter_filter_test.go
+++ b/internal/server/wake_transmitter_filter_test.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+    "bytes"
+    "context"
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+
+    "github.com/i2-open/i2goSignals/internal/dao/memory"
+    "github.com/i2-open/i2goSignals/internal/services"
+    "github.com/i2-open/i2goSignals/pkg/authSupport"
+    "github.com/i2-open/i2goSignals/pkg/goSet"
+    model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// TestWakeTransmitter_FilterChangeInvalidatesCache verifies issue #94: a
+// wake-transmitter call carrying reason "filter-change" invalidates the
+// push-transmitter lease owner's subject-filter match-result cache, so a
+// subject change applied on a peer node takes effect on the owner. Two
+// SubjectFilterService instances over one shared DAO model the two nodes.
+func TestWakeTransmitter_FilterChangeInvalidatesCache(t *testing.T) {
+    t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+    t.Setenv("I2SIG_CLUSTER_INTERNAL_TOKEN", "test-secret")
+    ctx := context.Background()
+
+    dao := memory.NewSubjectFilterDAO()
+    ownerSvc := services.NewSubjectFilterService(dao)
+    peerSvc := services.NewSubjectFilterService(dao)
+    sa := &SignalsApplication{SubjectFilterService: ownerSvc}
+
+    sid := "stream-cluster-94"
+    stream := &model.StreamStateRecord{DefaultSubjects: model.DefaultSubjectsNone}
+    stream.StreamConfiguration.Id = sid
+    subject := &goSet.SubjectIdentifier{Format: "email"}
+    subject.AddEmail("alice@example.com")
+    event := &model.AgEventRecord{Event: goSet.SecurityEventToken{SubjectId: subject}}
+
+    // The lease owner caches a "drop" decision (NONE stream, empty filter).
+    require.False(t, ownerSvc.Allows(ctx, stream, event))
+
+    // A peer node processes the Add Subject; the owner's cache is now stale.
+    require.NoError(t, peerSvc.AddSubject(ctx, stream, subject, false))
+    require.False(t, ownerSvc.Allows(ctx, stream, event),
+        "precondition: the owner's cached decision is expected to be stale")
+
+    // The peer notifies the owner via the cluster wake-transmitter call.
+    body, _ := json.Marshal(map[string]string{"sid": sid, "mode": "push", "reason": "filter-change"})
+    req := httptest.NewRequest(http.MethodPost, "/_cluster/wake-transmitter", bytes.NewReader(body))
+    req.Header.Set("Authorization", "Bearer "+authSupport.GenerateClusterToken("test-secret", sid, "push"))
+    w := httptest.NewRecorder()
+
+    sa.WakeTransmitter(w, req)
+
+    assert.Equal(t, http.StatusAccepted, w.Code)
+    assert.True(t, ownerSvc.Allows(ctx, stream, event),
+        "a filter-change wake-up must invalidate the owner's match-result cache")
+}

--- a/internal/services/stream_service.go
+++ b/internal/services/stream_service.go
@@ -926,6 +926,24 @@ func (s *StreamService) ListReceiverStreams(ctx context.Context) ([]model.Stream
 	return out, nil
 }
 
+// ListTransmitterStreams returns the streams whose delivery method makes this server a
+// transmitter (DeliveryPush or DeliveryPoll) — the downstream-stream set the HYBRID
+// interested-set is computed over (issue #96). Like ListReceiverStreams it is a pure
+// query: no cache mutation, no JWKS loading.
+func (s *StreamService) ListTransmitterStreams(ctx context.Context) ([]model.StreamStateRecord, error) {
+	recs, err := s.streamDAO.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]model.StreamStateRecord, 0, len(recs))
+	for _, rec := range recs {
+		if !rec.IsReceiver() {
+			out = append(out, rec)
+		}
+	}
+	return out, nil
+}
+
 func (s *StreamService) LoadReceiverStreams(ctx context.Context) map[string]*model.StreamStateRecord {
 	recs, err := s.ListReceiverStreams(ctx)
 	if err != nil {

--- a/internal/services/stream_service.go
+++ b/internal/services/stream_service.go
@@ -40,6 +40,7 @@ type StreamService struct {
 	keyService              *KeyService
 	serverService           *ServerService
 	subjectFilterService    *SubjectFilterService
+	subjectRelayService     *SubjectRelayService
 	defaultIssuer           string
 	receiverStreams         map[string]*model.StreamStateRecord
 	BaseUrl                 *url.URL
@@ -61,6 +62,32 @@ func (s *StreamService) SetSubjectFilterService(svc *SubjectFilterService) {
 // provider façade as part of PRD #39 PR 4.
 func (s *StreamService) SetServerService(svc *ServerService) {
     s.serverService = svc
+}
+
+// SetSubjectRelayService wires in the SubjectRelayService so that
+// CreateStream/UpdateStream validate a transmitter stream's subject-filter
+// mode against its upstream (PRD #89 #95). Optional: when unset, validation is
+// skipped.
+func (s *StreamService) SetSubjectRelayService(svc *SubjectRelayService) {
+    s.subjectRelayService = svc
+}
+
+// validateSubjectFilterMode rejects or warns on a transmitter stream's
+// subject-filter mode against its resolved upstream (PRD #89 #95). It is a
+// no-op when subject filtering is disabled server-wide, no mode is set, or the
+// relay service is unwired.
+func (s *StreamService) validateSubjectFilterMode(ctx context.Context, rec *model.StreamStateRecord) error {
+    if !SubjectFilteringEnabled() || rec.SubjectFilterMode == "" || s.subjectRelayService == nil {
+        return nil
+    }
+    verdict := s.subjectRelayService.ValidateConfig(ctx, rec)
+    if verdict.Err != nil {
+        return fmt.Errorf("invalid subject-filter configuration: %w", verdict.Err)
+    }
+    if verdict.Warn != "" {
+        ssLog.Warn(verdict.Warn, "stream_id", rec.StreamConfiguration.Id, "mode", rec.SubjectFilterMode)
+    }
+    return nil
 }
 
 func NewStreamService(streamDAO interfaces.StreamDAO, keyService *KeyService, defaultIssuer string) *StreamService {
@@ -482,6 +509,12 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamSt
 		EventSource:         request.EventSource,
 	}
 
+	// PRD #89 #95: reject (or WARN on) a subject-filter mode that is
+	// incompatible with the stream's upstream before the stream is persisted.
+	if err = s.validateSubjectFilterMode(ctx, streamRec); err != nil {
+		return model.StreamConfiguration{}, err
+	}
+
 	err = s.streamDAO.Create(ctx, streamRec)
 	if err != nil {
 		return model.StreamConfiguration{}, err
@@ -758,6 +791,12 @@ func (s *StreamService) UpdateStream(ctx context.Context, streamID string, proje
 	}
 	if configReq.EventSource != nil {
 		streamRec.EventSource = configReq.EventSource
+	}
+
+	// PRD #89 #95: re-validate the subject-filter mode against the upstream
+	// whenever the mode or event source could have changed.
+	if err = s.validateSubjectFilterMode(ctx, streamRec); err != nil {
+		return nil, err
 	}
 
 	err = s.streamDAO.Update(ctx, streamRec)

--- a/internal/services/stream_service.go
+++ b/internal/services/stream_service.go
@@ -39,12 +39,20 @@ type StreamService struct {
 	streamDAO               interfaces.StreamDAO
 	keyService              *KeyService
 	serverService           *ServerService
+	subjectFilterService    *SubjectFilterService
 	defaultIssuer           string
 	receiverStreams         map[string]*model.StreamStateRecord
 	BaseUrl                 *url.URL
 	mu                      sync.RWMutex
 	minVerificationInterval int
 	maxInactivityTimeout    int
+}
+
+// SetSubjectFilterService wires in the SubjectFilterService so that a
+// defaultSubjects baseline change on a live stream clears that stream's
+// subject filter. Optional: when unset, UpdateStream skips the filter clear.
+func (s *StreamService) SetSubjectFilterService(svc *SubjectFilterService) {
+	s.subjectFilterService = svc
 }
 
 // SetServerService wires in the ServerService that owns Server records. Once
@@ -737,8 +745,12 @@ func (s *StreamService) UpdateStream(ctx context.Context, streamID string, proje
 
 	// Subject-filtering operator knobs. defaultSubjects is gated on the
 	// server-wide feature being enabled; when disabled the request value is
-	// silently ignored, consistent with CreateStream.
+	// silently ignored, consistent with CreateStream. A baseline change clears
+	// the stream's subject filter so stale entries never carry the opposite
+	// meaning under the new baseline.
+	defaultSubjectsFlipped := false
 	if SubjectFilteringEnabled() && configReq.DefaultSubjects != "" {
+		defaultSubjectsFlipped = configReq.DefaultSubjects != streamRec.DefaultSubjects
 		streamRec.DefaultSubjects = configReq.DefaultSubjects
 	}
 	if configReq.SubjectFilterMode != "" {
@@ -751,6 +763,12 @@ func (s *StreamService) UpdateStream(ctx context.Context, streamID string, proje
 	err = s.streamDAO.Update(ctx, streamRec)
 	if err != nil {
 		return nil, err
+	}
+
+	if defaultSubjectsFlipped && s.subjectFilterService != nil {
+		if clearErr := s.subjectFilterService.ClearFilter(ctx, streamID); clearErr != nil {
+			ssLog.Warn("Error clearing subject filter after defaultSubjects change", "sid", streamID, "error", clearErr)
+		}
 	}
 
 	return config, nil

--- a/internal/services/stream_service.go
+++ b/internal/services/stream_service.go
@@ -108,7 +108,11 @@ func (s *StreamService) getFullUrl(relativePath string) string {
 	return u.String()
 }
 
-func (s *StreamService) CreateStream(ctx context.Context, request model.StreamConfiguration, projectID string, txServer *model.Server) (model.StreamConfiguration, error) {
+// CreateStream creates a stream from request. request is a StreamStateRecord
+// rather than a bare StreamConfiguration so that goSignals-specific operator
+// knobs (subject-filtering fields) can be supplied alongside the SSF
+// wire-format configuration without leaking into it.
+func (s *StreamService) CreateStream(ctx context.Context, request model.StreamStateRecord, projectID string, txServer *model.Server) (model.StreamConfiguration, error) {
     // Resolve tx_alias → Server when the caller didn't pre-resolve it. This
     // logic was previously in BaseProvider.CreateStream; it lives here now
     // so the provider façade can be a pass-through.
@@ -449,6 +453,14 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamCo
 
 	now := time.Now()
 
+	// defaultSubjects is an operator knob that is inert until subject filtering
+	// is enabled server-wide; silently ignore it otherwise so an upgrade does
+	// not change delivery behavior for streams that set it.
+	defaultSubjects := request.DefaultSubjects
+	if !SubjectFilteringEnabled() {
+		defaultSubjects = ""
+	}
+
 	streamRec := &model.StreamStateRecord{
 		Id:                  mid,
 		ProjectId:           projectID,
@@ -457,6 +469,9 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamCo
 		Status:              model.StreamStateEnabled,
 		CreatedAt:           now,
 		ModifiedAt:          now,
+		DefaultSubjects:     defaultSubjects,
+		SubjectFilterMode:   request.SubjectFilterMode,
+		EventSource:         request.EventSource,
 	}
 
 	err = s.streamDAO.Create(ctx, streamRec)
@@ -628,7 +643,11 @@ func (s *StreamService) calculateDeliveredEvents(requested []string, supported [
 	return delivered
 }
 
-func (s *StreamService) UpdateStream(ctx context.Context, streamID string, projectID string, configReq model.StreamConfiguration) (*model.StreamConfiguration, error) {
+// UpdateStream patches an existing stream. configReq is a StreamStateRecord so
+// the goSignals-specific subject-filtering operator knobs can be updated
+// alongside the SSF wire-format configuration. Like the rest of this method,
+// only non-empty request fields are applied.
+func (s *StreamService) UpdateStream(ctx context.Context, streamID string, projectID string, configReq model.StreamStateRecord) (*model.StreamConfiguration, error) {
 	streamRec, err := s.streamDAO.FindByID(ctx, streamID)
 	if err != nil {
 		return nil, err
@@ -715,6 +734,19 @@ func (s *StreamService) UpdateStream(ctx context.Context, streamID string, proje
 
 	streamRec.StreamConfiguration = *config
 	streamRec.ModifiedAt = time.Now()
+
+	// Subject-filtering operator knobs. defaultSubjects is gated on the
+	// server-wide feature being enabled; when disabled the request value is
+	// silently ignored, consistent with CreateStream.
+	if SubjectFilteringEnabled() && configReq.DefaultSubjects != "" {
+		streamRec.DefaultSubjects = configReq.DefaultSubjects
+	}
+	if configReq.SubjectFilterMode != "" {
+		streamRec.SubjectFilterMode = configReq.SubjectFilterMode
+	}
+	if configReq.EventSource != nil {
+		streamRec.EventSource = configReq.EventSource
+	}
 
 	err = s.streamDAO.Update(ctx, streamRec)
 	if err != nil {

--- a/internal/services/stream_service_registration_test.go
+++ b/internal/services/stream_service_registration_test.go
@@ -81,7 +81,7 @@ func TestCreateStream_AutomaticRegistration(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	config, err := svc.CreateStream(ctx, request, "test-project", nil)
+	config, err := svc.CreateStream(ctx, model.StreamStateRecord{StreamConfiguration: request}, "test-project", nil)
 
 	// 4. Verify Results
 	assert.NoError(t, err)
@@ -165,7 +165,7 @@ func TestCreateStream_AutomaticPollRegistration(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	config, err := svc.CreateStream(ctx, request, "test-project", nil)
+	config, err := svc.CreateStream(ctx, model.StreamStateRecord{StreamConfiguration: request}, "test-project", nil)
 
 	// 4. Verify Results
 	assert.NoError(t, err)

--- a/internal/services/stream_service_subject_filter_test.go
+++ b/internal/services/stream_service_subject_filter_test.go
@@ -2,8 +2,10 @@ package services
 
 import (
     "context"
+    "errors"
     "testing"
 
+    "github.com/i2-open/i2goSignals/internal/dao/interfaces"
     "github.com/i2-open/i2goSignals/internal/dao/memory"
     "github.com/i2-open/i2goSignals/pkg/ssfModels"
     "github.com/stretchr/testify/assert"
@@ -112,4 +114,74 @@ func TestStreamService_SubjectFilterFieldsRoundTripOnUpdate(t *testing.T) {
         "subjectFilterMode must round-trip through update")
     require.NotNil(t, state.EventSource, "event source must round-trip through update")
     assert.Equal(t, model.EventSourceAudience, state.EventSource.Type)
+}
+
+// TestStreamService_DefaultSubjectsFlipClearsFilter verifies that changing a
+// live stream's defaultSubjects baseline clears its subject filter, so stale
+// entries never carry the opposite meaning under the new baseline (#92
+// acceptance criterion 5).
+func TestStreamService_DefaultSubjectsFlipClearsFilter(t *testing.T) {
+    t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+    ctx := context.Background()
+
+    svc := newSubjectFilterTestService()
+    filterDAO := memory.NewSubjectFilterDAO()
+    svc.SetSubjectFilterService(NewSubjectFilterService(filterDAO))
+
+    req := pushTransmitterRequest()
+    req.DefaultSubjects = model.DefaultSubjectsNone
+    created, err := svc.CreateStream(ctx, req, "test-project", nil)
+    require.NoError(t, err)
+
+    // Seed the stream's filter with one entry.
+    require.NoError(t, filterDAO.Add(ctx, &model.SubjectFilterEntry{
+        StreamId:     created.Id,
+        CanonicalKey: "email:alice@example.com",
+        Kind:         model.SubjectKindSimple,
+    }))
+
+    // Flip the baseline NONE -> ALL.
+    update := model.StreamStateRecord{
+        StreamConfiguration: model.StreamConfiguration{Id: created.Id},
+        DefaultSubjects:     model.DefaultSubjectsAll,
+    }
+    _, err = svc.UpdateStream(ctx, created.Id, "test-project", update)
+    require.NoError(t, err)
+
+    _, getErr := filterDAO.Get(ctx, created.Id, "email:alice@example.com")
+    require.True(t, errors.Is(getErr, interfaces.ErrNotFound),
+        "flipping defaultSubjects must clear the stream's subject filter")
+}
+
+// TestStreamService_DefaultSubjectsUnchangedKeepsFilter verifies an UpdateStream
+// that does not change defaultSubjects leaves the filter intact.
+func TestStreamService_DefaultSubjectsUnchangedKeepsFilter(t *testing.T) {
+    t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+    ctx := context.Background()
+
+    svc := newSubjectFilterTestService()
+    filterDAO := memory.NewSubjectFilterDAO()
+    svc.SetSubjectFilterService(NewSubjectFilterService(filterDAO))
+
+    req := pushTransmitterRequest()
+    req.DefaultSubjects = model.DefaultSubjectsNone
+    created, err := svc.CreateStream(ctx, req, "test-project", nil)
+    require.NoError(t, err)
+
+    require.NoError(t, filterDAO.Add(ctx, &model.SubjectFilterEntry{
+        StreamId:     created.Id,
+        CanonicalKey: "email:alice@example.com",
+        Kind:         model.SubjectKindSimple,
+    }))
+
+    // Update something else; defaultSubjects stays NONE.
+    update := model.StreamStateRecord{
+        StreamConfiguration: model.StreamConfiguration{Id: created.Id, Description: "changed"},
+        DefaultSubjects:     model.DefaultSubjectsNone,
+    }
+    _, err = svc.UpdateStream(ctx, created.Id, "test-project", update)
+    require.NoError(t, err)
+
+    _, getErr := filterDAO.Get(ctx, created.Id, "email:alice@example.com")
+    require.NoError(t, getErr, "an unchanged defaultSubjects must leave the filter intact")
 }

--- a/internal/services/stream_service_subject_filter_test.go
+++ b/internal/services/stream_service_subject_filter_test.go
@@ -1,0 +1,115 @@
+package services
+
+import (
+    "context"
+    "testing"
+
+    "github.com/i2-open/i2goSignals/internal/dao/memory"
+    "github.com/i2-open/i2goSignals/pkg/ssfModels"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// newSubjectFilterTestService builds a StreamService backed by the in-memory
+// DAO, the standard fixture for service-level subject-filtering tests.
+func newSubjectFilterTestService() *StreamService {
+    streamDAO := memory.NewStreamDAO()
+    keyDAO := memory.NewKeyDAO()
+    keyService := NewKeyService(keyDAO, "http://test", nil)
+    return NewStreamService(streamDAO, keyService, "http://test")
+}
+
+// pushTransmitterRequest returns a minimal DeliveryPush transmitter stream
+// creation request.
+func pushTransmitterRequest() model.StreamStateRecord {
+    return model.StreamStateRecord{
+        StreamConfiguration: model.StreamConfiguration{
+            Iss: "test-issuer",
+            Delivery: &model.OneOfStreamConfigurationDelivery{
+                PushTransmitMethod: &model.PushTransmitMethod{
+                    Method:      model.DeliveryPush,
+                    EndpointUrl: "https://rx.example/push",
+                },
+            },
+        },
+    }
+}
+
+// TestStreamService_SubjectFilterFieldsRoundTripOnCreate verifies that the
+// subject-filtering configuration fields (defaultSubjects and the event-source
+// descriptor) supplied on stream creation are persisted and read back intact
+// when the feature is enabled.
+func TestStreamService_SubjectFilterFieldsRoundTripOnCreate(t *testing.T) {
+    t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+    svc := newSubjectFilterTestService()
+    ctx := context.Background()
+
+    req := pushTransmitterRequest()
+    req.DefaultSubjects = model.DefaultSubjectsNone
+    req.EventSource = &model.EventSource{
+        Type:            model.EventSourceExplicit,
+        SourceStreamIds: []string{"src-1"},
+    }
+
+    created, err := svc.CreateStream(ctx, req, "test-project", nil)
+    require.NoError(t, err)
+
+    state, err := svc.GetStreamState(ctx, created.Id)
+    require.NoError(t, err)
+    assert.Equal(t, model.DefaultSubjectsNone, state.DefaultSubjects,
+        "defaultSubjects must round-trip through create")
+    require.NotNil(t, state.EventSource, "event source must round-trip through create")
+    assert.Equal(t, model.EventSourceExplicit, state.EventSource.Type)
+    assert.Equal(t, []string{"src-1"}, state.EventSource.SourceStreamIds)
+}
+
+// TestStreamService_DefaultSubjectsIgnoredWhenDisabled verifies that a
+// defaultSubjects value supplied on stream creation is silently ignored while
+// subject filtering is disabled server-wide, so an upgrade does not change
+// delivery behavior for streams that set the knob.
+func TestStreamService_DefaultSubjectsIgnoredWhenDisabled(t *testing.T) {
+    t.Setenv("I2SIG_SUBJECT_FILTERING", "DISABLED")
+    svc := newSubjectFilterTestService()
+    ctx := context.Background()
+
+    req := pushTransmitterRequest()
+    req.DefaultSubjects = model.DefaultSubjectsNone
+
+    created, err := svc.CreateStream(ctx, req, "test-project", nil)
+    require.NoError(t, err)
+
+    state, err := svc.GetStreamState(ctx, created.Id)
+    require.NoError(t, err)
+    assert.Empty(t, state.DefaultSubjects,
+        "defaultSubjects must be ignored (left empty) when subject filtering is disabled")
+}
+
+// TestStreamService_SubjectFilterFieldsRoundTripOnUpdate verifies that the
+// subject-filtering configuration fields can be patched on an existing stream
+// and are persisted and read back intact when the feature is enabled.
+func TestStreamService_SubjectFilterFieldsRoundTripOnUpdate(t *testing.T) {
+    t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+    svc := newSubjectFilterTestService()
+    ctx := context.Background()
+
+    created, err := svc.CreateStream(ctx, pushTransmitterRequest(), "test-project", nil)
+    require.NoError(t, err)
+
+    update := model.StreamStateRecord{
+        StreamConfiguration: model.StreamConfiguration{Id: created.Id},
+        DefaultSubjects:     model.DefaultSubjectsNone,
+        SubjectFilterMode:   model.SubjectFilterModeHybrid,
+        EventSource:         &model.EventSource{Type: model.EventSourceAudience},
+    }
+    _, err = svc.UpdateStream(ctx, created.Id, "test-project", update)
+    require.NoError(t, err)
+
+    state, err := svc.GetStreamState(ctx, created.Id)
+    require.NoError(t, err)
+    assert.Equal(t, model.DefaultSubjectsNone, state.DefaultSubjects,
+        "defaultSubjects must round-trip through update")
+    assert.Equal(t, model.SubjectFilterModeHybrid, state.SubjectFilterMode,
+        "subjectFilterMode must round-trip through update")
+    require.NotNil(t, state.EventSource, "event source must round-trip through update")
+    assert.Equal(t, model.EventSourceAudience, state.EventSource.Type)
+}

--- a/internal/services/stream_service_tx_token_test.go
+++ b/internal/services/stream_service_tx_token_test.go
@@ -100,7 +100,7 @@ func TestCreateStream_TxTokenResilience(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			_, err = svc.CreateStream(ctx, request, "test-project", nil)
+			_, err = svc.CreateStream(ctx, model.StreamStateRecord{StreamConfiguration: request}, "test-project", nil)
 
 			// 4. Verify Results
 			assert.NoError(t, err)

--- a/internal/services/stream_service_tx_update_test.go
+++ b/internal/services/stream_service_tx_update_test.go
@@ -61,7 +61,7 @@ func TestUpdateStream_AllTxFieldsPersistence(t *testing.T) {
 	}
 
 	// Create stream (simulating discovery already happened)
-	created, err := svc.CreateStream(ctx, initialConfig, "test-project", nil)
+	created, err := svc.CreateStream(ctx, model.StreamStateRecord{StreamConfiguration: initialConfig}, "test-project", nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, created.TxAlias)
 	assert.Equal(t, txAlias, *created.TxAlias)
@@ -72,7 +72,7 @@ func TestUpdateStream_AllTxFieldsPersistence(t *testing.T) {
 	}
 
 	// Now update the stream, but don't include TxAlias in the update request (typical for SSF updates)
-	updateReq := created.DeepCopy()
+	updateReq := model.StreamStateRecord{StreamConfiguration: created.DeepCopy()}
 	updateReq.Description = "Updated description"
 	// Ensure TxAlias is still there in our "request" object
 	assert.NotNil(t, updateReq.TxAlias)
@@ -115,7 +115,7 @@ func TestCreateStream_NoDiscovery_TxAliasPreserved(t *testing.T) {
 		},
 	}
 
-	created, err := svc.CreateStream(ctx, config, "test-project", nil)
+	created, err := svc.CreateStream(ctx, model.StreamStateRecord{StreamConfiguration: config}, "test-project", nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, created.TxAlias)
 	assert.Equal(t, txAlias, *created.TxAlias)

--- a/internal/services/stream_service_txalias_test.go
+++ b/internal/services/stream_service_txalias_test.go
@@ -45,7 +45,7 @@ func TestCreateStream_UnknownTxAliasErrorsAtServiceLayer(t *testing.T) {
         TxAlias: &bogus,
     }
 
-    _, err := svc.CreateStream(context.Background(), request, "test-project", nil)
+    _, err := svc.CreateStream(context.Background(), model.StreamStateRecord{StreamConfiguration: request}, "test-project", nil)
     assert.Error(t, err)
     assert.True(t, strings.Contains(err.Error(), "tx_alias"),
         "error should mention tx_alias, got: %v", err)
@@ -75,7 +75,7 @@ func TestCreateStream_KnownTxAliasIsResolvedBeforeFurtherProcessing(t *testing.T
         TxAlias: &alias,
     }
 
-    _, err = svc.CreateStream(context.Background(), request, "test-project", nil)
+    _, err = svc.CreateStream(context.Background(), model.StreamStateRecord{StreamConfiguration: request}, "test-project", nil)
     // The alias resolved (otherwise we'd see "unknown tx_alias provided").
     // Whatever error comes back must not be the alias-failure error.
     if err != nil {
@@ -100,7 +100,7 @@ func TestCreateStream_IssuerJWKSUrlNoneIsNormalised(t *testing.T) {
         IssuerJWKSUrl: "none",
     }
 
-    cfg, _ := svc.CreateStream(context.Background(), request, "test-project", nil)
+    cfg, _ := svc.CreateStream(context.Background(), model.StreamStateRecord{StreamConfiguration: request}, "test-project", nil)
     // Whether or not the deeper pipeline succeeded, the returned config (if
     // any) must reflect the normalised value.
     assert.Equal(t, "", cfg.IssuerJWKSUrl,

--- a/internal/services/subject_filter_cluster_test.go
+++ b/internal/services/subject_filter_cluster_test.go
@@ -1,0 +1,50 @@
+package services
+
+import (
+    "context"
+    "testing"
+
+    "github.com/i2-open/i2goSignals/internal/dao/memory"
+)
+
+// TestSubjectFilterService_InvalidateCache_ReflectsRemoteNodeChange simulates
+// the PRD #89 cluster scenario (issue #94, ADR-0003): an Add Subject processed
+// on one node leaves a peer node's match-result cache stale, and InvalidateCache
+// on the peer makes its next decision re-read the shared filter.
+func TestSubjectFilterService_InvalidateCache_ReflectsRemoteNodeChange(t *testing.T) {
+    t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+    ctx := context.Background()
+
+    // Two SubjectFilterService instances over one shared DAO model two cluster
+    // nodes backed by the same subject_filters collection.
+    dao := memory.NewSubjectFilterDAO()
+    owner := NewSubjectFilterService(dao) // holds the push-transmitter lease
+    peer := NewSubjectFilterService(dao)  // receives the Add Subject request
+
+    stream := noneStream("stream-1")
+    subject := emailSubject("alice@example.com")
+    event := eventFor(subject)
+
+    // The owner caches a "drop" decision (NONE stream, empty filter).
+    if owner.Allows(ctx, stream, event) {
+        t.Fatal("precondition: NONE stream with an empty filter must not deliver")
+    }
+
+    // The Add Subject lands on the peer node; only the peer's cache is cleared.
+    if err := peer.AddSubject(ctx, stream, subject, false); err != nil {
+        t.Fatalf("AddSubject: %v", err)
+    }
+
+    // The owner's cache is now stale: the filter changed but its cached "drop"
+    // still suppresses the subject.
+    if owner.Allows(ctx, stream, event) {
+        t.Fatal("precondition: the owner's cached decision is expected to be stale")
+    }
+
+    // The cluster notification reaches the owner.
+    owner.InvalidateCache("stream-1")
+
+    if !owner.Allows(ctx, stream, event) {
+        t.Fatal("after InvalidateCache the owner must re-read the filter and deliver")
+    }
+}

--- a/internal/services/subject_filter_service.go
+++ b/internal/services/subject_filter_service.go
@@ -96,14 +96,22 @@ func (s *SubjectFilterService) InvalidateCache(streamID string) {
 }
 
 // Allows reports whether event should be delivered to stream under its subject
-// filter. Operational events and a server-wide disabled feature always pass.
-// On a NONE stream an event delivers only when its subject is in the filter; on
-// an ALL stream it delivers unless its subject is in the filter.
+// filter. Operational events and a server-wide disabled feature always pass;
+// otherwise the decision is delegated to Selects.
 func (s *SubjectFilterService) Allows(ctx context.Context, stream *model.StreamStateRecord, event *model.AgEventRecord) bool {
     if !SubjectFilteringEnabled() || event == nil || event.Operational {
         return true
     }
-    matched := s.matches(ctx, stream.StreamConfiguration.Id, event.Event.SubjectId)
+    return s.Selects(ctx, stream, event.Event.SubjectId)
+}
+
+// Selects reports whether stream's subject filter currently delivers subject.
+// On a NONE stream the subject delivers only when it is in the filter; on an
+// ALL stream it delivers unless it is. It is Allows without the
+// event/operational wrapper and is the HYBRID interested-set membership test
+// (issue #96): whether a downstream transmitter stream still wants the subject.
+func (s *SubjectFilterService) Selects(ctx context.Context, stream *model.StreamStateRecord, subject *goSet.SubjectIdentifier) bool {
+    matched := s.matches(ctx, stream.StreamConfiguration.Id, subject)
     if stream.DefaultSubjects == model.DefaultSubjectsNone {
         return matched
     }

--- a/internal/services/subject_filter_service.go
+++ b/internal/services/subject_filter_service.go
@@ -86,6 +86,15 @@ func (s *SubjectFilterService) ClearFilter(ctx context.Context, streamID string)
     return err
 }
 
+// InvalidateCache drops every cached match decision for streamID on this node.
+// It is the cluster reload signal of PRD #89 (ADR-0003): when an Add/Remove
+// Subject is processed on a peer node, that node notifies this stream's
+// push-transmitter lease owner, which calls InvalidateCache so its next
+// delivery-time decision re-reads the updated filter.
+func (s *SubjectFilterService) InvalidateCache(streamID string) {
+    s.cache.invalidateStream(streamID)
+}
+
 // Allows reports whether event should be delivered to stream under its subject
 // filter. Operational events and a server-wide disabled feature always pass.
 // On a NONE stream an event delivers only when its subject is in the filter; on

--- a/internal/services/subject_filter_service.go
+++ b/internal/services/subject_filter_service.go
@@ -1,0 +1,79 @@
+package services
+
+import (
+    "context"
+
+    "github.com/i2-open/i2goSignals/internal/dao/interfaces"
+    "github.com/i2-open/i2goSignals/pkg/goSet"
+    model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+    "github.com/i2-open/i2goSignals/pkg/subjectid"
+)
+
+// SubjectFilterService owns a transmitter stream's SSF §8.1.3 subject filter:
+// the non-default set of subjects, the ALL/NONE delivery decision, and the
+// delivery-time Allows predicate built on the §8.1.3.1 matching module
+// (pkg/subjectid). It is the "fat service" of PRD #89 — the thin persistence
+// sits behind interfaces.SubjectFilterDAO.
+type SubjectFilterService struct {
+    dao interfaces.SubjectFilterDAO
+}
+
+// NewSubjectFilterService constructs a SubjectFilterService over the given DAO.
+func NewSubjectFilterService(dao interfaces.SubjectFilterDAO) *SubjectFilterService {
+    return &SubjectFilterService{dao: dao}
+}
+
+// AddSubject records subject in the stream's filter. On a NONE stream this opts
+// the subject into delivery. verified is stored for audit only and has no
+// effect on filtering. It returns an error when the subject cannot be
+// canonicalized (missing/unrecognized RFC9493 format).
+func (s *SubjectFilterService) AddSubject(ctx context.Context, streamID string, subject *goSet.SubjectIdentifier, verified bool) error {
+    key, err := subjectid.CanonicalKey(subject)
+    if err != nil {
+        return err
+    }
+    return s.dao.Add(ctx, &model.SubjectFilterEntry{
+        StreamId:     streamID,
+        CanonicalKey: key,
+        Kind:         kindString(subjectid.Kind(subject)),
+        Subject:      subject,
+        Verified:     verified,
+    })
+}
+
+// Allows reports whether event should be delivered to stream under its subject
+// filter. Operational events and a server-wide disabled feature always pass.
+// On a NONE stream an event delivers only when its subject is in the filter; on
+// an ALL stream it delivers unless its subject is in the filter.
+func (s *SubjectFilterService) Allows(ctx context.Context, stream *model.StreamStateRecord, event *model.AgEventRecord) bool {
+    if !SubjectFilteringEnabled() || event == nil || event.Operational {
+        return true
+    }
+    matched := s.matches(ctx, stream.StreamConfiguration.Id, event.Event.SubjectId)
+    if stream.DefaultSubjects == model.DefaultSubjectsNone {
+        return matched
+    }
+    return !matched
+}
+
+// matches reports whether subject is present in the stream's filter.
+func (s *SubjectFilterService) matches(ctx context.Context, streamID string, subject *goSet.SubjectIdentifier) bool {
+    key, err := subjectid.CanonicalKey(subject)
+    if err != nil {
+        return false
+    }
+    _, err = s.dao.Get(ctx, streamID, key)
+    return err == nil
+}
+
+// kindString maps a subjectid.SubjectKind to its stored string form.
+func kindString(k subjectid.SubjectKind) string {
+    switch k {
+    case subjectid.KindComplex:
+        return model.SubjectKindComplex
+    case subjectid.KindAliases:
+        return model.SubjectKindAliases
+    default:
+        return model.SubjectKindSimple
+    }
+}

--- a/internal/services/subject_filter_service.go
+++ b/internal/services/subject_filter_service.go
@@ -15,30 +15,75 @@ import (
 // (pkg/subjectid). It is the "fat service" of PRD #89 — the thin persistence
 // sits behind interfaces.SubjectFilterDAO.
 type SubjectFilterService struct {
-    dao interfaces.SubjectFilterDAO
+    dao   interfaces.SubjectFilterDAO
+    cache *matchCache
 }
 
 // NewSubjectFilterService constructs a SubjectFilterService over the given DAO.
 func NewSubjectFilterService(dao interfaces.SubjectFilterDAO) *SubjectFilterService {
-    return &SubjectFilterService{dao: dao}
+    return &SubjectFilterService{
+        dao:   dao,
+        cache: newMatchCache(defaultMatchCacheTTL, defaultMatchCacheMaxKeys),
+    }
 }
 
-// AddSubject records subject in the stream's filter. On a NONE stream this opts
-// the subject into delivery. verified is stored for audit only and has no
-// effect on filtering. It returns an error when the subject cannot be
-// canonicalized (missing/unrecognized RFC9493 format).
-func (s *SubjectFilterService) AddSubject(ctx context.Context, streamID string, subject *goSet.SubjectIdentifier, verified bool) error {
+// AddSubject opts subject into delivery on stream. The filter stores only the
+// non-default set, so the effect depends on the stream's baseline: on a NONE
+// stream an inclusion entry is written; on an ALL stream any exclusion entry is
+// dropped. verified is stored for audit only and has no effect on filtering. It
+// returns an error when the subject cannot be canonicalized (missing or
+// unrecognized RFC9493 format).
+func (s *SubjectFilterService) AddSubject(ctx context.Context, stream *model.StreamStateRecord, subject *goSet.SubjectIdentifier, verified bool) error {
+    return s.applySubjectChange(ctx, stream, subject, verified, true)
+}
+
+// RemoveSubject opts subject out of delivery on stream. On a NONE stream any
+// inclusion entry is dropped; on an ALL stream an exclusion entry is written.
+// It returns an error when the subject cannot be canonicalized.
+func (s *SubjectFilterService) RemoveSubject(ctx context.Context, stream *model.StreamStateRecord, subject *goSet.SubjectIdentifier) error {
+    return s.applySubjectChange(ctx, stream, subject, false, false)
+}
+
+// applySubjectChange writes or removes a filter entry for subject. add reports
+// whether the receiver wants the subject delivered; combined with the stream's
+// baseline it decides whether a non-default-set entry is inserted or deleted.
+func (s *SubjectFilterService) applySubjectChange(ctx context.Context, stream *model.StreamStateRecord, subject *goSet.SubjectIdentifier, verified, add bool) error {
+    streamID := stream.StreamConfiguration.Id
     key, err := subjectid.CanonicalKey(subject)
     if err != nil {
         return err
     }
-    return s.dao.Add(ctx, &model.SubjectFilterEntry{
-        StreamId:     streamID,
-        CanonicalKey: key,
-        Kind:         kindString(subjectid.Kind(subject)),
-        Subject:      subject,
-        Verified:     verified,
-    })
+    // An entry always means "the opposite of the baseline". A NONE stream
+    // stores inclusions, so Add inserts; an ALL stream stores exclusions, so
+    // Remove inserts. The other two combinations drop the entry.
+    insert := (stream.DefaultSubjects == model.DefaultSubjectsNone) == add
+    if insert {
+        err = s.dao.Add(ctx, &model.SubjectFilterEntry{
+            StreamId:     streamID,
+            CanonicalKey: key,
+            Kind:         kindString(subjectid.Kind(subject)),
+            Subject:      subject,
+            Verified:     verified,
+        })
+    } else {
+        err = s.dao.Remove(ctx, streamID, key)
+    }
+    if err == nil {
+        s.cache.invalidateStream(streamID)
+    }
+    return err
+}
+
+// ClearFilter drops every subject filter entry for streamID, restoring the
+// stream's baseline delivery policy. It is invoked when a stream's
+// defaultSubjects baseline changes, so stale entries never carry the opposite
+// meaning under the new baseline.
+func (s *SubjectFilterService) ClearFilter(ctx context.Context, streamID string) error {
+    err := s.dao.ClearForStream(ctx, streamID)
+    if err == nil {
+        s.cache.invalidateStream(streamID)
+    }
+    return err
 }
 
 // Allows reports whether event should be delivered to stream under its subject
@@ -56,14 +101,41 @@ func (s *SubjectFilterService) Allows(ctx context.Context, stream *model.StreamS
     return !matched
 }
 
-// matches reports whether subject is present in the stream's filter.
+// matches reports whether subject is present in the stream's filter. A live
+// match-result cache hit is returned directly; a miss is computed and cached.
 func (s *SubjectFilterService) matches(ctx context.Context, streamID string, subject *goSet.SubjectIdentifier) bool {
     key, err := subjectid.CanonicalKey(subject)
     if err != nil {
         return false
     }
-    _, err = s.dao.Get(ctx, streamID, key)
-    return err == nil
+    if cached, hit := s.cache.get(streamID, key); hit {
+        return cached
+    }
+    result := s.computeMatch(ctx, streamID, key, subject)
+    s.cache.put(streamID, key, result)
+    return result
+}
+
+// computeMatch evaluates subject against the stream's filter on a cache miss.
+// It takes the two ADR-0003 paths: an indexed canonical-key Get for
+// simple-subject membership (O(1), the path that scales to millions of
+// entries), then a field-wise scan of the small complex/aliases list, which
+// lets a broad subscription match a narrower, more-specific event per SSF
+// §8.1.3.1.
+func (s *SubjectFilterService) computeMatch(ctx context.Context, streamID, key string, subject *goSet.SubjectIdentifier) bool {
+    if _, err := s.dao.Get(ctx, streamID, key); err == nil {
+        return true
+    }
+    complexEntries, err := s.dao.ListComplex(ctx, streamID)
+    if err != nil {
+        return false
+    }
+    for _, entry := range complexEntries {
+        if subjectid.Match(entry.Subject, subject) {
+            return true
+        }
+    }
+    return false
 }
 
 // kindString maps a subjectid.SubjectKind to its stored string form.

--- a/internal/services/subject_filter_service_test.go
+++ b/internal/services/subject_filter_service_test.go
@@ -22,6 +22,13 @@ func noneStream(id string) *model.StreamStateRecord {
 	return st
 }
 
+// allStream builds a transmitter stream whose baseline policy is ALL.
+func allStream(id string) *model.StreamStateRecord {
+	st := &model.StreamStateRecord{DefaultSubjects: model.DefaultSubjectsAll}
+	st.StreamConfiguration.Id = id
+	return st
+}
+
 // eventFor builds an event record carrying the given subject.
 func eventFor(subject *goSet.SubjectIdentifier) *model.AgEventRecord {
 	return &model.AgEventRecord{Event: goSet.SecurityEventToken{SubjectId: subject}}
@@ -43,11 +50,136 @@ func TestSubjectFilterService_NoneStream_DeliversAfterAdd(t *testing.T) {
 		t.Fatal("NONE stream with an empty filter must not deliver")
 	}
 
-	if err := svc.AddSubject(ctx, stream.StreamConfiguration.Id, subject, false); err != nil {
+	if err := svc.AddSubject(ctx, stream, subject, false); err != nil {
 		t.Fatalf("AddSubject: %v", err)
 	}
 
 	if !svc.Allows(ctx, stream, event) {
 		t.Fatal("after AddSubject the matching event must deliver")
+	}
+}
+
+// TestSubjectFilterService_AllStream_StopsAfterRemove verifies that on an ALL
+// stream every subject delivers until one is removed, after which that
+// subject's events stop (#92 acceptance criterion 2).
+func TestSubjectFilterService_AllStream_StopsAfterRemove(t *testing.T) {
+	t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+	ctx := context.Background()
+
+	svc := NewSubjectFilterService(memory.NewSubjectFilterDAO())
+	stream := allStream("stream-1")
+	subject := emailSubject("alice@example.com")
+	event := eventFor(subject)
+
+	if !svc.Allows(ctx, stream, event) {
+		t.Fatal("ALL stream with an empty filter must deliver every subject")
+	}
+
+	if err := svc.RemoveSubject(ctx, stream, subject); err != nil {
+		t.Fatalf("RemoveSubject: %v", err)
+	}
+
+	if svc.Allows(ctx, stream, event) {
+		t.Fatal("after RemoveSubject the removed subject's events must stop")
+	}
+}
+
+// TestSubjectFilterService_ClearFilterEmptiesTheFilter verifies ClearFilter
+// drops every entry for a stream, restoring the baseline delivery policy. It is
+// the service side of the defaultSubjects-flip filter clear (#92 criterion 5).
+func TestSubjectFilterService_ClearFilterEmptiesTheFilter(t *testing.T) {
+	t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+	ctx := context.Background()
+
+	svc := NewSubjectFilterService(memory.NewSubjectFilterDAO())
+	stream := noneStream("stream-1")
+	subject := emailSubject("alice@example.com")
+	event := eventFor(subject)
+
+	if err := svc.AddSubject(ctx, stream, subject, false); err != nil {
+		t.Fatalf("AddSubject: %v", err)
+	}
+	if !svc.Allows(ctx, stream, event) {
+		t.Fatal("precondition: added subject must deliver")
+	}
+
+	if err := svc.ClearFilter(ctx, stream.StreamConfiguration.Id); err != nil {
+		t.Fatalf("ClearFilter: %v", err)
+	}
+
+	if svc.Allows(ctx, stream, event) {
+		t.Fatal("after ClearFilter the NONE stream must deliver nothing again")
+	}
+}
+
+// opaqueSubject builds a simple RFC9493 opaque-format subject identifier, used
+// as a complex-subject member.
+func opaqueSubject(id string) *goSet.SubjectIdentifier {
+	s := &goSet.SubjectIdentifier{Format: "opaque"}
+	s.Id = id
+	return s
+}
+
+// TestSubjectFilterService_ComplexAddMatchesNarrowerEvent verifies that adding
+// a broad complex subject (few members) matches a narrower, more-specific
+// complex event per SSF §8.1.3.1 — an undefined member acts as a wildcard
+// (#92 acceptance criterion 4).
+func TestSubjectFilterService_ComplexAddMatchesNarrowerEvent(t *testing.T) {
+	t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+	ctx := context.Background()
+
+	svc := NewSubjectFilterService(memory.NewSubjectFilterDAO())
+	stream := noneStream("stream-1")
+
+	// Broad subscription: only the tenant member is defined.
+	subscription := &goSet.SubjectIdentifier{}
+	subscription.Tenant = opaqueSubject("tenant-1")
+
+	// Narrower event: same tenant plus a user member.
+	eventSubject := &goSet.SubjectIdentifier{}
+	eventSubject.Tenant = opaqueSubject("tenant-1")
+	eventSubject.User = opaqueSubject("user-9")
+	event := eventFor(eventSubject)
+
+	if svc.Allows(ctx, stream, event) {
+		t.Fatal("precondition: NONE stream with empty filter must not deliver")
+	}
+
+	if err := svc.AddSubject(ctx, stream, subscription, false); err != nil {
+		t.Fatalf("AddSubject: %v", err)
+	}
+
+	if !svc.Allows(ctx, stream, event) {
+		t.Fatal("a broad complex subscription must match a narrower complex event")
+	}
+}
+
+// TestSubjectFilterService_VerifiedFlagStoredNoFilteringEffect verifies the
+// verified flag is persisted for audit and has no effect on the delivery
+// decision (#92 acceptance criterion 8).
+func TestSubjectFilterService_VerifiedFlagStoredNoFilteringEffect(t *testing.T) {
+	t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+	ctx := context.Background()
+
+	dao := memory.NewSubjectFilterDAO()
+	svc := NewSubjectFilterService(dao)
+	stream := noneStream("stream-1")
+	subject := emailSubject("alice@example.com")
+
+	if err := svc.AddSubject(ctx, stream, subject, true); err != nil {
+		t.Fatalf("AddSubject: %v", err)
+	}
+
+	entry, err := dao.Get(ctx, stream.StreamConfiguration.Id, "email:alice@example.com")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !entry.Verified {
+		t.Fatal("the verified flag must be stored on the filter entry")
+	}
+
+	// verified has no effect: the subject delivers exactly as an unverified one.
+	if !svc.Allows(ctx, stream, eventFor(subject)) {
+		t.Fatal("a verified subject must deliver just like any added subject")
 	}
 }

--- a/internal/services/subject_filter_service_test.go
+++ b/internal/services/subject_filter_service_test.go
@@ -2,7 +2,9 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/i2-open/i2goSignals/internal/dao/memory"
 	"github.com/i2-open/i2goSignals/pkg/goSet"
@@ -181,5 +183,63 @@ func TestSubjectFilterService_VerifiedFlagStoredNoFilteringEffect(t *testing.T) 
 	// verified has no effect: the subject delivers exactly as an unverified one.
 	if !svc.Allows(ctx, stream, eventFor(subject)) {
 		t.Fatal("a verified subject must deliver just like any added subject")
+	}
+}
+
+// TestSubjectFilterService_SimpleMembershipScalesConstantly verifies #92
+// acceptance criterion 10: simple-subject membership is an indexed lookup, so a
+// stream whose filter holds a very large number of subjects still filters in
+// roughly constant time per event — it never degrades into a collection scan.
+//
+// It measures the per-event Allows cost against a small filter and against a
+// filter ~200x larger. An indexed lookup keeps the ratio near 1; an O(N) scan
+// would make the large filter ~200x slower. A generous 10x bound proves the
+// complexity class while leaving ample headroom for measurement noise.
+func TestSubjectFilterService_SimpleMembershipScalesConstantly(t *testing.T) {
+	t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+
+	const (
+		smallN = 1000
+		largeN = 200000
+		probes = 4000
+	)
+
+	// measure builds a NONE stream whose filter holds n simple subjects, then
+	// times `probes` distinct Allows calls. Probes are unique so every call is a
+	// match-cache miss and exercises the real indexed DAO lookup.
+	measure := func(n int) time.Duration {
+		ctx := context.Background()
+		svc := NewSubjectFilterService(memory.NewSubjectFilterDAO())
+		stream := noneStream("stream-scale")
+		for i := 0; i < n; i++ {
+			subj := emailSubject(fmt.Sprintf("member-%d@example.com", i))
+			if err := svc.AddSubject(ctx, stream, subj, false); err != nil {
+				t.Fatalf("AddSubject: %v", err)
+			}
+		}
+		// Sanity: a member in the filter delivers, a non-member does not.
+		if !svc.Allows(ctx, stream, eventFor(emailSubject("member-0@example.com"))) {
+			t.Fatal("a subject in the filter must deliver")
+		}
+		if svc.Allows(ctx, stream, eventFor(emailSubject("absent@example.com"))) {
+			t.Fatal("a subject not in the filter must not deliver")
+		}
+		start := time.Now()
+		for i := 0; i < probes; i++ {
+			subj := emailSubject(fmt.Sprintf("probe-%d@example.com", i))
+			svc.Allows(ctx, stream, eventFor(subj))
+		}
+		return time.Since(start)
+	}
+
+	small := measure(smallN)
+	large := measure(largeN)
+
+	// An indexed lookup is O(1): a 200x-larger filter must not be dramatically
+	// slower per event. 10x leaves headroom for noise while still failing a
+	// regression to an O(N) collection scan.
+	if large > small*10+time.Millisecond {
+		t.Fatalf("simple-subject membership did not scale: small filter (%d entries) took %v for %d probes, large filter (%d entries) took %v — expected roughly constant time, not an O(N) scan",
+			smallN, small, probes, largeN, large)
 	}
 }

--- a/internal/services/subject_filter_service_test.go
+++ b/internal/services/subject_filter_service_test.go
@@ -1,0 +1,53 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/i2-open/i2goSignals/internal/dao/memory"
+	"github.com/i2-open/i2goSignals/pkg/goSet"
+	model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+)
+
+// emailSubject builds a simple RFC9493 email-format subject identifier.
+func emailSubject(addr string) *goSet.SubjectIdentifier {
+	s := &goSet.SubjectIdentifier{Format: "email"}
+	return s.AddEmail(addr)
+}
+
+// noneStream builds a transmitter stream whose baseline policy is NONE.
+func noneStream(id string) *model.StreamStateRecord {
+	st := &model.StreamStateRecord{DefaultSubjects: model.DefaultSubjectsNone}
+	st.StreamConfiguration.Id = id
+	return st
+}
+
+// eventFor builds an event record carrying the given subject.
+func eventFor(subject *goSet.SubjectIdentifier) *model.AgEventRecord {
+	return &model.AgEventRecord{Event: goSet.SecurityEventToken{SubjectId: subject}}
+}
+
+// TestSubjectFilterService_NoneStream_DeliversAfterAdd is the tracer bullet for
+// issue #92: on a NONE stream nothing delivers until a matching subject is
+// added, after which the matching event delivers.
+func TestSubjectFilterService_NoneStream_DeliversAfterAdd(t *testing.T) {
+	t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+	ctx := context.Background()
+
+	svc := NewSubjectFilterService(memory.NewSubjectFilterDAO())
+	stream := noneStream("stream-1")
+	subject := emailSubject("alice@example.com")
+	event := eventFor(subject)
+
+	if svc.Allows(ctx, stream, event) {
+		t.Fatal("NONE stream with an empty filter must not deliver")
+	}
+
+	if err := svc.AddSubject(ctx, stream.StreamConfiguration.Id, subject, false); err != nil {
+		t.Fatalf("AddSubject: %v", err)
+	}
+
+	if !svc.Allows(ctx, stream, event) {
+		t.Fatal("after AddSubject the matching event must deliver")
+	}
+}

--- a/internal/services/subject_filtering.go
+++ b/internal/services/subject_filtering.go
@@ -1,0 +1,23 @@
+package services
+
+import (
+	"os"
+	"strings"
+)
+
+// SSF subject-filtering server-wide setting. The feature is governed by the
+// I2SIG_SUBJECT_FILTERING environment variable and is DISABLED unless the
+// operator explicitly opts in.
+const (
+	subjectFilteringEnvVar        = "I2SIG_SUBJECT_FILTERING"
+	SubjectFilteringEnabledValue  = "ENABLED"
+	SubjectFilteringDisabledValue = "DISABLED"
+)
+
+// SubjectFilteringEnabled reports whether SSF subject filtering (the
+// Add/Remove Subject mechanism, SSF §8.1.3) is enabled server-wide. It returns
+// true only when I2SIG_SUBJECT_FILTERING is set to ENABLED (case-insensitive);
+// unset or any other value means DISABLED.
+func SubjectFilteringEnabled() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv(subjectFilteringEnvVar)), SubjectFilteringEnabledValue)
+}

--- a/internal/services/subject_match_cache.go
+++ b/internal/services/subject_match_cache.go
@@ -1,0 +1,97 @@
+package services
+
+import (
+    "sync"
+    "time"
+)
+
+// Match-result cache defaults. The cache is deliberately short-lived: it
+// absorbs bursts of events about the same subject without pinning the whole
+// filter table in memory, and a short TTL bounds staleness on nodes that did
+// not originate a filter change (ADR-0003, PRD #89).
+const (
+    defaultMatchCacheTTL     = 5 * time.Second
+    defaultMatchCacheMaxKeys = 50000
+)
+
+// matchCacheEntry is one cached subject-match decision and its expiry.
+type matchCacheEntry struct {
+    matched bool
+    expiry  time.Time
+}
+
+// matchCache is a bounded, short-TTL per-node cache of subject match results,
+// keyed by (stream_id, subject canonical key). It lets a burst of events about
+// one subject pay a single filter lookup. Entries are invalidated per stream
+// when that stream's filter changes; a coarse drop-all on overflow keeps the
+// cache bounded.
+type matchCache struct {
+    mu      sync.Mutex
+    ttl     time.Duration
+    maxKeys int
+    size    int
+    streams map[string]map[string]matchCacheEntry
+}
+
+// newMatchCache constructs a matchCache with the given TTL and key cap.
+func newMatchCache(ttl time.Duration, maxKeys int) *matchCache {
+    return &matchCache{
+        ttl:     ttl,
+        maxKeys: maxKeys,
+        streams: map[string]map[string]matchCacheEntry{},
+    }
+}
+
+// get returns the cached match decision for (streamID, key) and whether it was
+// a live cache hit. An expired entry is evicted and reported as a miss.
+func (c *matchCache) get(streamID, key string) (matched bool, hit bool) {
+    c.mu.Lock()
+    defer c.mu.Unlock()
+    s, ok := c.streams[streamID]
+    if !ok {
+        return false, false
+    }
+    e, ok := s[key]
+    if !ok {
+        return false, false
+    }
+    if time.Now().After(e.expiry) {
+        delete(s, key)
+        c.size--
+        return false, false
+    }
+    return e.matched, true
+}
+
+// put records a match decision for (streamID, key). When the key cap is
+// reached the whole cache is dropped — coarse, but it keeps memory bounded
+// without per-entry bookkeeping.
+func (c *matchCache) put(streamID, key string, matched bool) {
+    c.mu.Lock()
+    defer c.mu.Unlock()
+    if c.size >= c.maxKeys {
+        c.streams = map[string]map[string]matchCacheEntry{}
+        c.size = 0
+    }
+    s, ok := c.streams[streamID]
+    if !ok {
+        s = map[string]matchCacheEntry{}
+        c.streams[streamID] = s
+    }
+    if _, existed := s[key]; !existed {
+        c.size++
+    }
+    s[key] = matchCacheEntry{matched: matched, expiry: time.Now().Add(c.ttl)}
+}
+
+// invalidateStream drops every cached decision for streamID. It is called
+// whenever that stream's subject filter changes so a subsequent lookup is
+// recomputed against the updated filter.
+func (c *matchCache) invalidateStream(streamID string) {
+    c.mu.Lock()
+    defer c.mu.Unlock()
+    if s, ok := c.streams[streamID]; ok {
+        c.size -= len(s)
+        delete(c.streams, streamID)
+    }
+}

--- a/internal/services/subject_match_cache_test.go
+++ b/internal/services/subject_match_cache_test.go
@@ -1,0 +1,50 @@
+package services
+
+import (
+    "testing"
+    "time"
+)
+
+// TestMatchCache_HitAfterPut verifies a stored decision is returned as a hit.
+func TestMatchCache_HitAfterPut(t *testing.T) {
+    c := newMatchCache(time.Minute, 100)
+    c.put("stream-1", "email:alice@example.com", true)
+
+    matched, hit := c.get("stream-1", "email:alice@example.com")
+    if !hit {
+        t.Fatal("a stored decision must be a cache hit")
+    }
+    if !matched {
+        t.Fatal("the cached match decision must be returned intact")
+    }
+}
+
+// TestMatchCache_InvalidateStreamDropsEntries verifies invalidateStream removes
+// a stream's cached decisions while leaving other streams untouched.
+func TestMatchCache_InvalidateStreamDropsEntries(t *testing.T) {
+    c := newMatchCache(time.Minute, 100)
+    c.put("stream-1", "email:alice@example.com", true)
+    c.put("stream-2", "email:bob@example.com", true)
+
+    c.invalidateStream("stream-1")
+
+    if _, hit := c.get("stream-1", "email:alice@example.com"); hit {
+        t.Fatal("invalidateStream must drop the stream's cached decisions")
+    }
+    if _, hit := c.get("stream-2", "email:bob@example.com"); !hit {
+        t.Fatal("invalidateStream must not affect other streams")
+    }
+}
+
+// TestMatchCache_EntryExpiresAfterTTL verifies a cached decision becomes a miss
+// once its TTL elapses — the short TTL that bounds cross-node staleness.
+func TestMatchCache_EntryExpiresAfterTTL(t *testing.T) {
+    c := newMatchCache(10*time.Millisecond, 100)
+    c.put("stream-1", "email:alice@example.com", true)
+
+    time.Sleep(25 * time.Millisecond)
+
+    if _, hit := c.get("stream-1", "email:alice@example.com"); hit {
+        t.Fatal("a cached decision must expire after its TTL")
+    }
+}

--- a/internal/services/subject_relay.go
+++ b/internal/services/subject_relay.go
@@ -158,20 +158,44 @@ func NewDefaultUpstreamResolver(servers *ServerService) UpstreamResolver {
 // relay can be exercised without a live upstream.
 type UpstreamResolver func(ctx context.Context, receiver *model.StreamStateRecord) (*UpstreamConn, error)
 
+// InterestPredicate reports whether a downstream transmitter stream's subject
+// filter currently selects subject — the HYBRID interested-set membership test
+// (issue #96). It is typically SubjectFilterService.Selects.
+type InterestPredicate func(ctx context.Context, stream *model.StreamStateRecord, subject *goSet.SubjectIdentifier) bool
+
 // SubjectRelayService relays PASSTHRU/HYBRID subject changes to the upstream
 // transmitter and validates a transmitter stream's subject-filter mode against
 // its upstream at config time (issue #95).
+//
+// listTransmitters and interested are the HYBRID interested-set inputs (issue
+// #96): the set of downstream transmitter streams and the predicate reporting
+// which of them still select a given subject.
 type SubjectRelayService struct {
-    listReceivers func(ctx context.Context) ([]model.StreamStateRecord, error)
-    resolve       UpstreamResolver
+    listReceivers    func(ctx context.Context) ([]model.StreamStateRecord, error)
+    resolve          UpstreamResolver
+    listTransmitters func(ctx context.Context) ([]model.StreamStateRecord, error)
+    interested       InterestPredicate
 }
 
 // NewSubjectRelayService constructs a SubjectRelayService. listReceivers
 // supplies the receiver streams resolution searches (typically
-// StreamService.ListReceiverStreams); resolve fetches an upstream's discovery
-// and credential.
-func NewSubjectRelayService(listReceivers func(ctx context.Context) ([]model.StreamStateRecord, error), resolve UpstreamResolver) *SubjectRelayService {
-    return &SubjectRelayService{listReceivers: listReceivers, resolve: resolve}
+// StreamService.ListReceiverStreams); listTransmitters supplies the downstream
+// transmitter streams the HYBRID interested-set is computed over (typically
+// StreamService.ListTransmitterStreams); interested reports HYBRID
+// interested-set membership (typically SubjectFilterService.Selects); resolve
+// fetches an upstream's discovery and credential.
+func NewSubjectRelayService(
+    listReceivers func(ctx context.Context) ([]model.StreamStateRecord, error),
+    listTransmitters func(ctx context.Context) ([]model.StreamStateRecord, error),
+    interested InterestPredicate,
+    resolve UpstreamResolver,
+) *SubjectRelayService {
+    return &SubjectRelayService{
+        listReceivers:    listReceivers,
+        resolve:          resolve,
+        listTransmitters: listTransmitters,
+        interested:       interested,
+    }
 }
 
 // Relay relays a subject change for the downstream transmitter stream to its
@@ -186,6 +210,67 @@ func (s *SubjectRelayService) Relay(ctx context.Context, downstream *model.Strea
     target, err := ResolveRelayTarget(downstream, receivers)
     if err != nil {
         return err
+    }
+    conn, err := s.resolve(ctx, target)
+    if err != nil {
+        return err
+    }
+    defer conn.release()
+    remoteStreamID := ""
+    if target.RemoteStreamId != nil {
+        remoteStreamID = *target.RemoteStreamId
+    }
+    return RelaySubjectChange(ctx, conn.HttpClient, conn.Config, conn.AuthHeader, remoteStreamID, subject, verified, add)
+}
+
+// RelayHybrid relays a HYBRID downstream stream's subject change to the
+// upstream transmitter only when the change crosses the interested-set 0↔1
+// boundary (issue #96). The caller has already written downstream's own local
+// filter; RelayHybrid decides whether the shared upstream subscription must
+// follow.
+//
+// Relay is engaged only against a defaultSubjects=NONE upstream: against an ALL
+// upstream every subject is delivered by default, so relaying a remove could
+// starve a not-yet-created downstream — there HYBRID is pure local filtering.
+// When engaged, RelayHybrid counts the other HYBRID downstreams fed by the same
+// subject handler that still select the subject. Because downstream's own
+// change is already applied, a count of zero means this change moved the
+// interested-set across the boundary — an add as the first downstream appears
+// (0→1) or a remove as the last one drops (1→0) — and the relay fires. A
+// sibling still interested suppresses the relay, so one downstream's change
+// never starves another.
+func (s *SubjectRelayService) RelayHybrid(ctx context.Context, downstream *model.StreamStateRecord, subject *goSet.SubjectIdentifier, verified, add bool) error {
+    receivers, err := s.listReceivers(ctx)
+    if err != nil {
+        return err
+    }
+    target, err := ResolveRelayTarget(downstream, receivers)
+    if err != nil {
+        return err
+    }
+    // HYBRID relays only against a NONE upstream (see the doc comment).
+    if target.DefaultSubjects != model.DefaultSubjectsNone {
+        return nil
+    }
+    transmitters, err := s.listTransmitters(ctx)
+    if err != nil {
+        return err
+    }
+    for i := range transmitters {
+        sibling := &transmitters[i]
+        if sibling.StreamConfiguration.Id == downstream.StreamConfiguration.Id {
+            continue // self — its change is already applied and not double-counted
+        }
+        if sibling.SubjectFilterMode != model.SubjectFilterModeHybrid {
+            continue
+        }
+        siblingTarget, err := ResolveRelayTarget(sibling, receivers)
+        if err != nil || siblingTarget.StreamConfiguration.Id != target.StreamConfiguration.Id {
+            continue // a sibling fed by a different subject handler
+        }
+        if s.interested(ctx, sibling, subject) {
+            return nil // a sibling still wants the subject — not a 0↔1 transition
+        }
     }
     conn, err := s.resolve(ctx, target)
     if err != nil {

--- a/internal/services/subject_relay.go
+++ b/internal/services/subject_relay.go
@@ -1,0 +1,266 @@
+package services
+
+import (
+    "bytes"
+    "context"
+    "encoding/json"
+    "errors"
+    "fmt"
+    "net/http"
+
+    "github.com/i2-open/i2goSignals/pkg/goSet"
+    "github.com/i2-open/i2goSignals/pkg/oauthClient"
+    model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+    "github.com/i2-open/i2goSignals/pkg/wellKnownSupport"
+)
+
+// relayBody is the SSF §8.1.3.2/§8.1.3.3 Add/Remove Subject request body sent
+// to an upstream transmitter. verified is meaningful for Add only.
+type relayBody struct {
+    StreamId string                   `json:"stream_id"`
+    Subject  *goSet.SubjectIdentifier `json:"subject"`
+    Verified bool                     `json:"verified,omitempty"`
+}
+
+// RelaySubjectChange relays a PASSTHRU subject change 1:1 to an upstream
+// transmitter (issue #95). add selects the upstream endpoint and SSF semantics:
+// Add posts to add_subject_endpoint, Remove to remove_subject_endpoint.
+// remoteStreamID is the stream_id the upstream assigned to goSignals' receiver
+// stream. A non-2xx upstream response is returned as an error.
+func RelaySubjectChange(ctx context.Context, client *http.Client, upstream *model.TransmitterConfiguration, authHeader, remoteStreamID string, subject *goSet.SubjectIdentifier, verified, add bool) error {
+    endpoint := upstream.RemoveSubjectEndpoint
+    if add {
+        endpoint = upstream.AddSubjectEndpoint
+    }
+    if endpoint == "" {
+        return errors.New("upstream advertises no subject endpoint to relay to")
+    }
+
+    body, err := json.Marshal(relayBody{StreamId: remoteStreamID, Subject: subject, Verified: verified && add})
+    if err != nil {
+        return err
+    }
+    req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+    if err != nil {
+        return err
+    }
+    req.Header.Set("Content-Type", "application/json")
+    if authHeader != "" {
+        req.Header.Set("Authorization", authHeader)
+    }
+    resp, err := client.Do(req)
+    if err != nil {
+        return err
+    }
+    defer func() { _ = resp.Body.Close() }()
+    if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+        return fmt.Errorf("upstream subject relay returned status %d", resp.StatusCode)
+    }
+    return nil
+}
+
+// Relay-target resolution errors (issue #95). Both reject stream configuration
+// at config time when a PASSTHRU/HYBRID stream cannot designate an upstream.
+var (
+    // ErrRelayTargetNotFound means no receiver stream feeds the downstream stream.
+    ErrRelayTargetNotFound = errors.New("no upstream receiver stream feeds this stream")
+    // ErrRelayTargetAmbiguous means several receiver streams share the issuer and
+    // the operator must name a Subject handler SID explicitly.
+    ErrRelayTargetAmbiguous = errors.New("multiple receiver streams match the issuer; name a subject handler explicitly")
+)
+
+// RelayConfigVerdict is the outcome of validating a transmitter stream's
+// subject-filter mode against its upstream's discovery metadata (issue #95). A
+// non-nil Err rejects the configuration at config time; a non-empty Warn is a
+// survivable misconfiguration the caller logs at WARN while the stream runs.
+type RelayConfigVerdict struct {
+    Err  error
+    Warn string
+}
+
+// ClassifyUpstreamSupport reports whether mode is compatible with what the
+// upstream advertises. An upstream that advertises neither add_subject_endpoint
+// nor remove_subject_endpoint does not support subject filtering at all:
+// PASSTHRU/HYBRID then has nowhere to relay and is rejected, while LOCAL still
+// works (filtering only what arrives) but earns a WARN.
+func ClassifyUpstreamSupport(mode string, upstream *model.TransmitterConfiguration) RelayConfigVerdict {
+    supportsFiltering := upstream != nil &&
+        upstream.AddSubjectEndpoint != "" && upstream.RemoveSubjectEndpoint != ""
+
+    switch mode {
+    case model.SubjectFilterModePassthru, model.SubjectFilterModeHybrid:
+        if !supportsFiltering {
+            return RelayConfigVerdict{Err: fmt.Errorf(
+                "subject_filter_mode %s requires an upstream that advertises add_subject_endpoint and remove_subject_endpoint", mode)}
+        }
+    case model.SubjectFilterModeLocal:
+        if !supportsFiltering {
+            return RelayConfigVerdict{Warn: "LOCAL subject filtering against an upstream that does not support subject filtering: only locally-filtered delivery is possible"}
+        }
+    }
+    return RelayConfigVerdict{}
+}
+
+// UpstreamConn bundles what a subject relay needs to reach an upstream
+// transmitter: its discovery metadata, an HTTP client carrying the upstream
+// credential, and an Authorization header value (empty when the client's
+// transport already injects the credential). Close, when non-nil, releases the
+// HTTP client and must be invoked once the connection is done with.
+type UpstreamConn struct {
+    Config     *model.TransmitterConfiguration
+    HttpClient *http.Client
+    AuthHeader string
+    Close      func()
+}
+
+// release invokes the connection's Close hook when one is set.
+func (c *UpstreamConn) release() {
+    if c != nil && c.Close != nil {
+        c.Close()
+    }
+}
+
+// NewDefaultUpstreamResolver builds the production UpstreamResolver: it derives
+// a model.Server from the receiver stream's upstream credentials (resolving a
+// tx_alias through servers when set), obtains a credentialed HTTP client, and
+// fetches the upstream's SSF discovery metadata.
+func NewDefaultUpstreamResolver(servers *ServerService) UpstreamResolver {
+    return func(ctx context.Context, receiver *model.StreamStateRecord) (*UpstreamConn, error) {
+        var server *model.Server
+        if receiver.TxAlias != nil && *receiver.TxAlias != "" && servers != nil {
+            resolved, err := servers.GetServerByAlias(ctx, *receiver.TxAlias)
+            if err != nil {
+                return nil, fmt.Errorf("cannot resolve upstream tx_alias %q: %w", *receiver.TxAlias, err)
+            }
+            server = resolved
+        }
+        if server == nil {
+            if receiver.TxWellKnownUrl == nil || *receiver.TxWellKnownUrl == "" {
+                return nil, ErrRelayTargetNotFound
+            }
+            server = &model.Server{Host: *receiver.TxWellKnownUrl, ClientToken: receiver.TxToken}
+        }
+        client, closeClient, err := oauthClient.GetClientForServer(ctx, server)
+        if err != nil {
+            return nil, fmt.Errorf("cannot obtain upstream client: %w", err)
+        }
+        config, err := wellKnownSupport.FetchSSFConfiguration(ctx, client, server.Host)
+        if err != nil {
+            closeClient()
+            return nil, fmt.Errorf("cannot fetch upstream configuration: %w", err)
+        }
+        return &UpstreamConn{Config: config, HttpClient: client, Close: closeClient}, nil
+    }
+}
+
+// UpstreamResolver resolves the live connection details for a receiver
+// stream's upstream. It is injected so config-time validation and runtime
+// relay can be exercised without a live upstream.
+type UpstreamResolver func(ctx context.Context, receiver *model.StreamStateRecord) (*UpstreamConn, error)
+
+// SubjectRelayService relays PASSTHRU/HYBRID subject changes to the upstream
+// transmitter and validates a transmitter stream's subject-filter mode against
+// its upstream at config time (issue #95).
+type SubjectRelayService struct {
+    listReceivers func(ctx context.Context) ([]model.StreamStateRecord, error)
+    resolve       UpstreamResolver
+}
+
+// NewSubjectRelayService constructs a SubjectRelayService. listReceivers
+// supplies the receiver streams resolution searches (typically
+// StreamService.ListReceiverStreams); resolve fetches an upstream's discovery
+// and credential.
+func NewSubjectRelayService(listReceivers func(ctx context.Context) ([]model.StreamStateRecord, error), resolve UpstreamResolver) *SubjectRelayService {
+    return &SubjectRelayService{listReceivers: listReceivers, resolve: resolve}
+}
+
+// Relay relays a subject change for the downstream transmitter stream to its
+// upstream transmitter — the PASSTHRU path of issue #95. It resolves the
+// feeding receiver stream, fetches the upstream connection, and posts the
+// Add/Remove carrying the upstream's assigned stream id.
+func (s *SubjectRelayService) Relay(ctx context.Context, downstream *model.StreamStateRecord, subject *goSet.SubjectIdentifier, verified, add bool) error {
+    receivers, err := s.listReceivers(ctx)
+    if err != nil {
+        return err
+    }
+    target, err := ResolveRelayTarget(downstream, receivers)
+    if err != nil {
+        return err
+    }
+    conn, err := s.resolve(ctx, target)
+    if err != nil {
+        return err
+    }
+    defer conn.release()
+    remoteStreamID := ""
+    if target.RemoteStreamId != nil {
+        remoteStreamID = *target.RemoteStreamId
+    }
+    return RelaySubjectChange(ctx, conn.HttpClient, conn.Config, conn.AuthHeader, remoteStreamID, subject, verified, add)
+}
+
+// ValidateConfig checks a downstream transmitter stream's subject-filter mode
+// against its upstream at config time. A PASSTHRU/HYBRID stream with no
+// resolvable relay target, or whose upstream advertises no subject endpoints,
+// is rejected; a LOCAL stream is never rejected but may earn a WARN.
+func (s *SubjectRelayService) ValidateConfig(ctx context.Context, downstream *model.StreamStateRecord) RelayConfigVerdict {
+    mode := downstream.SubjectFilterMode
+    if mode == "" {
+        return RelayConfigVerdict{}
+    }
+    receivers, err := s.listReceivers(ctx)
+    if err != nil {
+        return RelayConfigVerdict{Err: err}
+    }
+    target, err := ResolveRelayTarget(downstream, receivers)
+    if err != nil {
+        // PASSTHRU/HYBRID must relay, so an unresolved target is fatal; LOCAL
+        // does not relay and tolerates having no upstream subject handler.
+        if mode == model.SubjectFilterModePassthru || mode == model.SubjectFilterModeHybrid {
+            return RelayConfigVerdict{Err: err}
+        }
+        return RelayConfigVerdict{}
+    }
+    conn, err := s.resolve(ctx, target)
+    if err != nil {
+        return RelayConfigVerdict{Err: err}
+    }
+    defer conn.release()
+    return ClassifyUpstreamSupport(mode, conn.Config)
+}
+
+// ResolveRelayTarget finds the receiver stream that feeds a downstream
+// transmitter stream's events — the upstream a PASSTHRU/HYBRID subject change
+// must relay to (issue #95). receivers is the caller's set of receiver streams
+// (model.StreamStateRecord.IsReceiver()).
+//
+// An explicitly named Subject handler SID (downstream.EventSource.SourceStreamIds)
+// always wins. Otherwise an AUDIENCE-routed stream is resolved by matching the
+// downstream issuer against each receiver's issuer; several issuer matches make
+// the target ambiguous.
+func ResolveRelayTarget(downstream *model.StreamStateRecord, receivers []model.StreamStateRecord) (*model.StreamStateRecord, error) {
+    // An explicitly named Subject handler SID resolves the target directly.
+    if downstream.EventSource != nil && len(downstream.EventSource.SourceStreamIds) > 0 {
+        sid := downstream.EventSource.SourceStreamIds[0]
+        for i := range receivers {
+            if receivers[i].StreamConfiguration.Id == sid {
+                return &receivers[i], nil
+            }
+        }
+        return nil, ErrRelayTargetNotFound
+    }
+    var matches []*model.StreamStateRecord
+    for i := range receivers {
+        if receivers[i].StreamConfiguration.Iss == downstream.StreamConfiguration.Iss {
+            matches = append(matches, &receivers[i])
+        }
+    }
+    switch len(matches) {
+    case 0:
+        return nil, ErrRelayTargetNotFound
+    case 1:
+        return matches[0], nil
+    default:
+        return nil, ErrRelayTargetAmbiguous
+    }
+}

--- a/internal/services/subject_relay_hybrid_test.go
+++ b/internal/services/subject_relay_hybrid_test.go
@@ -1,0 +1,175 @@
+package services
+
+import (
+    "context"
+    "net/http"
+    "testing"
+
+    "github.com/i2-open/i2goSignals/pkg/goSet"
+    model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+)
+
+// noneUpstreamReceiver builds a receiver stream that feeds a HYBRID downstream
+// and whose upstream applies a defaultSubjects=NONE baseline — the only
+// baseline against which HYBRID engages its upstream relay (issue #96).
+func noneUpstreamReceiver(id, iss, remoteId string) model.StreamStateRecord {
+    rx := relayReceiverWithRemoteId(id, iss, remoteId)
+    rx.DefaultSubjects = model.DefaultSubjectsNone
+    return rx
+}
+
+// hybridDownstream builds an AUDIENCE-routed HYBRID transmitter stream with the
+// given id and issuer.
+func hybridDownstream(id, iss string) *model.StreamStateRecord {
+    st := relayDownstream(iss, &model.EventSource{Type: model.EventSourceAudience})
+    st.StreamConfiguration.Id = id
+    st.SubjectFilterMode = model.SubjectFilterModeHybrid
+    return st
+}
+
+// hybridRelayService wires a SubjectRelayService for HYBRID relay tests: a
+// fixed receiver and downstream-stream list, an upstream connection, and an
+// interested-set predicate evaluated per downstream stream.
+func hybridRelayService(receivers, transmitters []model.StreamStateRecord, conn *UpstreamConn, interested func(*model.StreamStateRecord) bool) *SubjectRelayService {
+    return &SubjectRelayService{
+        listReceivers:    func(context.Context) ([]model.StreamStateRecord, error) { return receivers, nil },
+        resolve:          func(context.Context, *model.StreamStateRecord) (*UpstreamConn, error) { return conn, nil },
+        listTransmitters: func(context.Context) ([]model.StreamStateRecord, error) { return transmitters, nil },
+        interested: func(_ context.Context, st *model.StreamStateRecord, _ *goSet.SubjectIdentifier) bool {
+            return interested(st)
+        },
+    }
+}
+
+// TestRelayHybrid_AddRelaysOnZeroToOneTransition is the tracer bullet for issue
+// #96: a HYBRID add against a NONE upstream, when no other downstream is yet
+// interested in the subject, relays the add upstream (the 0→1 transition).
+func TestRelayHybrid_AddRelaysOnZeroToOneTransition(t *testing.T) {
+    srv, got := upstreamRelayServer(t, http.StatusOK)
+    upstream := &model.TransmitterConfiguration{
+        AddSubjectEndpoint:    srv.URL + "/add-subject",
+        RemoveSubjectEndpoint: srv.URL + "/remove-subject",
+    }
+    receivers := []model.StreamStateRecord{noneUpstreamReceiver("rx-1", "https://issuer.example", "remote-7")}
+    downstream := hybridDownstream("tx-1", "https://issuer.example")
+    transmitters := []model.StreamStateRecord{*downstream}
+    relaySvc := hybridRelayService(receivers, transmitters,
+        &UpstreamConn{Config: upstream, HttpClient: srv.Client()},
+        func(*model.StreamStateRecord) bool { return false })
+
+    if err := relaySvc.RelayHybrid(context.Background(), downstream, emailSubject("alice@example.com"), true, true); err != nil {
+        t.Fatalf("RelayHybrid: %v", err)
+    }
+    if got.path != "/add-subject" {
+        t.Fatalf("expected a 0→1 add to relay POST /add-subject, got %q", got.path)
+    }
+    if got.body["stream_id"] != "remote-7" {
+        t.Fatalf("expected the relay to carry the upstream stream id remote-7, got %v", got.body["stream_id"])
+    }
+}
+
+// TestRelayHybrid_AddSuppressedWhenSiblingInterested verifies that a HYBRID add
+// does not relay upstream when another downstream fed by the same subject
+// handler is already interested in the subject — the interested-set was
+// already ≥1, so this is not a 0→1 transition.
+func TestRelayHybrid_AddSuppressedWhenSiblingInterested(t *testing.T) {
+    srv, got := upstreamRelayServer(t, http.StatusOK)
+    upstream := &model.TransmitterConfiguration{
+        AddSubjectEndpoint:    srv.URL + "/add-subject",
+        RemoveSubjectEndpoint: srv.URL + "/remove-subject",
+    }
+    receivers := []model.StreamStateRecord{noneUpstreamReceiver("rx-1", "https://issuer.example", "remote-7")}
+    downstream := hybridDownstream("tx-1", "https://issuer.example")
+    sibling := hybridDownstream("tx-2", "https://issuer.example")
+    transmitters := []model.StreamStateRecord{*downstream, *sibling}
+    // The sibling tx-2 already selects the subject.
+    relaySvc := hybridRelayService(receivers, transmitters,
+        &UpstreamConn{Config: upstream, HttpClient: srv.Client()},
+        func(st *model.StreamStateRecord) bool { return st.StreamConfiguration.Id == "tx-2" })
+
+    if err := relaySvc.RelayHybrid(context.Background(), downstream, emailSubject("alice@example.com"), true, true); err != nil {
+        t.Fatalf("RelayHybrid: %v", err)
+    }
+    if got.path != "" {
+        t.Fatalf("expected no relay when a sibling is already interested, got POST %q", got.path)
+    }
+}
+
+// TestRelayHybrid_RemoveRelaysOnOneToZeroTransition verifies that a HYBRID
+// remove relays upstream when no other downstream remains interested in the
+// subject — the last interested downstream dropping it (the 1→0 transition).
+func TestRelayHybrid_RemoveRelaysOnOneToZeroTransition(t *testing.T) {
+    srv, got := upstreamRelayServer(t, http.StatusNoContent)
+    upstream := &model.TransmitterConfiguration{
+        AddSubjectEndpoint:    srv.URL + "/add-subject",
+        RemoveSubjectEndpoint: srv.URL + "/remove-subject",
+    }
+    receivers := []model.StreamStateRecord{noneUpstreamReceiver("rx-1", "https://issuer.example", "remote-7")}
+    downstream := hybridDownstream("tx-1", "https://issuer.example")
+    transmitters := []model.StreamStateRecord{*downstream}
+    // downstream's own filter entry has already been removed by the caller, so
+    // no downstream remains interested.
+    relaySvc := hybridRelayService(receivers, transmitters,
+        &UpstreamConn{Config: upstream, HttpClient: srv.Client()},
+        func(*model.StreamStateRecord) bool { return false })
+
+    if err := relaySvc.RelayHybrid(context.Background(), downstream, emailSubject("alice@example.com"), false, false); err != nil {
+        t.Fatalf("RelayHybrid: %v", err)
+    }
+    if got.path != "/remove-subject" {
+        t.Fatalf("expected a 1→0 remove to relay POST /remove-subject, got %q", got.path)
+    }
+}
+
+// TestRelayHybrid_RemoveSuppressedWhenSiblingInterested verifies that a HYBRID
+// remove does not relay upstream while another downstream fed by the same
+// subject handler is still interested — one downstream's remove must never
+// starve another (issue #96 acceptance criterion 4).
+func TestRelayHybrid_RemoveSuppressedWhenSiblingInterested(t *testing.T) {
+    srv, got := upstreamRelayServer(t, http.StatusNoContent)
+    upstream := &model.TransmitterConfiguration{
+        AddSubjectEndpoint:    srv.URL + "/add-subject",
+        RemoveSubjectEndpoint: srv.URL + "/remove-subject",
+    }
+    receivers := []model.StreamStateRecord{noneUpstreamReceiver("rx-1", "https://issuer.example", "remote-7")}
+    downstream := hybridDownstream("tx-1", "https://issuer.example")
+    sibling := hybridDownstream("tx-2", "https://issuer.example")
+    transmitters := []model.StreamStateRecord{*downstream, *sibling}
+    relaySvc := hybridRelayService(receivers, transmitters,
+        &UpstreamConn{Config: upstream, HttpClient: srv.Client()},
+        func(st *model.StreamStateRecord) bool { return st.StreamConfiguration.Id == "tx-2" })
+
+    if err := relaySvc.RelayHybrid(context.Background(), downstream, emailSubject("alice@example.com"), false, false); err != nil {
+        t.Fatalf("RelayHybrid: %v", err)
+    }
+    if got.path != "" {
+        t.Fatalf("expected no relay while a sibling is still interested, got POST %q", got.path)
+    }
+}
+
+// TestRelayHybrid_AllUpstreamNeverRelays verifies that against an ALL upstream
+// HYBRID performs no relay at all — it behaves as pure local filtering, since
+// relaying a remove could starve a not-yet-created downstream (issue #96
+// acceptance criterion 5).
+func TestRelayHybrid_AllUpstreamNeverRelays(t *testing.T) {
+    srv, got := upstreamRelayServer(t, http.StatusOK)
+    upstream := &model.TransmitterConfiguration{
+        AddSubjectEndpoint:    srv.URL + "/add-subject",
+        RemoveSubjectEndpoint: srv.URL + "/remove-subject",
+    }
+    // An ALL upstream: the relay-target receiver carries no NONE baseline.
+    receivers := []model.StreamStateRecord{relayReceiverWithRemoteId("rx-1", "https://issuer.example", "remote-7")}
+    receivers[0].DefaultSubjects = model.DefaultSubjectsAll
+    downstream := hybridDownstream("tx-1", "https://issuer.example")
+    transmitters := []model.StreamStateRecord{*downstream}
+    relaySvc := hybridRelayService(receivers, transmitters,
+        &UpstreamConn{Config: upstream, HttpClient: srv.Client()},
+        func(*model.StreamStateRecord) bool { return false })
+
+    if err := relaySvc.RelayHybrid(context.Background(), downstream, emailSubject("alice@example.com"), true, true); err != nil {
+        t.Fatalf("RelayHybrid: %v", err)
+    }
+    if got.path != "" {
+        t.Fatalf("expected no relay against an ALL upstream, got POST %q", got.path)
+    }
+}

--- a/internal/services/subject_relay_test.go
+++ b/internal/services/subject_relay_test.go
@@ -1,0 +1,385 @@
+package services
+
+import (
+    "context"
+    "encoding/json"
+    "errors"
+    "io"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+
+    model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+)
+
+// relayReceiver builds a receiver stream record carrying only the fields the
+// relay-target resolver reads: the stream id and the upstream issuer.
+func relayReceiver(id, iss string) model.StreamStateRecord {
+    var st model.StreamStateRecord
+    st.StreamConfiguration.Id = id
+    st.StreamConfiguration.Iss = iss
+    return st
+}
+
+// relayDownstream builds a downstream transmitter stream with the given
+// issuer and event source.
+func relayDownstream(iss string, src *model.EventSource) *model.StreamStateRecord {
+    st := &model.StreamStateRecord{EventSource: src}
+    st.StreamConfiguration.Iss = iss
+    return st
+}
+
+// TestResolveRelayTarget_AudienceSingleIssuerMatch is the tracer bullet for
+// issue #95: an AUDIENCE-routed transmitter stream resolves its relay target
+// by matching its issuer to exactly one receiver stream's issuer.
+func TestResolveRelayTarget_AudienceSingleIssuerMatch(t *testing.T) {
+    receivers := []model.StreamStateRecord{
+        relayReceiver("rx-1", "https://issuer.example/a"),
+        relayReceiver("rx-2", "https://issuer.example/b"),
+    }
+    downstream := relayDownstream("https://issuer.example/b", &model.EventSource{Type: model.EventSourceAudience})
+
+    target, err := ResolveRelayTarget(downstream, receivers)
+    if err != nil {
+        t.Fatalf("ResolveRelayTarget: %v", err)
+    }
+    if target.StreamConfiguration.Id != "rx-2" {
+        t.Fatalf("expected relay target rx-2, got %q", target.StreamConfiguration.Id)
+    }
+}
+
+// TestResolveRelayTarget_AudienceAmbiguous verifies that when several receiver
+// streams share the downstream issuer the relay target is ambiguous and config
+// must be rejected (#95 acceptance criterion 4).
+func TestResolveRelayTarget_AudienceAmbiguous(t *testing.T) {
+    receivers := []model.StreamStateRecord{
+        relayReceiver("rx-1", "https://issuer.example/shared"),
+        relayReceiver("rx-2", "https://issuer.example/shared"),
+    }
+    downstream := relayDownstream("https://issuer.example/shared", &model.EventSource{Type: model.EventSourceAudience})
+
+    _, err := ResolveRelayTarget(downstream, receivers)
+    if !errors.Is(err, ErrRelayTargetAmbiguous) {
+        t.Fatalf("expected ErrRelayTargetAmbiguous, got %v", err)
+    }
+}
+
+// TestResolveRelayTarget_ExplicitHandlerSidWins verifies that an explicitly
+// named Subject handler SID (EventSource.SourceStreamIds) resolves the relay
+// target directly, even when the issuer match would otherwise be ambiguous
+// (#95 acceptance criterion 2).
+func TestResolveRelayTarget_ExplicitHandlerSidWins(t *testing.T) {
+    receivers := []model.StreamStateRecord{
+        relayReceiver("rx-1", "https://issuer.example/shared"),
+        relayReceiver("rx-2", "https://issuer.example/shared"),
+    }
+    downstream := relayDownstream("https://issuer.example/shared", &model.EventSource{
+        Type:            model.EventSourceExplicit,
+        SourceStreamIds: []string{"rx-2"},
+    })
+
+    target, err := ResolveRelayTarget(downstream, receivers)
+    if err != nil {
+        t.Fatalf("ResolveRelayTarget: %v", err)
+    }
+    if target.StreamConfiguration.Id != "rx-2" {
+        t.Fatalf("expected explicitly named relay target rx-2, got %q", target.StreamConfiguration.Id)
+    }
+}
+
+// TestResolveRelayTarget_NoMatch verifies that a downstream issuer with no
+// matching receiver stream yields ErrRelayTargetNotFound.
+func TestResolveRelayTarget_NoMatch(t *testing.T) {
+    receivers := []model.StreamStateRecord{
+        relayReceiver("rx-1", "https://issuer.example/a"),
+    }
+    downstream := relayDownstream("https://issuer.example/unknown", &model.EventSource{Type: model.EventSourceAudience})
+
+    _, err := ResolveRelayTarget(downstream, receivers)
+    if !errors.Is(err, ErrRelayTargetNotFound) {
+        t.Fatalf("expected ErrRelayTargetNotFound, got %v", err)
+    }
+}
+
+// TestClassifyUpstreamSupport_PassthruNoEndpointsRejected verifies that a
+// PASSTHRU stream against an upstream that advertises no subject endpoints is
+// rejected at config time (#95 acceptance criterion 3).
+func TestClassifyUpstreamSupport_PassthruNoEndpointsRejected(t *testing.T) {
+    upstream := &model.TransmitterConfiguration{Issuer: "https://issuer.example"}
+
+    verdict := ClassifyUpstreamSupport(model.SubjectFilterModePassthru, upstream)
+    if verdict.Err == nil {
+        t.Fatal("PASSTHRU against an upstream with no subject endpoints must be rejected")
+    }
+}
+
+// upstreamWithEndpoints builds an upstream discovery record that advertises the
+// add and remove subject endpoints.
+func upstreamWithEndpoints() *model.TransmitterConfiguration {
+    return &model.TransmitterConfiguration{
+        Issuer:                "https://issuer.example",
+        AddSubjectEndpoint:    "https://issuer.example/add-subject",
+        RemoveSubjectEndpoint: "https://issuer.example/remove-subject",
+    }
+}
+
+// TestClassifyUpstreamSupport_PassthruWithEndpointsAccepted verifies that a
+// PASSTHRU stream against an upstream that advertises both subject endpoints is
+// accepted with no error and no warning.
+func TestClassifyUpstreamSupport_PassthruWithEndpointsAccepted(t *testing.T) {
+    verdict := ClassifyUpstreamSupport(model.SubjectFilterModePassthru, upstreamWithEndpoints())
+    if verdict.Err != nil {
+        t.Fatalf("PASSTHRU against a filtering-capable upstream must be accepted: %v", verdict.Err)
+    }
+    if verdict.Warn != "" {
+        t.Fatalf("expected no warning, got %q", verdict.Warn)
+    }
+}
+
+// TestClassifyUpstreamSupport_LocalNoEndpointsWarns verifies that a LOCAL
+// stream against an upstream with no subject endpoints is survivable: it earns
+// a WARN, not a rejection (#95 acceptance criterion 5).
+func TestClassifyUpstreamSupport_LocalNoEndpointsWarns(t *testing.T) {
+    upstream := &model.TransmitterConfiguration{Issuer: "https://issuer.example"}
+
+    verdict := ClassifyUpstreamSupport(model.SubjectFilterModeLocal, upstream)
+    if verdict.Err != nil {
+        t.Fatalf("LOCAL must never be rejected at config time: %v", verdict.Err)
+    }
+    if verdict.Warn == "" {
+        t.Fatal("LOCAL against a non-filtering upstream must produce a WARN")
+    }
+}
+
+// capturedRelay records what an upstream subject endpoint received.
+type capturedRelay struct {
+    method string
+    path   string
+    auth   string
+    body   map[string]interface{}
+}
+
+// upstreamRelayServer starts a fake upstream that records add/remove-subject
+// calls and replies with status.
+func upstreamRelayServer(t *testing.T, status int) (*httptest.Server, *capturedRelay) {
+    t.Helper()
+    got := &capturedRelay{}
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        got.method = r.Method
+        got.path = r.URL.Path
+        got.auth = r.Header.Get("Authorization")
+        raw, _ := io.ReadAll(r.Body)
+        _ = json.Unmarshal(raw, &got.body)
+        w.WriteHeader(status)
+    }))
+    t.Cleanup(srv.Close)
+    return srv, got
+}
+
+// TestRelaySubjectChange_AddPostsToAddEndpoint is the tracer bullet for the
+// PASSTHRU relay (#95 acceptance criterion 1): an Add Subject relays a POST to
+// the upstream's add_subject_endpoint carrying the remote stream id, subject
+// and verified flag, with the upstream credential.
+func TestRelaySubjectChange_AddPostsToAddEndpoint(t *testing.T) {
+    srv, got := upstreamRelayServer(t, http.StatusOK)
+    upstream := &model.TransmitterConfiguration{
+        AddSubjectEndpoint:    srv.URL + "/add-subject",
+        RemoveSubjectEndpoint: srv.URL + "/remove-subject",
+    }
+    subject := emailSubject("alice@example.com")
+
+    err := RelaySubjectChange(context.Background(), srv.Client(), upstream, "Bearer up-token", "remote-99", subject, true, true)
+    if err != nil {
+        t.Fatalf("RelaySubjectChange: %v", err)
+    }
+    if got.method != http.MethodPost || got.path != "/add-subject" {
+        t.Fatalf("expected POST /add-subject, got %s %s", got.method, got.path)
+    }
+    if got.auth != "Bearer up-token" {
+        t.Fatalf("expected upstream credential to be forwarded, got %q", got.auth)
+    }
+    if got.body["stream_id"] != "remote-99" {
+        t.Fatalf("expected relayed stream_id remote-99, got %v", got.body["stream_id"])
+    }
+    if got.body["verified"] != true {
+        t.Fatalf("expected verified=true relayed, got %v", got.body["verified"])
+    }
+    if got.body["subject"] == nil {
+        t.Fatal("expected the subject identifier to be relayed")
+    }
+}
+
+// TestRelaySubjectChange_RemovePostsToRemoveEndpoint verifies a Remove Subject
+// relays a POST to the upstream's remove_subject_endpoint.
+func TestRelaySubjectChange_RemovePostsToRemoveEndpoint(t *testing.T) {
+    srv, got := upstreamRelayServer(t, http.StatusNoContent)
+    upstream := &model.TransmitterConfiguration{
+        AddSubjectEndpoint:    srv.URL + "/add-subject",
+        RemoveSubjectEndpoint: srv.URL + "/remove-subject",
+    }
+
+    err := RelaySubjectChange(context.Background(), srv.Client(), upstream, "Bearer up-token", "remote-99", emailSubject("alice@example.com"), false, false)
+    if err != nil {
+        t.Fatalf("RelaySubjectChange: %v", err)
+    }
+    if got.method != http.MethodPost || got.path != "/remove-subject" {
+        t.Fatalf("expected POST /remove-subject, got %s %s", got.method, got.path)
+    }
+}
+
+// TestRelaySubjectChange_UpstreamErrorStatusReturnsError verifies that a
+// non-2xx upstream response surfaces as an error so the caller can refuse the
+// subject change rather than silently dropping the relay.
+func TestRelaySubjectChange_UpstreamErrorStatusReturnsError(t *testing.T) {
+    srv, _ := upstreamRelayServer(t, http.StatusBadRequest)
+    upstream := &model.TransmitterConfiguration{
+        AddSubjectEndpoint:    srv.URL + "/add-subject",
+        RemoveSubjectEndpoint: srv.URL + "/remove-subject",
+    }
+
+    err := RelaySubjectChange(context.Background(), srv.Client(), upstream, "Bearer up-token", "remote-99", emailSubject("alice@example.com"), false, true)
+    if err == nil {
+        t.Fatal("a non-2xx upstream response must surface as an error")
+    }
+}
+
+// relayServiceWith builds a SubjectRelayService over a fixed receiver-stream
+// list and upstream connection — the fixture for service-level relay tests.
+func relayServiceWith(receivers []model.StreamStateRecord, conn *UpstreamConn) *SubjectRelayService {
+    return &SubjectRelayService{
+        listReceivers: func(context.Context) ([]model.StreamStateRecord, error) {
+            return receivers, nil
+        },
+        resolve: func(context.Context, *model.StreamStateRecord) (*UpstreamConn, error) {
+            return conn, nil
+        },
+    }
+}
+
+// relayReceiverWithRemoteId builds a receiver stream carrying the upstream's
+// assigned stream id.
+func relayReceiverWithRemoteId(id, iss, remoteId string) model.StreamStateRecord {
+    rx := relayReceiver(id, iss)
+    rx.StreamConfiguration.RemoteStreamId = &remoteId
+    return rx
+}
+
+// TestSubjectRelayService_Relay_PassthruPostsUpstream verifies that Relay
+// resolves the feeding receiver stream and posts the subject change to the
+// upstream carrying the upstream's assigned stream id (#95 criterion 1).
+func TestSubjectRelayService_Relay_PassthruPostsUpstream(t *testing.T) {
+    srv, got := upstreamRelayServer(t, http.StatusOK)
+    upstream := &model.TransmitterConfiguration{
+        AddSubjectEndpoint:    srv.URL + "/add-subject",
+        RemoveSubjectEndpoint: srv.URL + "/remove-subject",
+    }
+    receivers := []model.StreamStateRecord{relayReceiverWithRemoteId("rx-1", "https://issuer.example", "remote-7")}
+    relaySvc := relayServiceWith(receivers, &UpstreamConn{Config: upstream, HttpClient: srv.Client()})
+
+    downstream := relayDownstream("https://issuer.example", &model.EventSource{Type: model.EventSourceAudience})
+    if err := relaySvc.Relay(context.Background(), downstream, emailSubject("alice@example.com"), false, true); err != nil {
+        t.Fatalf("Relay: %v", err)
+    }
+    if got.path != "/add-subject" {
+        t.Fatalf("expected relay to POST /add-subject, got %s", got.path)
+    }
+    if got.body["stream_id"] != "remote-7" {
+        t.Fatalf("expected relay to carry the upstream stream id remote-7, got %v", got.body["stream_id"])
+    }
+}
+
+// TestSubjectRelayService_ValidateConfig_PassthruAmbiguousRejected verifies
+// that a PASSTHRU stream whose relay target is ambiguous is rejected at config
+// time (#95 acceptance criterion 4).
+func TestSubjectRelayService_ValidateConfig_PassthruAmbiguousRejected(t *testing.T) {
+    receivers := []model.StreamStateRecord{
+        relayReceiver("rx-1", "https://issuer.example/shared"),
+        relayReceiver("rx-2", "https://issuer.example/shared"),
+    }
+    relaySvc := relayServiceWith(receivers, nil)
+
+    downstream := relayDownstream("https://issuer.example/shared", &model.EventSource{Type: model.EventSourceAudience})
+    downstream.SubjectFilterMode = model.SubjectFilterModePassthru
+
+    verdict := relaySvc.ValidateConfig(context.Background(), downstream)
+    if !errors.Is(verdict.Err, ErrRelayTargetAmbiguous) {
+        t.Fatalf("expected an ambiguous PASSTHRU target to be rejected, got %v", verdict.Err)
+    }
+}
+
+// TestSubjectRelayService_ValidateConfig_LocalNoEndpointsWarns verifies a
+// LOCAL stream against an upstream that advertises no subject endpoints is
+// survivable: a WARN, not a rejection (#95 acceptance criterion 5).
+func TestSubjectRelayService_ValidateConfig_LocalNoEndpointsWarns(t *testing.T) {
+    receivers := []model.StreamStateRecord{relayReceiver("rx-1", "https://issuer.example")}
+    upstream := &model.TransmitterConfiguration{Issuer: "https://issuer.example"}
+    relaySvc := relayServiceWith(receivers, &UpstreamConn{Config: upstream})
+
+    downstream := relayDownstream("https://issuer.example", &model.EventSource{Type: model.EventSourceAudience})
+    downstream.SubjectFilterMode = model.SubjectFilterModeLocal
+
+    verdict := relaySvc.ValidateConfig(context.Background(), downstream)
+    if verdict.Err != nil {
+        t.Fatalf("LOCAL must never be rejected at config time: %v", verdict.Err)
+    }
+    if verdict.Warn == "" {
+        t.Fatal("LOCAL against a non-filtering upstream must produce a WARN")
+    }
+}
+
+// nonFilteringRelayService builds a SubjectRelayService whose single upstream
+// advertises no subject endpoints — the fixture for config-time CreateStream
+// validation tests.
+func nonFilteringRelayService() *SubjectRelayService {
+    receivers := []model.StreamStateRecord{relayReceiver("rx-1", "test-issuer")}
+    return &SubjectRelayService{
+        listReceivers: func(context.Context) ([]model.StreamStateRecord, error) {
+            return receivers, nil
+        },
+        resolve: func(context.Context, *model.StreamStateRecord) (*UpstreamConn, error) {
+            return &UpstreamConn{Config: &model.TransmitterConfiguration{Issuer: "test-issuer"}}, nil
+        },
+    }
+}
+
+// TestStreamService_CreatePassthruRejectedWhenUpstreamLacksEndpoints verifies
+// that CreateStream rejects a PASSTHRU transmitter stream whose upstream
+// advertises no subject endpoints (#95 acceptance criterion 3).
+func TestStreamService_CreatePassthruRejectedWhenUpstreamLacksEndpoints(t *testing.T) {
+    t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+    svc := newSubjectFilterTestService()
+    svc.SetSubjectRelayService(nonFilteringRelayService())
+
+    req := pushTransmitterRequest()
+    req.SubjectFilterMode = model.SubjectFilterModePassthru
+    req.EventSource = &model.EventSource{Type: model.EventSourceAudience}
+
+    if _, err := svc.CreateStream(context.Background(), req, "test-project", nil); err == nil {
+        t.Fatal("CreateStream must reject PASSTHRU against a non-filtering upstream")
+    }
+}
+
+// TestStreamService_CreateLocalSurvivesNonFilteringUpstream verifies that a
+// LOCAL transmitter stream against a non-filtering upstream is still created —
+// the misconfiguration is survivable (#95 acceptance criterion 5).
+func TestStreamService_CreateLocalSurvivesNonFilteringUpstream(t *testing.T) {
+    t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+    svc := newSubjectFilterTestService()
+    svc.SetSubjectRelayService(nonFilteringRelayService())
+
+    req := pushTransmitterRequest()
+    req.SubjectFilterMode = model.SubjectFilterModeLocal
+    req.EventSource = &model.EventSource{Type: model.EventSourceAudience}
+
+    created, err := svc.CreateStream(context.Background(), req, "test-project", nil)
+    if err != nil {
+        t.Fatalf("CreateStream must still create a LOCAL stream: %v", err)
+    }
+    state, err := svc.GetStreamState(context.Background(), created.Id)
+    if err != nil {
+        t.Fatalf("GetStreamState: %v", err)
+    }
+    if state.SubjectFilterMode != model.SubjectFilterModeLocal {
+        t.Fatalf("expected the LOCAL stream to persist, got mode %q", state.SubjectFilterMode)
+    }
+}

--- a/pkg/goSet/set.go
+++ b/pkg/goSet/set.go
@@ -53,6 +53,24 @@ type SubIdentifier struct {
 	Sub string `json:"sub,omitempty"`
 }
 
+// AliasesIdentifier carries the RFC9493 §3.2.8 "aliases" format: a set of
+// subject identifiers that all refer to the same principal.
+type AliasesIdentifier struct {
+	Identifiers []SubjectIdentifier `json:"identifiers,omitempty"`
+}
+
+// ComplexIdentifier carries the SSF §8.1.3 complex-subject members. Each member
+// is itself a (simple) subject identifier; an absent member is a wildcard
+// during §8.1.3.1 matching.
+type ComplexIdentifier struct {
+	User    *SubjectIdentifier `json:"user,omitempty"`
+	Group   *SubjectIdentifier `json:"group,omitempty"`
+	Device  *SubjectIdentifier `json:"device,omitempty"`
+	Session *SubjectIdentifier `json:"session,omitempty"`
+	Tenant  *SubjectIdentifier `json:"tenant,omitempty"`
+	OrgUnit *SubjectIdentifier `json:"org_unit,omitempty"`
+}
+
 type EventSubject struct {
 	SubIdentifier     // Supports top-level sub claim
 	SubjectIdentifier // Used for draft-ietf-secevent-subject-identifier format
@@ -68,6 +86,8 @@ type SubjectIdentifier struct {
 	DecentralizedIdentifier
 	UniformResourceIdentifier
 	ExternalIdentifier
+	AliasesIdentifier
+	ComplexIdentifier
 }
 
 func (sid *SubjectIdentifier) AddUsername(username string) *SubjectIdentifier {

--- a/pkg/goSet/test/set_test.go
+++ b/pkg/goSet/test/set_test.go
@@ -214,6 +214,32 @@ func TestSetJws(t *testing.T) {
 
 }
 
+// TestSubjectIdentifierAliasesFormat verifies goSet.SubjectIdentifier supports
+// the RFC9493 §3.2.8 "aliases" format through a JSON round-trip.
+func TestSubjectIdentifierAliasesFormat(t *testing.T) {
+	original := goSet.SubjectIdentifier{
+		Format: "aliases",
+		AliasesIdentifier: goSet.AliasesIdentifier{
+			Identifiers: []goSet.SubjectIdentifier{
+				{Format: "email", EmailIdentifier: goSet.EmailIdentifier{Email: "alice@example.com"}},
+				{Format: "phone_number", PhoneNumberIdentifier: goSet.PhoneNumberIdentifier{PhoneNumber: "+16045551212"}},
+			},
+		},
+	}
+
+	encoded, err := json.Marshal(original)
+	assert.NoError(t, err, "aliases subject marshals to JSON")
+	assert.Contains(t, string(encoded), `"identifiers"`, "JSON carries the identifiers member")
+
+	var decoded goSet.SubjectIdentifier
+	err = json.Unmarshal(encoded, &decoded)
+	assert.NoError(t, err, "aliases subject unmarshals from JSON")
+	assert.Equal(t, "aliases", decoded.Format)
+	assert.Len(t, decoded.Identifiers, 2)
+	assert.Equal(t, "alice@example.com", decoded.Identifiers[0].Email)
+	assert.Equal(t, "+16045551212", decoded.Identifiers[1].PhoneNumber)
+}
+
 /*
 func TestSetJws(t *testing.T) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)

--- a/pkg/goSsfServer/ssf-application.go
+++ b/pkg/goSsfServer/ssf-application.go
@@ -36,6 +36,7 @@ type SsfApplication struct {
 	ServerService        *services.ServerService
 	TokenService         *services.TokenService
 	SubjectFilterService *services.SubjectFilterService
+	SubjectRelayService  *services.SubjectRelayService
 	Server               *http.Server
 	Handler       http.Handler
 	EventRouter   eventRouter.EventRouter
@@ -57,6 +58,9 @@ func (sa *SsfApplication) GetServerService() *services.ServerService  { return s
 func (sa *SsfApplication) GetTokenService() *services.TokenService    { return sa.TokenService }
 func (sa *SsfApplication) GetSubjectFilterService() *services.SubjectFilterService {
 	return sa.SubjectFilterService
+}
+func (sa *SsfApplication) GetSubjectRelayService() *services.SubjectRelayService {
+	return sa.SubjectRelayService
 }
 func (sa *SsfApplication) GetCoordinator() cluster.ClusterCoordinator { return sa.Coordinator }
 func (sa *SsfApplication) GetStorage() storage.Storage                { return sa.Storage }
@@ -266,6 +270,7 @@ func NewApplication(persistence *dbProviders.Persistence, baseUrlString string) 
 		ServerService:        persistence.ServerService,
 		TokenService:         persistence.TokenService,
 		SubjectFilterService: persistence.SubjectFilterService,
+		SubjectRelayService:  persistence.SubjectRelayService,
 		AdminRole:            role,
 		NodeID:               nodeID,
 		StartedAt:            time.Now().UTC(),

--- a/pkg/goSsfServer/ssf-application.go
+++ b/pkg/goSsfServer/ssf-application.go
@@ -27,15 +27,16 @@ import (
 var serverLog = logger.Sub("SERVER")
 
 type SsfApplication struct {
-	Coordinator   cluster.ClusterCoordinator
-	Storage       storage.Storage
-	StreamService *services.StreamService
-	KeyService    *services.KeyService
-	EventService  *services.EventService
-	ClientService *services.ClientService
-	ServerService *services.ServerService
-	TokenService  *services.TokenService
-	Server        *http.Server
+	Coordinator          cluster.ClusterCoordinator
+	Storage              storage.Storage
+	StreamService        *services.StreamService
+	KeyService           *services.KeyService
+	EventService         *services.EventService
+	ClientService        *services.ClientService
+	ServerService        *services.ServerService
+	TokenService         *services.TokenService
+	SubjectFilterService *services.SubjectFilterService
+	Server               *http.Server
 	Handler       http.Handler
 	EventRouter   eventRouter.EventRouter
 	BaseUrl       *url.URL
@@ -54,6 +55,9 @@ func (sa *SsfApplication) GetEventService() *services.EventService    { return s
 func (sa *SsfApplication) GetClientService() *services.ClientService  { return sa.ClientService }
 func (sa *SsfApplication) GetServerService() *services.ServerService  { return sa.ServerService }
 func (sa *SsfApplication) GetTokenService() *services.TokenService    { return sa.TokenService }
+func (sa *SsfApplication) GetSubjectFilterService() *services.SubjectFilterService {
+	return sa.SubjectFilterService
+}
 func (sa *SsfApplication) GetCoordinator() cluster.ClusterCoordinator { return sa.Coordinator }
 func (sa *SsfApplication) GetStorage() storage.Storage                { return sa.Storage }
 
@@ -253,17 +257,18 @@ func NewApplication(persistence *dbProviders.Persistence, baseUrlString string) 
 	nodeID := nodeid.Resolve()
 
 	sa := &SsfApplication{
-		Coordinator:   persistence.Coordinator,
-		Storage:       persistence.Storage,
-		StreamService: persistence.StreamService,
-		KeyService:    persistence.KeyService,
-		EventService:  persistence.EventService,
-		ClientService: persistence.ClientService,
-		ServerService: persistence.ServerService,
-		TokenService:  persistence.TokenService,
-		AdminRole:     role,
-		NodeID:        nodeID,
-		StartedAt:     time.Now().UTC(),
+		Coordinator:          persistence.Coordinator,
+		Storage:              persistence.Storage,
+		StreamService:        persistence.StreamService,
+		KeyService:           persistence.KeyService,
+		EventService:         persistence.EventService,
+		ClientService:        persistence.ClientService,
+		ServerService:        persistence.ServerService,
+		TokenService:         persistence.TokenService,
+		SubjectFilterService: persistence.SubjectFilterService,
+		AdminRole:            role,
+		NodeID:               nodeID,
+		StartedAt:            time.Now().UTC(),
 	}
 
 	if sa.KeyService != nil {
@@ -277,11 +282,12 @@ func NewApplication(persistence *dbProviders.Persistence, baseUrlString string) 
 	sa.Handler = httpRouter.router
 
 	sa.EventRouter = eventRouter.NewRouter(eventRouter.RouterDeps{
-		StreamService: persistence.StreamService,
-		KeyService:    persistence.KeyService,
-		EventService:  persistence.EventService,
-		Coordinator:   persistence.Coordinator,
-		PushDelivery:  delivery.NewHTTPAdapter(persistence.StreamService, nil),
+		StreamService:        persistence.StreamService,
+		KeyService:           persistence.KeyService,
+		EventService:         persistence.EventService,
+		Coordinator:          persistence.Coordinator,
+		SubjectFilterService: persistence.SubjectFilterService,
+		PushDelivery:         delivery.NewHTTPAdapter(persistence.StreamService, nil),
 	}, nodeID)
 
 	var baseUrl *url.URL

--- a/pkg/ssfModels/model_stream_state.go
+++ b/pkg/ssfModels/model_stream_state.go
@@ -82,6 +82,42 @@ type StreamStateRecord struct {
 	ErrorMsg string `json:"reason,omitempty" bson:"error_msg,omitempty" json:"errorMsg,omitempty"`
 
 	RemoteAddress *RemoteIP `json:"remote_address,omitempty" bson:"remote_address,omitempty"`
+
+	// DefaultSubjects is the SSF subject-filtering baseline policy for a
+	// transmitter stream: DefaultSubjectsAll or DefaultSubjectsNone. It is a
+	// goSignals operator knob and is deliberately kept off the SSF wire-format
+	// StreamConfiguration. An empty value means the default (ALL).
+	DefaultSubjects string `json:"default_subjects,omitempty" bson:"default_subjects,omitempty"`
+
+	// SubjectFilterMode governs how a receiver stream relays subject changes to
+	// its upstream transmitter: SubjectFilterModePassthru, SubjectFilterModeLocal,
+	// or SubjectFilterModeHybrid.
+	SubjectFilterMode string `json:"subject_filter_mode,omitempty" bson:"subject_filter_mode,omitempty"`
+
+	// EventSource describes where a transmitter stream's events originate.
+	EventSource *EventSource `json:"event_source,omitempty" bson:"event_source,omitempty"`
+}
+
+// EventSource describes where a transmitter stream's events originate. This is
+// a distinct axis from RouteMode. Type is one of EventSourceDirect,
+// EventSourceAudience, or EventSourceExplicit; when EventSourceExplicit,
+// SourceStreamIds names the source stream SID(s).
+type EventSource struct {
+	Type            string   `json:"type,omitempty" bson:"type,omitempty"`
+	SourceStreamIds []string `json:"source_stream_ids,omitempty" bson:"source_stream_ids,omitempty"`
+}
+
+// DeepCopy returns an independent copy of the EventSource, or nil when es is nil.
+func (es *EventSource) DeepCopy() *EventSource {
+	if es == nil {
+		return nil
+	}
+	res := *es
+	if es.SourceStreamIds != nil {
+		res.SourceStreamIds = make([]string, len(es.SourceStreamIds))
+		copy(res.SourceStreamIds, es.SourceStreamIds)
+	}
+	return &res
 }
 
 func (ss *StreamStateRecord) DeepCopy() *StreamStateRecord {
@@ -90,6 +126,7 @@ func (ss *StreamStateRecord) DeepCopy() *StreamStateRecord {
 	}
 	res := *ss
 	res.StreamConfiguration = ss.StreamConfiguration.DeepCopy()
+	res.EventSource = ss.EventSource.DeepCopy()
 	return &res
 }
 
@@ -105,6 +142,9 @@ func (ss *StreamStateRecord) Update(mod *StreamStateRecord) {
 	ss.StartDate = mod.StartDate
 	ss.ModifiedAt = mod.ModifiedAt
 	ss.RemoteAddress = mod.RemoteAddress
+	ss.DefaultSubjects = mod.DefaultSubjects
+	ss.SubjectFilterMode = mod.SubjectFilterMode
+	ss.EventSource = mod.EventSource
 }
 
 // GetType returns the delivery method for the stream state record. Returns one of ReceivePush, ReceivePoll, DeliveryPush, DeliveryPoll.
@@ -155,4 +195,18 @@ const (
 	RouteModeImport     = "IM" // Indicates the router will not further propagate the event and save to database for local use
 	RouteModeForward    = "FW" // Indicates the router will move events received to other eligable streams
 	RouteModePublish    = "PB" // Indicates the router will router to target streams and generate new JWS/JWE tokens
+
+	// DefaultSubjects baseline policy values for a transmitter stream (SSF §8.1.3).
+	DefaultSubjectsAll  = "ALL"  // Deliver every subject unless explicitly removed
+	DefaultSubjectsNone = "NONE" // Deliver no subject unless explicitly added
+
+	// SubjectFilterMode values for a receiver stream: how subject changes relay upstream.
+	SubjectFilterModePassthru = "PASSTHRU" // Relay Add/Remove 1:1 upstream, no local filtering
+	SubjectFilterModeLocal    = "LOCAL"    // Filter locally per stream, never relay upstream
+	SubjectFilterModeHybrid   = "HYBRID"   // Relay upstream and filter locally
+
+	// EventSource Type values: where a transmitter stream's events originate.
+	EventSourceDirect   = "DIRECT"   // Events arrive directly on this stream
+	EventSourceAudience = "AUDIENCE" // Events routed in by audience matching
+	EventSourceExplicit = "EXPLICIT" // Events sourced from explicitly named stream SID(s)
 )

--- a/pkg/ssfModels/model_subject_filter_entry.go
+++ b/pkg/ssfModels/model_subject_filter_entry.go
@@ -1,0 +1,29 @@
+package model
+
+import "github.com/i2-open/i2goSignals/pkg/goSet"
+
+// Subject kinds for a SubjectFilterEntry, mirroring subjectid.SubjectKind. The
+// kind selects the ADR-0003 storage/match path: simple subjects are matched by
+// indexed canonical-key membership, complex subjects by a linear field-wise
+// scan.
+const (
+    SubjectKindSimple  = "simple"
+    SubjectKindComplex = "complex"
+    SubjectKindAliases = "aliases"
+)
+
+// SubjectFilterEntry is one row of a stream's SSF §8.1.3 subject filter: a
+// single subject the receiver has Added (on a NONE stream) or Removed (on an
+// ALL stream). The filter stores only the non-default set, so an entry always
+// carries the meaning opposite to the stream's DefaultSubjects baseline.
+//
+// CanonicalKey is the ADR-0003 canonical key (see pkg/subjectid) and is the
+// indexed lookup key for simple-subject membership. Verified is stored for
+// audit only and has no effect on filtering.
+type SubjectFilterEntry struct {
+    StreamId     string                   `json:"stream_id" bson:"stream_id"`
+    CanonicalKey string                   `json:"canonical_key" bson:"canonical_key"`
+    Kind         string                   `json:"kind" bson:"kind"`
+    Subject      *goSet.SubjectIdentifier `json:"subject" bson:"subject"`
+    Verified     bool                     `json:"verified,omitempty" bson:"verified,omitempty"`
+}

--- a/pkg/subjectid/subject.go
+++ b/pkg/subjectid/subject.go
@@ -1,0 +1,267 @@
+// Package subjectid is a pure, isolation-testable module for SSF subject
+// identity and matching. It normalizes RFC9493 subject identifiers to a
+// canonical filter key and implements the SSF §8.1.3.1 match predicate.
+//
+// The package is pure: no I/O, no DAO, no goSignals internal dependencies. It
+// is the spec-correctness foundation that PRD #89's SubjectFilterService and
+// the ADR-0003 split-storage model are built on.
+package subjectid
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/i2-open/i2goSignals/pkg/goSet"
+)
+
+// SubjectKind classifies a subject by how SSF §8.1.3.1 matches it: a simple
+// subject by exact identity, a complex subject field-wise, an aliases subject
+// as a set of equivalent identifiers.
+type SubjectKind int
+
+const (
+	KindSimple SubjectKind = iota
+	KindComplex
+	KindAliases
+)
+
+// orderedComplexMembers is the fixed iteration order of complex-subject
+// members, giving a complex subject a deterministic canonical key.
+var orderedComplexMembers = []string{"user", "group", "device", "session", "tenant", "org_unit"}
+
+// complexMember returns the named complex-subject member, or nil if undefined.
+func complexMember(sid *goSet.SubjectIdentifier, name string) *goSet.SubjectIdentifier {
+	switch name {
+	case "user":
+		return sid.User
+	case "group":
+		return sid.Group
+	case "device":
+		return sid.Device
+	case "session":
+		return sid.Session
+	case "tenant":
+		return sid.Tenant
+	case "org_unit":
+		return sid.OrgUnit
+	default:
+		return nil
+	}
+}
+
+// Kind classifies a subject as simple, complex, or aliases. A subject carrying
+// any complex member is complex; one in the aliases format is aliases;
+// otherwise it is simple.
+func Kind(sid *goSet.SubjectIdentifier) SubjectKind {
+	if sid == nil {
+		return KindSimple
+	}
+	if sid.Format == "aliases" || len(sid.Identifiers) > 0 {
+		return KindAliases
+	}
+	for _, name := range orderedComplexMembers {
+		if complexMember(sid, name) != nil {
+			return KindComplex
+		}
+	}
+	return KindSimple
+}
+
+// CanonicalKey normalizes a subject identifier to a stable canonical key. For a
+// simple subject the key is a single, format-prefixed string suitable for
+// hash-indexed membership (ADR-0003). Each RFC9493 format applies its own
+// normalization rules. Complex and aliases subjects normalize to a stable key
+// built from their members. It returns an error when the subject's format is
+// missing, unrecognized, or its required value is empty.
+func CanonicalKey(sid *goSet.SubjectIdentifier) (string, error) {
+	if sid == nil {
+		return "", fmt.Errorf("subject identifier is nil")
+	}
+
+	switch Kind(sid) {
+	case KindAliases:
+		return aliasesKey(sid)
+	case KindComplex:
+		return complexKey(sid)
+	}
+
+	switch sid.Format {
+	case "email":
+		email := strings.TrimSpace(sid.Email)
+		if email == "" {
+			return "", fmt.Errorf("email format subject has no email value")
+		}
+		return "email:" + normalizeEmail(email), nil
+	case "iss_sub":
+		iss := strings.TrimSpace(sid.Issuer)
+		sub := strings.TrimSpace(sid.Sub)
+		if iss == "" || sub == "" {
+			return "", fmt.Errorf("iss_sub format subject is missing iss or sub")
+		}
+		return fmt.Sprintf("iss_sub:%q|%q", iss, sub), nil
+	case "phone_number":
+		phone := normalizePhoneNumber(sid.PhoneNumber)
+		if phone == "" {
+			return "", fmt.Errorf("phone_number format subject has no phone_number value")
+		}
+		return "phone_number:" + phone, nil
+	case "opaque":
+		id := strings.TrimSpace(sid.Id)
+		if id == "" {
+			return "", fmt.Errorf("opaque format subject has no id value")
+		}
+		return "opaque:" + id, nil
+	case "did":
+		url := strings.TrimSpace(sid.Url)
+		if url == "" {
+			return "", fmt.Errorf("did format subject has no url value")
+		}
+		return "did:" + url, nil
+	case "account":
+		uri := strings.TrimSpace(sid.Uri)
+		if uri == "" {
+			return "", fmt.Errorf("account format subject has no uri value")
+		}
+		return "account:" + uri, nil
+	case "uri":
+		uri := strings.TrimSpace(sid.Uri)
+		if uri == "" {
+			return "", fmt.Errorf("uri format subject has no uri value")
+		}
+		return "uri:" + uri, nil
+	default:
+		return "", fmt.Errorf("unrecognized subject format %q", sid.Format)
+	}
+}
+
+// MatchSimple reports whether two simple subjects are the same identity, per
+// SSF §8.1.3.1: simple subjects match iff they are exactly identical. It is the
+// canonical-key equality path of ADR-0003. A subject that cannot produce a
+// stable canonical key never matches.
+func MatchSimple(a, b *goSet.SubjectIdentifier) bool {
+	keyA, err := CanonicalKey(a)
+	if err != nil {
+		return false
+	}
+	keyB, err := CanonicalKey(b)
+	if err != nil {
+		return false
+	}
+	return keyA == keyB
+}
+
+// Match reports whether two subjects refer to the same principal under SSF
+// §8.1.3.1. It dispatches by subject kind: an aliases subject matches when any
+// of its aliases matches; otherwise both subjects must share a kind — two
+// simple subjects match by canonical-key equality, two complex subjects
+// field-wise. A simple subject never matches a complex one.
+func Match(a, b *goSet.SubjectIdentifier) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	// An aliases subject matches if any of its members matches the other side.
+	if Kind(a) == KindAliases {
+		for i := range a.Identifiers {
+			if Match(&a.Identifiers[i], b) {
+				return true
+			}
+		}
+		return false
+	}
+	if Kind(b) == KindAliases {
+		return Match(b, a)
+	}
+	switch Kind(a) {
+	case KindComplex:
+		return Kind(b) == KindComplex && MatchComplex(a, b)
+	default:
+		return Kind(b) == KindSimple && MatchSimple(a, b)
+	}
+}
+
+// MatchComplex reports whether two complex subjects match field-wise, per SSF
+// §8.1.3.1. For each complex member, a side that leaves it undefined acts as a
+// wildcard; the match holds when every member defined on both sides is the
+// same identity. It is the field-wise scan path of ADR-0003 — a broad
+// subscription (few members) still matches a narrower, more-specific event.
+func MatchComplex(subscription, event *goSet.SubjectIdentifier) bool {
+	if subscription == nil || event == nil {
+		return false
+	}
+	for _, name := range orderedComplexMembers {
+		subMember := complexMember(subscription, name)
+		evtMember := complexMember(event, name)
+		if subMember == nil || evtMember == nil {
+			continue // undefined on either side: wildcard
+		}
+		if !MatchSimple(subMember, evtMember) {
+			return false
+		}
+	}
+	return true
+}
+
+// aliasesKey builds an order-independent canonical key from the member keys of
+// an aliases subject.
+func aliasesKey(sid *goSet.SubjectIdentifier) (string, error) {
+	if len(sid.Identifiers) == 0 {
+		return "", fmt.Errorf("aliases format subject has no identifiers")
+	}
+	memberKeys := make([]string, 0, len(sid.Identifiers))
+	for i := range sid.Identifiers {
+		memberKey, err := CanonicalKey(&sid.Identifiers[i])
+		if err != nil {
+			return "", fmt.Errorf("aliases member %d: %w", i, err)
+		}
+		memberKeys = append(memberKeys, memberKey)
+	}
+	sort.Strings(memberKeys)
+	return "aliases:[" + strings.Join(memberKeys, ",") + "]", nil
+}
+
+// complexKey builds a stable canonical key from the defined members of a
+// complex subject, visiting members in a fixed order.
+func complexKey(sid *goSet.SubjectIdentifier) (string, error) {
+	parts := make([]string, 0, len(orderedComplexMembers))
+	for _, name := range orderedComplexMembers {
+		member := complexMember(sid, name)
+		if member == nil {
+			continue
+		}
+		memberKey, err := CanonicalKey(member)
+		if err != nil {
+			return "", fmt.Errorf("complex member %q: %w", name, err)
+		}
+		parts = append(parts, name+"="+memberKey)
+	}
+	if len(parts) == 0 {
+		return "", fmt.Errorf("complex subject has no members")
+	}
+	return "complex:[" + strings.Join(parts, ",") + "]", nil
+}
+
+// normalizeEmail lower-cases the domain part of an email address while
+// preserving the case-sensitive local-part.
+func normalizeEmail(email string) string {
+	at := strings.LastIndex(email, "@")
+	if at < 0 {
+		return email
+	}
+	return email[:at] + "@" + strings.ToLower(email[at+1:])
+}
+
+// normalizePhoneNumber strips visual separators (spaces, dashes, parentheses,
+// dots) leaving only digits and an optional leading "+", per RFC9493 §3.2.5.
+func normalizePhoneNumber(phone string) string {
+	var b strings.Builder
+	for i, r := range strings.TrimSpace(phone) {
+		switch {
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '+' && i == 0:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/pkg/subjectid/subject_test.go
+++ b/pkg/subjectid/subject_test.go
@@ -1,0 +1,287 @@
+package subjectid_test
+
+import (
+	"testing"
+
+	"github.com/i2-open/i2goSignals/pkg/goSet"
+	"github.com/i2-open/i2goSignals/pkg/subjectid"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCanonicalKeyEmail is the tracer bullet: an email subject canonicalizes to
+// a single, format-prefixed, stable string with the domain lower-cased.
+func TestCanonicalKeyEmail(t *testing.T) {
+	sid := &goSet.SubjectIdentifier{Format: "email"}
+	sid.Email = "Alice@Example.COM"
+
+	key, err := subjectid.CanonicalKey(sid)
+	require.NoError(t, err)
+	assert.Equal(t, "email:Alice@example.com", key,
+		"email domain is lower-cased, local-part preserved, format-prefixed")
+}
+
+// TestCanonicalKeyIssSub canonicalizes an iss_sub subject into a composite key
+// that unambiguously combines issuer and subject.
+func TestCanonicalKeyIssSub(t *testing.T) {
+	sid := &goSet.SubjectIdentifier{Format: "iss_sub"}
+	sid.Issuer = "https://idp.example.com"
+	sid.Sub = "248289761001"
+
+	key, err := subjectid.CanonicalKey(sid)
+	require.NoError(t, err)
+	assert.Equal(t, `iss_sub:"https://idp.example.com"|"248289761001"`, key)
+
+	// A change to either component yields a different key.
+	other := &goSet.SubjectIdentifier{Format: "iss_sub"}
+	other.Issuer = "https://idp.example.com"
+	other.Sub = "248289761001x"
+	otherKey, err := subjectid.CanonicalKey(other)
+	require.NoError(t, err)
+	assert.NotEqual(t, key, otherKey)
+}
+
+// TestCanonicalKeyPhoneNumber strips visual separators so that the same number
+// written different ways canonicalizes identically (RFC9493 §3.2.5).
+func TestCanonicalKeyPhoneNumber(t *testing.T) {
+	a := &goSet.SubjectIdentifier{Format: "phone_number"}
+	a.PhoneNumber = "+1 (604) 555-1212"
+	b := &goSet.SubjectIdentifier{Format: "phone_number"}
+	b.PhoneNumber = "+1.604.555.1212"
+
+	keyA, err := subjectid.CanonicalKey(a)
+	require.NoError(t, err)
+	keyB, err := subjectid.CanonicalKey(b)
+	require.NoError(t, err)
+
+	assert.Equal(t, "phone_number:+16045551212", keyA)
+	assert.Equal(t, keyA, keyB, "visual separators do not affect the canonical key")
+}
+
+// TestCanonicalKeySingleValueFormats covers the formats whose canonical key is
+// the trimmed value behind a format prefix: opaque, did, uri and account.
+func TestCanonicalKeySingleValueFormats(t *testing.T) {
+	opaque := &goSet.SubjectIdentifier{Format: "opaque"}
+	opaque.Id = " 11112222333344445555 "
+	key, err := subjectid.CanonicalKey(opaque)
+	require.NoError(t, err)
+	assert.Equal(t, "opaque:11112222333344445555", key)
+
+	did := &goSet.SubjectIdentifier{Format: "did"}
+	did.Url = "did:example:123456/did/url"
+	key, err = subjectid.CanonicalKey(did)
+	require.NoError(t, err)
+	assert.Equal(t, "did:did:example:123456/did/url", key)
+
+	// account and uri both carry their value in the uri field; the format
+	// prefix keeps an acct URI and a plain URI with the same value distinct.
+	acct := &goSet.SubjectIdentifier{Format: "account"}
+	acct.Uri = "acct:example.user@service.example.com"
+	uri := &goSet.SubjectIdentifier{Format: "uri"}
+	uri.Uri = "acct:example.user@service.example.com"
+
+	acctKey, err := subjectid.CanonicalKey(acct)
+	require.NoError(t, err)
+	uriKey, err := subjectid.CanonicalKey(uri)
+	require.NoError(t, err)
+	assert.Equal(t, "account:acct:example.user@service.example.com", acctKey)
+	assert.Equal(t, "uri:acct:example.user@service.example.com", uriKey)
+	assert.NotEqual(t, acctKey, uriKey, "format prefix prevents account/uri collision")
+}
+
+// TestCanonicalKeyErrors rejects subjects that cannot produce a stable key.
+func TestCanonicalKeyErrors(t *testing.T) {
+	_, err := subjectid.CanonicalKey(nil)
+	assert.Error(t, err, "nil subject identifier")
+
+	_, err = subjectid.CanonicalKey(&goSet.SubjectIdentifier{})
+	assert.Error(t, err, "missing format")
+
+	_, err = subjectid.CanonicalKey(&goSet.SubjectIdentifier{Format: "carrier_pigeon"})
+	assert.Error(t, err, "unrecognized format")
+
+	_, err = subjectid.CanonicalKey(&goSet.SubjectIdentifier{Format: "email"})
+	assert.Error(t, err, "email format with no email value")
+}
+
+// TestCanonicalKeyAliases canonicalizes an aliases subject into a key built
+// from its member keys; member order does not affect the result.
+func TestCanonicalKeyAliases(t *testing.T) {
+	email := goSet.SubjectIdentifier{Format: "email"}
+	email.Email = "alice@example.com"
+	phone := goSet.SubjectIdentifier{Format: "phone_number"}
+	phone.PhoneNumber = "+16045551212"
+
+	a := &goSet.SubjectIdentifier{Format: "aliases"}
+	a.Identifiers = []goSet.SubjectIdentifier{email, phone}
+	b := &goSet.SubjectIdentifier{Format: "aliases"}
+	b.Identifiers = []goSet.SubjectIdentifier{phone, email}
+
+	keyA, err := subjectid.CanonicalKey(a)
+	require.NoError(t, err)
+	keyB, err := subjectid.CanonicalKey(b)
+	require.NoError(t, err)
+
+	assert.Equal(t, keyA, keyB, "aliases canonical key is order-independent")
+	assert.Contains(t, keyA, "email:alice@example.com")
+	assert.Contains(t, keyA, "phone_number:+16045551212")
+
+	// An aliases subject with no members has no stable key.
+	_, err = subjectid.CanonicalKey(&goSet.SubjectIdentifier{Format: "aliases"})
+	assert.Error(t, err, "empty aliases subject")
+}
+
+// TestKind classifies a subject as simple, complex or aliases.
+func TestKind(t *testing.T) {
+	simple := &goSet.SubjectIdentifier{Format: "email"}
+	simple.Email = "alice@example.com"
+	assert.Equal(t, subjectid.KindSimple, subjectid.Kind(simple))
+
+	aliases := &goSet.SubjectIdentifier{Format: "aliases"}
+	aliases.Identifiers = []goSet.SubjectIdentifier{*simple}
+	assert.Equal(t, subjectid.KindAliases, subjectid.Kind(aliases))
+
+	complex := &goSet.SubjectIdentifier{}
+	complex.User = simple
+	assert.Equal(t, subjectid.KindComplex, subjectid.Kind(complex))
+}
+
+// TestCanonicalKeyComplex canonicalizes a complex subject from its defined
+// members; an undefined member contributes nothing to the key.
+func TestCanonicalKeyComplex(t *testing.T) {
+	user := goSet.SubjectIdentifier{Format: "email"}
+	user.Email = "alice@example.com"
+	device := goSet.SubjectIdentifier{Format: "opaque"}
+	device.Id = "device-42"
+
+	full := &goSet.SubjectIdentifier{}
+	full.User = &user
+	full.Device = &device
+
+	key, err := subjectid.CanonicalKey(full)
+	require.NoError(t, err)
+	assert.Contains(t, key, "user=email:alice@example.com")
+	assert.Contains(t, key, "device=opaque:device-42")
+
+	// The same members produce the same key regardless of which was set first.
+	again := &goSet.SubjectIdentifier{}
+	again.Device = &device
+	again.User = &user
+	keyAgain, err := subjectid.CanonicalKey(again)
+	require.NoError(t, err)
+	assert.Equal(t, key, keyAgain, "complex canonical key is stable")
+
+	// A user-only complex subject yields a different, narrower key.
+	userOnly := &goSet.SubjectIdentifier{}
+	userOnly.User = &user
+	userOnlyKey, err := subjectid.CanonicalKey(userOnly)
+	require.NoError(t, err)
+	assert.NotEqual(t, key, userOnlyKey)
+
+	// A complex subject with no members has no stable key.
+	_, err = subjectid.CanonicalKey(&goSet.SubjectIdentifier{})
+	assert.Error(t, err)
+}
+
+// TestMatchSimple matches simple subjects on exact identity: two subjects match
+// iff their canonical keys are equal.
+func TestMatchSimple(t *testing.T) {
+	a := &goSet.SubjectIdentifier{Format: "email"}
+	a.Email = "alice@example.com"
+	// Same identity, different domain case — normalization makes them equal.
+	b := &goSet.SubjectIdentifier{Format: "email"}
+	b.Email = "alice@EXAMPLE.COM"
+	assert.True(t, subjectid.MatchSimple(a, b), "same identity matches")
+
+	c := &goSet.SubjectIdentifier{Format: "email"}
+	c.Email = "bob@example.com"
+	assert.False(t, subjectid.MatchSimple(a, c), "different identity does not match")
+
+	// A different format with a coincidentally similar value does not match.
+	uri := &goSet.SubjectIdentifier{Format: "uri"}
+	uri.Uri = "alice@example.com"
+	assert.False(t, subjectid.MatchSimple(a, uri), "format prefix keeps subjects distinct")
+
+	// An un-keyable subject never matches.
+	assert.False(t, subjectid.MatchSimple(a, &goSet.SubjectIdentifier{Format: "email"}),
+		"a subject with no stable key does not match")
+}
+
+// email and opaque are small constructors that keep the complex-subject tests
+// readable.
+func email(addr string) *goSet.SubjectIdentifier {
+	s := &goSet.SubjectIdentifier{Format: "email"}
+	s.Email = addr
+	return s
+}
+
+func opaque(id string) *goSet.SubjectIdentifier {
+	s := &goSet.SubjectIdentifier{Format: "opaque"}
+	s.Id = id
+	return s
+}
+
+// TestMatchComplex matches complex subjects field-wise: a field undefined on
+// either side acts as a wildcard, so a broad subscription matches a narrower,
+// more-specific event subject.
+func TestMatchComplex(t *testing.T) {
+	// Fully specified on both sides, identical — match.
+	subFull := &goSet.SubjectIdentifier{}
+	subFull.User = email("alice@example.com")
+	subFull.Device = opaque("device-42")
+	evtFull := &goSet.SubjectIdentifier{}
+	evtFull.User = email("alice@example.com")
+	evtFull.Device = opaque("device-42")
+	assert.True(t, subjectid.MatchComplex(subFull, evtFull), "identical complex subjects match")
+
+	// Broad subscription (user only) matches a narrower event (user + device):
+	// the subscription leaves device undefined, so device is a wildcard.
+	broad := &goSet.SubjectIdentifier{}
+	broad.User = email("alice@example.com")
+	assert.True(t, subjectid.MatchComplex(broad, evtFull),
+		"broad subscription matches narrower event subject")
+
+	// A field defined on both sides but differing — no match.
+	wrongDevice := &goSet.SubjectIdentifier{}
+	wrongDevice.User = email("alice@example.com")
+	wrongDevice.Device = opaque("device-99")
+	assert.False(t, subjectid.MatchComplex(wrongDevice, evtFull),
+		"a field that differs on both sides defeats the match")
+
+	// The wildcard is symmetric: a field undefined on the event side is also a
+	// wildcard, so a more-specific subscription still matches a broad event.
+	narrowEvent := &goSet.SubjectIdentifier{}
+	narrowEvent.User = email("alice@example.com")
+	assert.True(t, subjectid.MatchComplex(subFull, narrowEvent),
+		"a field undefined on the event side acts as a wildcard too")
+}
+
+// TestMatch dispatches by subject kind and resolves aliases.
+func TestMatch(t *testing.T) {
+	alice := email("alice@example.com")
+	bob := email("bob@example.com")
+
+	// Same-kind dispatch: simple→simple and complex→complex.
+	assert.True(t, subjectid.Match(alice, email("alice@EXAMPLE.com")))
+	assert.False(t, subjectid.Match(alice, bob))
+
+	complexAlice := &goSet.SubjectIdentifier{}
+	complexAlice.User = alice
+	assert.True(t, subjectid.Match(complexAlice, complexAlice))
+
+	// Kind mismatch: a simple subject never matches a complex one.
+	assert.False(t, subjectid.Match(alice, complexAlice), "simple and complex kinds do not match")
+
+	// An aliases subject matches another subject when any alias matches.
+	aliasSet := &goSet.SubjectIdentifier{Format: "aliases"}
+	aliasSet.Identifiers = []goSet.SubjectIdentifier{*bob, *alice}
+	assert.True(t, subjectid.Match(aliasSet, alice), "aliases matches when one alias matches")
+	assert.False(t, subjectid.Match(aliasSet, email("carol@example.com")),
+		"aliases does not match when no alias matches")
+
+	// Two aliases subjects match when they share an alias.
+	otherSet := &goSet.SubjectIdentifier{Format: "aliases"}
+	otherSet.Identifiers = []goSet.SubjectIdentifier{*alice}
+	assert.True(t, subjectid.Match(aliasSet, otherSet), "aliases sets match on a shared alias")
+}


### PR DESCRIPTION
## Summary

Implements **PRD #89** — SSF Subject Filtering (Add/Remove Subject, §8.1.3)
end to end. A receiver can now narrow delivery to a watched set of subjects
instead of receiving every event for every audience-matched subject.

The Add/Remove Subject handlers — previously `501 Not Implemented` stubs that
discovery falsely advertised — are now live, gated behind a server-wide
`I2SIG_SUBJECT_FILTERING` switch (disabled by default, so upgrades change no
existing delivery behavior).

## What's included (PRD 89 tracer-bullet slices)

| Issue | Slice |
|-------|-------|
| #90 | Discovery gating (`I2SIG_SUBJECT_FILTERING`) + `StreamStateRecord` config fields (`defaultSubjects`, mode, event source) |
| #91 | Pure RFC9493 subject identity & SSF §8.1.3.1 matching module |
| #92 | `SubjectFilterService` + `LOCAL` filtering on single-node PUSH streams |
| #93 | POLL delivery-time subject filtering (poll-response time) |
| #94 | Cluster match-cache invalidation on subject filter changes |
| #95 | `PASSTHRU` upstream relay + event-source / relay-target validation |
| #96 | `HYBRID` refcounted upstream subject relay (interested-set 0→1 / 1→0) |

Design vocabulary is documented in `CONTEXT.md` ("Subject filtering
vocabulary"); decisions are recorded in `docs/adr/0002-subject-filtering-at-
delivery-time.md` and `docs/adr/0003-split-subject-filter-storage.md`.

## Key design points

- **Storage at scale** — per-stream filter holds only the non-default set,
  split by subject kind: simple subjects hash-indexed (O(1) membership),
  complex subjects field-wise scanned (ADR-0003).
- **Delivery-time filtering** — applied as the PUSH buffer drains (filtered
  JTIs acked/discarded, buffer stays bounded) and at POLL-response time;
  `MatchesStream` / `HandleEvent` untouched (ADR-0002).
- **Relay modes** — `PASSTHRU` relays Add/Remove 1:1; `LOCAL` filters per
  downstream and never relays; `HYBRID` relays via a refcounted interested-set
  against a `NONE` upstream only.
- **Cluster consistency** — Add/Remove on any node invalidates the match
  cache on the `push-transmitter:<sid>` lease owner via the existing
  point-to-point wake-up scheme.
- **Operational events** (verify, stream-updated) always bypass the filter.

## Testing

`go build ./...` passes. Per-slice tests land with each commit: pure matching
unit tests, `SubjectFilterService` tests against the memory DAO, router-level
delivery + cluster-reload tests, and relay / config-validation tests.

## Notes

- Commit `cb28883` (docker-compose-dev / genTlsKeys / Keycloak redirect) is
  unrelated dev-stack tooling that rode along on this branch.
- PRD #97 (admin review + §9 removal grace period) is follow-on work and is
  **not** part of this PR.

Closes #90, #91, #92, #93, #94, #95, #96
Implements #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)