### PR TITLE
fix(poll-receiver): revive dead goroutine and bound 403 retries

### DIFF
--- a/internal/server/api_receiver.go
+++ b/internal/server/api_receiver.go
@@ -32,7 +32,8 @@ type ClientPollStream struct {
 	stream    *model.StreamStateRecord
 	ctx       context.Context
 	cancel    context.CancelFunc
-	active    bool
+	active    bool // false once Close() or a terminal error asked the receiver to stop
+	running   bool // true while the polling goroutine is alive (set on launch, cleared on goroutine exit)
 	statusUrl string
 }
 
@@ -242,11 +243,12 @@ func (sa *SignalsApplication) handleClientPollReceiver(streamState *model.Stream
 		ctx, cancel := context.WithCancel(context.Background())
 
 		ps = &ClientPollStream{
-			sa:     sa,
-			stream: streamState,
-			active: true,
-			ctx:    ctx,
-			cancel: cancel,
+			sa:      sa,
+			stream:  streamState,
+			active:  true,
+			running: true,
+			ctx:     ctx,
+			cancel:  cancel,
 		}
 		sa.pollClients[streamState.StreamConfiguration.Id] = ps
 		pollUrl := streamState.Delivery.PollReceiveMethod.EndpointUrl
@@ -254,9 +256,32 @@ func (sa *SignalsApplication) handleClientPollReceiver(streamState *model.Stream
 		go ps.pollEventsReceiver()
 		return ps
 	}
+
 	ps.mu.Lock()
 	ps.stream = streamState
+	// Revive whenever the goroutine isn't alive and the caller wants the stream to run.
+	// Two paths reach here with a dead goroutine: (a) a prior terminal error set active=false
+	// and the goroutine returned, (b) the goroutine exited via pollEventsReceiver's outer-loop
+	// status check because the stream was Disabled at the time, leaving active=true but
+	// running=false. The status flip back to non-Disable is what re-arms the receiver.
+	needsRevive := !ps.running && streamState.Status != model.StreamStateDisable
+	if needsRevive {
+		// Cancel any lingering context from the previous goroutine before replacing.
+		if ps.cancel != nil {
+			ps.cancel()
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		ps.ctx = ctx
+		ps.cancel = cancel
+		ps.active = true
+		ps.running = true
+	}
 	ps.mu.Unlock()
+
+	if needsRevive {
+		serverLog.Info("POLL-RCV: Reviving inactive poll receiver", "sid", streamState.StreamConfiguration.Id, "status", streamState.Status)
+		go ps.pollEventsReceiver()
+	}
 	return ps
 }
 
@@ -807,6 +832,12 @@ func (ps *ClientPollStream) pollEventsReceiver() {
 	sid := ps.stream.StreamConfiguration.Id
 	resource := fmt.Sprintf("poll-receiver:%s", sid)
 
+	defer func() {
+		ps.mu.Lock()
+		ps.running = false
+		ps.mu.Unlock()
+	}()
+
 	for {
 		ps.mu.RLock()
 		stream := ps.stream
@@ -909,6 +940,8 @@ func (ps *ClientPollStream) runPollLoop(resource string) {
 	statusCheckInterval := pollCfg.StatusCheckInterval
 	unauthorizedRetryDelay := pollCfg.UnauthorizedRetryDelay
 	unauthorizedRetryLimit := pollCfg.UnauthorizedRetryLimit
+	forbiddenRetryDelay := pollCfg.ForbiddenRetryDelay
+	forbiddenRetryLimit := pollCfg.ForbiddenRetryLimit
 
 	// Initial status check upon lease acquisition - verify that the transmitter is active
 	if ok, _ := ps.handleTransmitterStatus(heartbeatCtx, statusCheckInterval); !ok {
@@ -917,6 +950,7 @@ func (ps *ClientPollStream) runPollLoop(resource string) {
 
 	retryCount := 0
 	unauthorizedCount := 0
+	forbiddenCount := 0
 	var firstErrorTime time.Time
 
 	for {
@@ -1011,12 +1045,53 @@ func (ps *ClientPollStream) runPollLoop(resource string) {
 			}
 
 			if httpStatus == http.StatusForbidden {
-				errMsg := fmt.Sprintf("POLL-RCV[%s] Stream disabled by transmitter: %d %s", sid, httpStatus, http.StatusText(httpStatus))
-				ps.sa.updateStreamAfterError(sid, model.StreamStateDisable, errMsg)
-				ps.mu.Lock()
-				ps.active = false
-				ps.mu.Unlock()
-				return
+				forbiddenCount++
+				if forbiddenCount >= forbiddenRetryLimit {
+					scopesDesc := ps.sa.describeRequestedScopes(ps.ctx, ps.stream)
+					errMsg := fmt.Sprintf(
+						"POLL-RCV[%s] Stream disabled after %d forbidden (403) attempts. "+
+							"Transmitter rejected the token. Likely cause: OAuth client_credentials scope mismatch. "+
+							"Requested scopes: %s. Required scope: '%s'.",
+						sid, forbiddenCount, scopesDesc, authSupport.ScopeEventDelivery)
+					ps.sa.updateStreamAfterError(sid, model.StreamStateDisable, errMsg)
+					ps.mu.Lock()
+					ps.active = false
+					ps.mu.Unlock()
+					return
+				}
+
+				delaySeconds := float64(forbiddenRetryDelay) / float64(time.Second) * math.Pow(backoffFactor, float64(forbiddenCount-1))
+				if delaySeconds > maxDelay {
+					delaySeconds = maxDelay
+				}
+				delay := time.Duration(delaySeconds * float64(time.Second))
+
+				scopesDesc := ps.sa.describeRequestedScopes(ps.ctx, ps.stream)
+				serverLog.Warn("POLL-RCV: Forbidden response, retrying after delay",
+					"sid", sid, "delay", delay, "attempt", forbiddenCount, "limit", forbiddenRetryLimit,
+					"requested_scopes", scopesDesc, "required_scope", authSupport.ScopeEventDelivery)
+				ps.sa.pauseStreamOnError(sid,
+					fmt.Sprintf("forbidden response (403), retrying after %v (attempt %d/%d). "+
+						"Requested scopes: %s. Required scope: '%s'.",
+						delay, forbiddenCount, forbiddenRetryLimit, scopesDesc, authSupport.ScopeEventDelivery))
+
+				select {
+				case <-time.After(delay):
+					updatedStream, _ := ps.sa.StreamService.GetStreamState(context.Background(), sid)
+					if updatedStream != nil {
+						ps.mu.Lock()
+						ps.stream = updatedStream
+						ps.mu.Unlock()
+					}
+					closeClient()
+					client, auth, closeClient, err = ps.sa.getHTTPClientForStream(ps.ctx, ps.stream)
+					if err != nil {
+						serverLog.Error("POLL-RCV: Failed to refresh client/auth after 403", "sid", sid, "error", err)
+					}
+					continue
+				case <-heartbeatCtx.Done():
+					return
+				}
 			}
 
 			if isConnectionError(err) || httpStatus == http.StatusServiceUnavailable {
@@ -1257,4 +1332,24 @@ func (sa *SignalsApplication) updateStreamAfterError(streamId string, mode strin
 func (sa *SignalsApplication) pauseStreamOnError(streamId string, errMsg string) {
 	sa.StreamService.UpdateStreamStatus(context.Background(), streamId, model.StreamStatePause, errMsg)
 	// TODO:  Update event router with stream state change??
+}
+
+// describeRequestedScopes returns a human-readable list of the OAuth scopes the
+// stream's TxAlias server is configured to request via client_credentials. Used
+// to surface scope-mismatch hints in stream error messages.
+func (sa *SignalsApplication) describeRequestedScopes(ctx context.Context, stream *model.StreamStateRecord) string {
+	if stream == nil || stream.StreamConfiguration.TxAlias == nil || *stream.StreamConfiguration.TxAlias == "" {
+		return "(no TxAlias)"
+	}
+	server, err := sa.ServerService.GetServerByAlias(ctx, *stream.StreamConfiguration.TxAlias)
+	if err != nil || server == nil {
+		return "(server lookup failed)"
+	}
+	if server.OAuthClientConfig == nil {
+		return "(not using OAuth client_credentials)"
+	}
+	if len(server.OAuthClientConfig.Scopes) == 0 {
+		return "(none)"
+	}
+	return "[" + strings.Join(server.OAuthClientConfig.Scopes, ", ") + "]"
 }

--- a/internal/server/poll_config.go
+++ b/internal/server/poll_config.go
@@ -19,6 +19,8 @@ type pollConfig struct {
     StatusCheckInterval    time.Duration
     UnauthorizedRetryDelay time.Duration
     UnauthorizedRetryLimit int
+    ForbiddenRetryDelay    time.Duration
+    ForbiddenRetryLimit    int
 }
 
 func loadPollConfig() pollConfig {
@@ -30,6 +32,8 @@ func loadPollConfig() pollConfig {
         StatusCheckInterval:    30 * time.Second,
         UnauthorizedRetryDelay: 15 * time.Second,
         UnauthorizedRetryLimit: 10,
+        ForbiddenRetryDelay:    30 * time.Second,
+        ForbiddenRetryLimit:    3,
     }
 
     if v, err := strconv.ParseFloat(envcompat.Lookup("I2SIG_POLL_RETRY_BASE_DELAY", "POLL_RETRY_BASE_DELAY"), 64); err == nil {
@@ -52,6 +56,12 @@ func loadPollConfig() pollConfig {
     }
     if v, err := strconv.Atoi(envcompat.Lookup("I2SIG_POLL_AUTH_RETRY_LIMIT", "POLL_UNAUTHORIZED_RETRY_LIMIT")); err == nil {
         cfg.UnauthorizedRetryLimit = v
+    }
+    if v, err := strconv.ParseFloat(envcompat.Lookup("I2SIG_POLL_FORBIDDEN_RETRY_DELAY", "POLL_FORBIDDEN_RETRY_DELAY"), 64); err == nil {
+        cfg.ForbiddenRetryDelay = time.Duration(v * float64(time.Second))
+    }
+    if v, err := strconv.Atoi(envcompat.Lookup("I2SIG_POLL_FORBIDDEN_RETRY_LIMIT", "POLL_FORBIDDEN_RETRY_LIMIT")); err == nil {
+        cfg.ForbiddenRetryLimit = v
     }
 
     return cfg

--- a/internal/server/test/poll_behavior_v2_test.go
+++ b/internal/server/test/poll_behavior_v2_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -362,6 +363,11 @@ func (suite *PollBehaviorSuite) TestPollSrvBehavior_LegacyTranslation() {
 func (suite *PollBehaviorSuite) TestReceiverHandles403() {
 	t := suite.T()
 
+	// With the bounded-403-retry behavior the first 403 no longer disables the
+	// stream. Pin the retry limit to 1 so this test still exercises the
+	// terminal-disable path.
+	t.Setenv("I2SIG_POLL_FORBIDDEN_RETRY_LIMIT", "1")
+
 	// Mock a transmitter that returns 403
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/jwks" {
@@ -401,5 +407,77 @@ func (suite *PollBehaviorSuite) TestReceiverHandles403() {
 	// Check if stream is now DISABLED in provider
 	updatedState, _ := suite.instance.GetStreamState(createdConfig.Id)
 	assert.Equal(t, model.StreamStateDisable, updatedState.Status)
-	assert.Contains(t, updatedState.ErrorMsg, "Stream disabled by transmitter")
+	assert.Contains(t, updatedState.ErrorMsg, "Stream disabled after")
+	assert.Contains(t, updatedState.ErrorMsg, "forbidden (403)")
 }
+
+func (suite *PollBehaviorSuite) TestReceiverRetriesOn403BeforeDisable() {
+	t := suite.T()
+
+	// Allow up to 3 forbidden attempts before disabling. With a short delay
+	// and backoff factor, the test should observe at least one paused state
+	// before the stream is ultimately disabled.
+	t.Setenv("I2SIG_POLL_FORBIDDEN_RETRY_DELAY", "0.05") // 50ms base
+	t.Setenv("I2SIG_POLL_FORBIDDEN_RETRY_LIMIT", "3")
+	t.Setenv("I2SIG_POLL_RETRY_BACKOFF_FACTOR", "1.0") // disable exponential growth for predictability
+	t.Setenv("I2SIG_POLL_RETRY_MAX_DELAY", "1.0")     // cap
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/jwks" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"keys":[]}`))
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer ts.Close()
+
+	streamConfig := model.StreamConfiguration{
+		Id:            "transmitter-403-retry",
+		Iss:           "transmitter-403-retry.example.com",
+		IssuerJWKSUrl: ts.URL + "/jwks",
+		Delivery: &model.OneOfStreamConfigurationDelivery{
+			PollReceiveMethod: &model.PollReceiveMethod{
+				Method:      model.ReceivePoll,
+				EndpointUrl: ts.URL + "/poll",
+				PollConfig:  &model.PollParameters{},
+			},
+		},
+	}
+
+	createdConfig, err := suite.instance.CreateStream(streamConfig, authUtil.ConvertProject(suite.instance.projectId))
+	assert.NoError(t, err)
+	state, _ := suite.instance.GetStreamState(createdConfig.Id)
+
+	ps := suite.instance.app.HandleReceiver(state)
+	assert.NotNil(t, ps)
+
+	// Within the first ~100ms we should see at least one retry (status paused
+	// with a retry-attempt message), well before the limit of 3 is reached.
+	sawPause := false
+	for i := 0; i < 20; i++ {
+		time.Sleep(25 * time.Millisecond)
+		updatedState, _ := suite.instance.GetStreamState(createdConfig.Id)
+		if updatedState != nil && updatedState.Status == model.StreamStatePause &&
+			strings.Contains(updatedState.ErrorMsg, "forbidden response (403), retrying") {
+			sawPause = true
+			break
+		}
+	}
+	assert.True(t, sawPause, "expected to observe a paused state with a 403 retry message during retries")
+
+	// Eventually the stream must end up DISABLED with the diagnostic message.
+	var finalState *model.StreamStateRecord
+	for i := 0; i < 40; i++ {
+		time.Sleep(50 * time.Millisecond)
+		finalState, _ = suite.instance.GetStreamState(createdConfig.Id)
+		if finalState != nil && finalState.Status == model.StreamStateDisable {
+			break
+		}
+	}
+	assert.NotNil(t, finalState)
+	assert.Equal(t, model.StreamStateDisable, finalState.Status)
+	assert.Contains(t, finalState.ErrorMsg, "Stream disabled after 3 forbidden (403)")
+	assert.Contains(t, finalState.ErrorMsg, "scope")
+}
+

--- a/pkg/constants/server.go
+++ b/pkg/constants/server.go
@@ -1,6 +1,6 @@
 package constants
 
-const GoSignalsVersion = "0.11.0-beta.2"
+const GoSignalsVersion = "0.11.0-beta.3"
 
 const BearerAuth = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 const RFC6749 = "urn:ietf:rfc:6749"


### PR DESCRIPTION
## Summary

Two latent defects combined to make scope-misconfigured poll-receiver streams permanently dead until process restart, with an opaque error message that didn't point at the actual cause.

- **Dead-goroutine revival**: `handleClientPollReceiver`'s existing-entry branch silently no-op'd when the polling goroutine had already exited. Two paths reached this state — a terminal error setting `active=false`, and a stream that was already Disabled at boot (goroutine exited via the outer-loop status check without touching `active`). Added a separate `running` flag (set on launch, cleared via `defer`) so an existing entry with a dead goroutine is detected and respawned with a fresh context as soon as the stream is re-enabled.
- **Bounded 403 retry with diagnostic error message**: a single 403 immediately disabled the stream with an unhelpful `"Stream disabled by transmitter: 403 Forbidden"`. Replaced with a bounded retry mirroring the 401 path (`I2SIG_POLL_FORBIDDEN_RETRY_DELAY` / `_LIMIT`, defaults 30s and 3 attempts). The terminal `error_msg` now identifies the likely cause and lists the OAuth client_credentials scopes actually requested vs the scope required:
  > `Stream disabled after 3 forbidden (403) attempts. Transmitter rejected the token. Likely cause: OAuth client_credentials scope mismatch. Requested scopes: [admin, stream, reg]. Required scope: 'event'.`

## Test plan

- [x] `go test -race ./internal/server/...` — existing `TestReceiverHandles403` updated to pin retry limit=1 and assert the new message format; new `TestReceiverRetriesOn403BeforeDisable` covers the bounded-retry → pause → eventual-disable path.
- [x] `go test -race ./internal/eventRouter/...` — unaffected, all green.
- [x] Live verification on dev cluster against two streams:
  - Healthy poll receiver (`6a160a7d3e01d1a372903e01`) — long-poll cycle unchanged.
  - Scope-misconfigured receiver (`6a160c313e01d1a372903e03`) — boot → 3 retries with the scope diagnostic in WARN logs → disabled with the diagnostic written to mongo `error_msg`.
  - Re-enable via admin UI — `POLL-RCV: Reviving inactive poll receiver` log fires, fresh goroutine acquires lease and retries.

## Follow-ups not in this PR

- Data fix: add `event` to the `go1cc` server's `oauthclientconfig.scopes` so the bad-scope stream becomes good.
- Transmitter side: emit RFC6750 `WWW-Authenticate: Bearer error="insufficient_scope"` so the receiver's diagnostic becomes *correct* (currently heuristic — labels the cause as "Likely scope mismatch").

🤖 Generated with [Claude Code](https://claude.com/claude-code)