### PR TITLE
fix(ssf): allow non-project-bound tokens to update streams by stream_id (#114)

### DIFF
--- a/internal/server/test/stream_update_issue114_test.go
+++ b/internal/server/test/stream_update_issue114_test.go
@@ -1,0 +1,81 @@
+package test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/MicahParks/keyfunc/v2"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/i2-open/i2goSignals/internal/authUtil"
+	"github.com/i2-open/i2goSignals/pkg/authSupport"
+	"github.com/i2-open/i2goSignals/pkg/httpSupport"
+	model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestStreamUpdate_Issue114_AdminTokenRealProject reproduces issue #114:
+// a project/admin-scoped credential that is not a per-stream EAT (here an
+// external OAuth/STS token, as goSignalsAdmin uses) names the target stream
+// in ?stream_id= and should be able to update it. The stream is created the
+// normal way (owned by a real project), unlike TestStreamUpdate_ExternalToken
+// which side-steps the bug by creating the stream with an empty project.
+func TestStreamUpdate_Issue114_AdminTokenRealProject(t *testing.T) {
+	instance, err := createServer(t, "issue114_test_db", true)
+	assert.NoError(t, err)
+	defer instance.app.Shutdown()
+	defer instance.ts.Close()
+
+	// External "OAuth" server key + JWKS, as goSignalsAdmin's STS would have.
+	oauthPrivateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.NoError(t, err)
+	n := base64.RawURLEncoding.EncodeToString(oauthPrivateKey.N.Bytes())
+	jwksJSON := []byte(fmt.Sprintf(`{"keys":[{"kty":"RSA","kid":"external","n":"%s","e":"AQAB"}]}`, n))
+	jwks, err := keyfunc.NewJSON(jwksJSON)
+	assert.NoError(t, err)
+	instance.app.Auth.OAuthPubKeys = []*keyfunc.JWKS{jwks}
+
+	claims := &authSupport.OidcClaims{
+		Scope: authSupport.ScopeStreamMgmt,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    "external-issuer",
+			Subject:   "gosignals-admin",
+			Audience:  jwt.ClaimStrings{"goSignals"},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = "external"
+	tokenString, err := token.SignedString(oauthPrivateKey)
+	assert.NoError(t, err)
+
+	// Create a stream owned by a real project (the normal case).
+	transConfig := model.StreamConfiguration{
+		Aud: []string{"test.example.com"},
+		Iss: "DEFAULT",
+	}
+	config, err := instance.CreateStream(transConfig, authUtil.ConvertProject(instance.projectId))
+	assert.NoError(t, err)
+	assert.NotEmpty(t, instance.projectId, "stream must be owned by a real project")
+
+	// Update it, naming the stream in ?stream_id=.
+	config.EventsRequested = config.EventsSupported
+	bodyBytes, _ := json.Marshal(config)
+	streamUrl := fmt.Sprintf("http://%s/stream?stream_id=%s", instance.host, config.Id)
+	req, err := http.NewRequest(http.MethodPut, streamUrl, bytes.NewReader(bodyBytes))
+	assert.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+tokenString)
+
+	resp, err := instance.client.Do(req)
+	assert.NoError(t, err)
+	defer httpSupport.HandleRespClose(resp)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"admin-scoped token must update a stream named by ?stream_id= regardless of stream project ownership")
+}

--- a/internal/services/stream_service.go
+++ b/internal/services/stream_service.go
@@ -729,12 +729,17 @@ func (s *StreamService) calculateDeliveredEvents(requested []string, supported [
 // the goSignals-specific subject-filtering operator knobs can be updated
 // alongside the SSF wire-format configuration. Like the rest of this method,
 // only non-empty request fields are applied.
+//
+// projectID confines a project-scoped token to streams it owns. An empty
+// projectID means the caller is not project-bound (e.g. an external OAuth/STS
+// admin token authorized purely by scope, as goSignalsAdmin uses); such a
+// caller addresses the stream by stream_id and is not project-confined.
 func (s *StreamService) UpdateStream(ctx context.Context, streamID string, projectID string, configReq model.StreamStateRecord) (*model.StreamConfiguration, error) {
 	streamRec, err := s.streamDAO.FindByID(ctx, streamID)
 	if err != nil {
 		return nil, err
 	}
-	if streamRec.ProjectId != projectID {
+	if projectID != "" && streamRec.ProjectId != projectID {
 		return nil, errors.New(ErrorInvalidProject)
 	}
 


### PR DESCRIPTION
## Summary
- Fixes #114. `StreamService.UpdateStream` enforced `streamRec.ProjectId != projectID` unconditionally. An external OAuth/STS admin token (as goSignalsAdmin uses) carries no `ProjectId` — `validateOAuthToken` returns `AuthContext{ProjectId: ""}` — so the check always failed with HTTP 401 "Streamid invalid for authorization", even when the stream was named explicitly in `?stream_id=`.
- The fix skips the project-ownership check when `projectID` is empty: such a caller is authorized purely by scope and is not project-confined. A project-scoped local EAT is still confined to its own project, and a stream-bound EAT is still constrained by `ValidateAuthorizationAny`. This aligns `StreamUpdateHandler` with `StreamGetHandler`, which already does no project check.
- `UpdateStream` has exactly one non-test caller, so the blast radius is minimal.

## Test plan
- [x] New regression test `TestStreamUpdate_Issue114_AdminTokenRealProject` — full HTTP server, external OAuth admin token, stream owned by a real project, `PUT /stream?stream_id=`. Reproduces 401 before the fix, 200 after.
- [x] `go test ./internal/server/... ./internal/services/...` all pass (including the pre-existing `TestStreamUpdate_ExternalToken` and `Test4_StreamUpdate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)