### PR TITLE
goSignals CLI delegated-OAuth login + safe unattended bootstrap (PRD #120)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,6 +19,51 @@ depends on the narrowest seam it actually uses.
 
 ## Vocabulary
 
+### Management-plane vs data-plane auth
+
+Two independent authorization planes:
+
+- **Management plane** — administering a server (define streams, create issuer
+  keys, mint IATs, register clients). Authorized by a delegated-OAuth user
+  session (`login`) or the bootstrap secret / admin token (automation).
+- **Data plane** — moving events (transmitter push, receiver poll). Authorized
+  by per-stream/per-client tokens carrying `stream`/`event` scopes within a
+  project.
+
+A management session never grants event delivery; a delivery token never
+administers the server. See [`docs/security_model.md`](docs/security_model.md).
+
+### `key` scope
+
+`authSupport.ScopeKey` (`"key"`) — a narrow capability between `reg` and
+`admin`. A `key`-scoped caller may create a **new** issuer signing key
+(`POST /key/<issuer>`) and obtain a **`reg`-only** IAT (`GET /iat`), but is
+denied key takeover (`force=replace`/`rotate`/`?rotate` → `keyScopeOnly` guard in
+`api_out_of_band.go`) and has no stream/event capability. It seeds the machine
+tier ladder for unattended bootstrap.
+
+### Bootstrap secret
+
+`I2SIG_BOOTSTRAP_TOKEN` — a shared secret read by `authUtil.resolveBootstrapBearer`.
+A presented bearer that **constant-time-equals** the configured value is
+synthesized into a `key`-scope `AuthContext` before any JWT validation. When the
+variable is unset, the path is closed and no bootstrap bearer is accepted (fail
+closed). It is an app-layer authorization mechanism, orthogonal to and coexisting
+with transport-layer SPIFFE/TLS identity. **There is no anonymous `/iat`
+endpoint** — closing it is the reason the secret exists.
+
+### PRM-driven login
+
+The CLI's `login` flow is driven by the server's RFC 9728 **Protected Resource
+Metadata** (`/.well-known/oauth-protected-resource`), which advertises the OAuth
+`authorization_servers` and the recommended public `client_id`
+(`I2SIG_CLI_CLIENT_ID`, default `gosignals-cli`). `add server` caches the PRM's
+`authorization_servers`; `login` resolves the issuer from it, discovers the
+issuer's OpenID configuration, then runs OAuth authorization-code + PKCE
+(RFC 7636) via a loopback listener — or RFC 8628 device-code on headless hosts.
+Sessions are stored per-issuer in `credentials.json`; see
+[`docs/cli_login.md`](docs/cli_login.md).
+
 ### Persistence record
 
 `*dbProviders.Persistence` — the composition root returned by

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ docker exec spire-server sh /etc/spire/registration/register.sh
 
 ## Documentation
 * [GoSignals Administration Tool](docs/gosignals_tool.md) - CLI usage and commands.
+* [CLI Login &amp; Bootstrap Guide](docs/cli_login.md) - Delegated-OAuth `login` (browser PKCE / device-code), unattended `I2SIG_BOOTSTRAP_TOKEN` bootstrap, and the docker-compose variant matrix.
 * [Configuration Properties](docs/configuration_properties.md) - Environment variables and settings.
 * [Security Model](docs/security_model.md) - Authentication, authorization, and SPIFFE details.
 * [Clustering & High Availability](docs/Cluster.md) - Multi-node deployment and lease management.

--- a/cmd/goSignals/authurl_test.go
+++ b/cmd/goSignals/authurl_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+    "net/url"
+    "testing"
+)
+
+func TestBuildAuthorizationURL_CarriesPKCEAndState(t *testing.T) {
+    pkce := &pkceParams{Verifier: "v", Challenge: "chal", Method: "S256"}
+    raw := buildAuthorizationURL("https://idp.example.com/auth", "gosignals-cli",
+        "http://127.0.0.1:5555/callback", "state-xyz", pkce, []string{"openid", "admin"})
+
+    u, err := url.Parse(raw)
+    if err != nil {
+        t.Fatalf("authorization URL did not parse: %v", err)
+    }
+    q := u.Query()
+    if q.Get("response_type") != "code" {
+        t.Errorf("expected response_type=code, got %q", q.Get("response_type"))
+    }
+    if q.Get("code_challenge") != "chal" || q.Get("code_challenge_method") != "S256" {
+        t.Errorf("PKCE challenge not in URL: %v", q)
+    }
+    if q.Get("state") != "state-xyz" {
+        t.Errorf("state not in URL: %q", q.Get("state"))
+    }
+    if q.Get("client_id") != "gosignals-cli" {
+        t.Errorf("client_id not in URL: %q", q.Get("client_id"))
+    }
+    if q.Get("redirect_uri") != "http://127.0.0.1:5555/callback" {
+        t.Errorf("redirect_uri not in URL: %q", q.Get("redirect_uri"))
+    }
+    if q.Get("scope") != "openid admin" {
+        t.Errorf("scope not joined: %q", q.Get("scope"))
+    }
+}

--- a/cmd/goSignals/bearer.go
+++ b/cmd/goSignals/bearer.go
@@ -104,6 +104,29 @@ func refreshSession(tokenEndpoint string, prior *Session) (*Session, error) {
     return updated, nil
 }
 
+// revokeRefreshToken makes a best-effort RFC 7009 token revocation request for
+// a session's refresh token. It is intentionally side-effect-only: any error
+// (missing endpoint, no refresh token, transport failure, non-2xx response) is
+// swallowed so that logout always succeeds locally even when the IdP is
+// unreachable or does not support revocation.
+func revokeRefreshToken(revocationEndpoint string, sess *Session) {
+    if revocationEndpoint == "" || sess == nil || sess.RefreshToken == "" {
+        return
+    }
+    form := url.Values{}
+    form.Set("token", sess.RefreshToken)
+    form.Set("token_type_hint", "refresh_token")
+    if sess.ClientId != "" {
+        form.Set("client_id", sess.ClientId)
+    }
+    client := getHttpClient(15 * time.Second)
+    resp, err := client.PostForm(revocationEndpoint, form)
+    if err != nil {
+        return
+    }
+    _ = resp.Body.Close()
+}
+
 // serverBearer resolves the Authorization bearer to present on a management
 // call for the given server. It prefers a logged-in IdP session (with silent
 // refresh) keyed by the server's active issuer; absent a session it falls back
@@ -111,24 +134,26 @@ func refreshSession(tokenEndpoint string, prior *Session) (*Session, error) {
 // refresh is dead, the errReloginRequired sentinel is wrapped so callers can
 // surface a clear re-login instruction.
 func serverBearer(g *Globals, server *SsfServer) (string, error) {
-    if server.ActiveIssuer != "" {
-        store, err := LoadCredentialStore(g)
-        if err != nil {
-            return "", err
+    store, err := LoadCredentialStore(g)
+    if err != nil {
+        return "", err
+    }
+    // Resolve which realm session authorizes this call: the server's active
+    // issuer wins when it has a live session, else the most-recently-logged-in
+    // trusted realm (last-login-wins).
+    issuer := selectIssuerForServer(store, server)
+    if issuer != "" {
+        br := &bearerResolver{
+            store: store,
+            tokenEndpoint: func(issuer string) (string, error) {
+                ep, derr := discoverEndpoints(issuer)
+                if derr != nil {
+                    return "", derr
+                }
+                return ep.Token, nil
+            },
         }
-        if store.Get(server.ActiveIssuer) != nil {
-            br := &bearerResolver{
-                store: store,
-                tokenEndpoint: func(issuer string) (string, error) {
-                    ep, derr := discoverEndpoints(issuer)
-                    if derr != nil {
-                        return "", derr
-                    }
-                    return ep.Token, nil
-                },
-            }
-            return br.resolve(server.ActiveIssuer)
-        }
+        return br.resolve(issuer)
     }
     if server.ClientToken != "" {
         return server.ClientToken, nil

--- a/cmd/goSignals/bearer.go
+++ b/cmd/goSignals/bearer.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+    "encoding/json"
+    "errors"
+    "fmt"
+    "io"
+    "net/http"
+    "net/url"
+    "time"
+)
+
+// errReloginRequired is returned by the bearer resolver when there is no usable
+// session and silent refresh is impossible (no session, or a dead refresh
+// token). Callers surface a clear "please run `goSignals login` again" message.
+var errReloginRequired = errors.New("re-login required")
+
+// tokenEndpointFunc resolves the OAuth token endpoint for an issuer. It is a
+// function so tests can inject a fake endpoint without network discovery.
+type tokenEndpointFunc func(issuer string) (string, error)
+
+// bearerResolver presents the per-issuer session access token on management
+// calls, silently refreshing it when expired and instructing re-login when the
+// refresh token is dead.
+type bearerResolver struct {
+    store         *CredentialStore
+    tokenEndpoint tokenEndpointFunc
+}
+
+// resolve returns a currently-valid access token for the issuer, refreshing if
+// needed. It persists any refreshed tokens back to the credential store.
+func (b *bearerResolver) resolve(issuer string) (string, error) {
+    sess := b.store.Get(issuer)
+    if sess == nil || sess.AccessToken == "" {
+        return "", fmt.Errorf("no session for issuer %s: %w", issuer, errReloginRequired)
+    }
+    if !sess.Expired() {
+        return sess.AccessToken, nil
+    }
+
+    if sess.RefreshToken == "" {
+        return "", fmt.Errorf("session for %s has expired and has no refresh token: %w", issuer, errReloginRequired)
+    }
+
+    endpoint, err := b.tokenEndpoint(issuer)
+    if err != nil {
+        return "", fmt.Errorf("could not discover token endpoint for %s: %w", issuer, err)
+    }
+
+    refreshed, err := refreshSession(endpoint, sess)
+    if err != nil {
+        return "", fmt.Errorf("token refresh failed for %s (%v): %w", issuer, err, errReloginRequired)
+    }
+
+    b.store.Set(issuer, refreshed)
+    // Best-effort persist; resolution still succeeds if the write fails.
+    _ = b.store.Save()
+    return refreshed.AccessToken, nil
+}
+
+// refreshSession performs an RFC6749 refresh_token grant and returns an updated
+// Session. Identity claims (subject/email) are carried forward from the prior
+// session since refresh responses typically omit them.
+func refreshSession(tokenEndpoint string, prior *Session) (*Session, error) {
+    form := url.Values{}
+    form.Set("grant_type", "refresh_token")
+    form.Set("refresh_token", prior.RefreshToken)
+    if prior.ClientId != "" {
+        form.Set("client_id", prior.ClientId)
+    }
+
+    client := getHttpClient(30 * time.Second)
+    resp, err := client.PostForm(tokenEndpoint, form)
+    if err != nil {
+        return nil, err
+    }
+    defer func() { _ = resp.Body.Close() }()
+    body, _ := io.ReadAll(resp.Body)
+    if resp.StatusCode != http.StatusOK {
+        return nil, fmt.Errorf("refresh endpoint returned %s: %s", resp.Status, string(body))
+    }
+
+    var tr tokenResponse
+    if err := json.Unmarshal(body, &tr); err != nil {
+        return nil, err
+    }
+    if tr.AccessToken == "" {
+        return nil, errors.New("refresh response did not include an access_token")
+    }
+
+    updated := sessionFromTokenResponse(&tr, prior.ClientId)
+    if updated.RefreshToken == "" {
+        updated.RefreshToken = prior.RefreshToken
+    }
+    if updated.Subject == "" {
+        updated.Subject = prior.Subject
+    }
+    if updated.Email == "" {
+        updated.Email = prior.Email
+    }
+    if len(updated.Scopes) == 0 {
+        updated.Scopes = prior.Scopes
+    }
+    return updated, nil
+}
+
+// serverBearer resolves the Authorization bearer to present on a management
+// call for the given server. It prefers a logged-in IdP session (with silent
+// refresh) keyed by the server's active issuer; absent a session it falls back
+// to a configured client token (non-interactive). When a session exists but
+// refresh is dead, the errReloginRequired sentinel is wrapped so callers can
+// surface a clear re-login instruction.
+func serverBearer(g *Globals, server *SsfServer) (string, error) {
+    if server.ActiveIssuer != "" {
+        store, err := LoadCredentialStore(g)
+        if err != nil {
+            return "", err
+        }
+        if store.Get(server.ActiveIssuer) != nil {
+            br := &bearerResolver{
+                store: store,
+                tokenEndpoint: func(issuer string) (string, error) {
+                    ep, derr := discoverEndpoints(issuer)
+                    if derr != nil {
+                        return "", derr
+                    }
+                    return ep.Token, nil
+                },
+            }
+            return br.resolve(server.ActiveIssuer)
+        }
+    }
+    if server.ClientToken != "" {
+        return server.ClientToken, nil
+    }
+    return "", nil
+}

--- a/cmd/goSignals/bearer_test.go
+++ b/cmd/goSignals/bearer_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+    "errors"
+    "net/http"
+    "net/http/httptest"
+    "path/filepath"
+    "testing"
+    "time"
+)
+
+func TestResolveBearer_ReturnsValidToken(t *testing.T) {
+    store := &CredentialStore{Path: filepath.Join(t.TempDir(), "credentials.json")}
+    store.Set("https://idp.example.com", &Session{
+        AccessToken: "still-good",
+        Expiry:      time.Now().Add(time.Hour),
+    })
+
+    br := &bearerResolver{store: store, tokenEndpoint: func(string) (string, error) { return "", nil }}
+    tok, err := br.resolve("https://idp.example.com")
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    if tok != "still-good" {
+        t.Errorf("expected unrefreshed valid token, got %q", tok)
+    }
+}
+
+func TestResolveBearer_SilentRefreshOnExpiry(t *testing.T) {
+    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        _ = r.ParseForm()
+        if r.Form.Get("grant_type") != "refresh_token" || r.Form.Get("refresh_token") != "rt-live" {
+            w.WriteHeader(http.StatusBadRequest)
+            return
+        }
+        w.Header().Set("Content-Type", "application/json")
+        _, _ = w.Write([]byte(`{"access_token":"fresh-token","refresh_token":"rt-new","expires_in":3600,"token_type":"Bearer"}`))
+    }))
+    defer ts.Close()
+
+    store := &CredentialStore{Path: filepath.Join(t.TempDir(), "credentials.json")}
+    store.Set("https://idp.example.com", &Session{
+        AccessToken:  "expired",
+        RefreshToken: "rt-live",
+        Expiry:       time.Now().Add(-time.Hour),
+        ClientId:     "gosignals-cli",
+    })
+
+    br := &bearerResolver{store: store, tokenEndpoint: func(string) (string, error) { return ts.URL, nil }}
+    tok, err := br.resolve("https://idp.example.com")
+    if err != nil {
+        t.Fatalf("silent refresh failed: %v", err)
+    }
+    if tok != "fresh-token" {
+        t.Errorf("expected refreshed access token, got %q", tok)
+    }
+    // The new tokens should be persisted back into the store.
+    sess := store.Get("https://idp.example.com")
+    if sess.AccessToken != "fresh-token" || sess.RefreshToken != "rt-new" {
+        t.Errorf("refreshed session not persisted: %+v", sess)
+    }
+}
+
+func TestResolveBearer_DeadRefreshInstructsRelogin(t *testing.T) {
+    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.WriteHeader(http.StatusBadRequest)
+        _, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+    }))
+    defer ts.Close()
+
+    store := &CredentialStore{Path: filepath.Join(t.TempDir(), "credentials.json")}
+    store.Set("https://idp.example.com", &Session{
+        AccessToken:  "expired",
+        RefreshToken: "rt-dead",
+        Expiry:       time.Now().Add(-time.Hour),
+    })
+
+    br := &bearerResolver{store: store, tokenEndpoint: func(string) (string, error) { return ts.URL, nil }}
+    _, err := br.resolve("https://idp.example.com")
+    if err == nil {
+        t.Fatal("expected error when refresh token is dead")
+    }
+    if !errors.Is(err, errReloginRequired) {
+        t.Errorf("expected errReloginRequired sentinel, got %v", err)
+    }
+}
+
+func TestResolveBearer_NoSessionInstructsLogin(t *testing.T) {
+    store := &CredentialStore{Path: filepath.Join(t.TempDir(), "credentials.json")}
+    br := &bearerResolver{store: store, tokenEndpoint: func(string) (string, error) { return "", nil }}
+    _, err := br.resolve("https://idp.example.com")
+    if !errors.Is(err, errReloginRequired) {
+        t.Errorf("expected errReloginRequired when no session, got %v", err)
+    }
+}

--- a/cmd/goSignals/commands.go
+++ b/cmd/goSignals/commands.go
@@ -12,7 +12,6 @@ import (
 	"regexp"
 
 	jwt "github.com/golang-jwt/jwt/v5"
-	"github.com/i2-open/i2goSignals/pkg/authSupport"
 	"github.com/i2-open/i2goSignals/pkg/goScim/resource"
 	"github.com/i2-open/i2goSignals/pkg/httpSupport"
 	"github.com/i2-open/i2goSignals/pkg/ssfModels"
@@ -51,12 +50,14 @@ func getHttpClient(timeout time.Duration) *http.Client {
 }
 
 type AddServerCmd struct {
-	Alias string `arg:"" help:"A unique name to identify the server"`
-	Host  string `arg:"" required:"" help:"Http URL for a goSignals server"`
-	Desc  string `help:"Description of project"`
-	Email string `help:"Contact email for project"`
-	Iat   string `help:"Registration Initial Access Auth if provided"`
-	Token string `help:"Administration authorization token"`
+	Alias        string `arg:"" help:"A unique name to identify the server"`
+	Host         string `arg:"" required:"" help:"Http URL for a goSignals server"`
+	Desc         string `help:"Description of project"`
+	Email        string `help:"Contact email for project"`
+	Iat          string `help:"Registration Initial Access Auth if provided (non-interactive)"`
+	Token        string `help:"Administration authorization token (non-interactive)"`
+	ClientSecret string `help:"OAuth client secret for non-interactive client-credentials use"`
+	Bootstrap    bool   `help:"Use the I2SIG_BOOTSTRAP_TOKEN shared secret to mint an IAT (non-interactive)"`
 }
 
 func (as *AddServerCmd) Run(c *CLI) error {
@@ -114,22 +115,25 @@ func (as *AddServerCmd) Run(c *CLI) error {
 	}
 	server.ServerConfiguration = &transmitterConfiguration
 
-	// bootstrapOnly is set when the IAT was obtained via the shared bootstrap
-	// secret rather than an existing client token. In that case we do NOT
-	// auto-register an admin client (the privilege ceiling caps registration
-	// below stream_admin); instead we leave ClientToken empty so subsequent
-	// bootstrap-capable commands (create key / create iat) fall back to the
-	// bootstrap secret, which the server resolves to the narrow "key" scope.
-	bootstrapOnly := false
-
-	if as.Iat != "" {
+	// `add server` is connect-only: it performs SSF discovery and records the
+	// server without minting any credential. Interactive auth happens later via
+	// `login <alias>` (PKCE). The --iat/--token/--client-secret/--bootstrap
+	// flags remain for non-interactive (CI/bootstrap) use.
+	switch {
+	case as.Iat != "":
 		server.IatToken = cleanQuotes(as.Iat)
-	} else if as.Token == "" {
-		// The anonymous /iat path is closed. Obtain an IAT using the bootstrap
-		// secret (I2SIG_BOOTSTRAP_TOKEN) when no client token is configured.
+	case as.Token != "":
+		server.ClientToken = cleanQuotes(as.Token)
+	case as.ClientSecret != "":
+		// Stored for non-interactive client-credentials flows. Treated as a
+		// client token surrogate; the server validates it on use.
+		server.ClientToken = cleanQuotes(as.ClientSecret)
+	case as.Bootstrap:
+		// Explicit opt-in: mint an IAT using the shared bootstrap secret
+		// (I2SIG_BOOTSTRAP_TOKEN). The anonymous /iat path is closed.
 		boot := os.Getenv("I2SIG_BOOTSTRAP_TOKEN")
 		if boot == "" {
-			return errors.New("no client token and no I2SIG_BOOTSTRAP_TOKEN set; cannot obtain an IAT (anonymous /iat is disabled)")
+			return errors.New("--bootstrap requires I2SIG_BOOTSTRAP_TOKEN to be set")
 		}
 		iatUrl, _ := serverUrl.Parse("/iat")
 		fmt.Println("Obtaining authorization via bootstrap secret...")
@@ -145,44 +149,31 @@ func (as *AddServerCmd) Run(c *CLI) error {
 			return errors.New("unexpected status obtaining IAT: " + resp.Status)
 		}
 		regBytes, err := io.ReadAll(resp.Body)
-		var registration model.RegisterResponse
-		err = json.Unmarshal(regBytes, &registration)
 		if err != nil {
+			return err
+		}
+		var registration model.RegisterResponse
+		if err = json.Unmarshal(regBytes, &registration); err != nil {
 			return err
 		}
 		server.IatToken = registration.Token
-		bootstrapOnly = true
-	}
-
-	if as.Token != "" {
-		server.ClientToken = as.Token
-	} else if bootstrapOnly {
-		// Skip auto-registration: the bootstrap identity is key-scoped and may
-		// only mint keys/IATs, not a stream-admin client. ClientToken stays empty.
-		fmt.Println("Bootstrap mode: skipping client auto-registration for " + as.Alias)
-	} else {
-		as.Desc = cleanQuotes(as.Desc)
-		regUrl, _ := serverUrl.Parse("/register")
-		clientReg := model.RegisterParameters{
-			Scopes:      []string{authSupport.ScopeStreamAdmin, authSupport.ScopeStreamMgmt},
-			Email:       as.Email,
-			Description: as.Desc,
+		fmt.Println("Bootstrap mode: IAT recorded; client auto-registration skipped for " + as.Alias)
+	default:
+		// Connect-only. Attempt PRM discovery to cache the advertised
+		// authorization_servers so a subsequent `login` can proceed without
+		// re-discovery. Discovery failure is non-fatal (the server may simply
+		// not advertise OAuth; bootstrap-secret flows still work).
+		if prm, derr := discoverProtectedResource(server.Host); derr == nil && prm != nil {
+			server.AuthorizationServers = prm.AuthorizationServers
+			if len(prm.AuthorizationServers) > 0 {
+				fmt.Printf("Discovered authorization server(s): %v\n", prm.AuthorizationServers)
+				fmt.Printf("Run 'login %s' to authenticate.\n", as.Alias)
+			} else {
+				fmt.Println("Server does not advertise OAuth authorization_servers; use --bootstrap or --token for non-interactive auth.")
+			}
+		} else {
+			fmt.Println("Server recorded (no protected-resource metadata advertised).")
 		}
-		regBytes, _ := json.Marshal(&clientReg)
-		req, err := http.NewRequest(http.MethodPost, regUrl.String(), bytes.NewReader(regBytes))
-		req.Header.Set("Authorization", "Bearer "+server.IatToken)
-		resp, err = client.Do(req)
-		defer httpSupport.HandleRespClose(resp)
-		if err != nil {
-			return err
-		}
-		if resp.StatusCode != http.StatusOK {
-			return errors.New("Unexpected status response: " + resp.Status)
-		}
-		var clientResponse model.RegisterResponse
-		regBytes, err = io.ReadAll(resp.Body)
-		err = json.Unmarshal(regBytes, &clientResponse)
-		server.ClientToken = clientResponse.Token
 	}
 
 	c.Data.Servers[as.Alias] = server
@@ -762,10 +753,14 @@ func (cli *CLI) executeCreateRequest(streamAlias string, reg model.StreamConfigu
 	if err != nil {
 		return nil, err
 	}
-	if server.ClientToken != "" {
-		req.Header.Set("Authorization", "Bearer "+server.ClientToken)
+	bearer, err := serverBearer(&cli.Globals, server)
+	if err != nil {
+		return nil, err
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
 	} else {
-		fmt.Println("No server client token detected. Attempting anonymous request...")
+		fmt.Println("No server credential detected. Run 'login " + server.Alias + "' or attempt anonymous request...")
 	}
 
 	client := getHttpClient(0)
@@ -1185,7 +1180,13 @@ func (s *GetStreamStatusCmd) Run(cli *CLI) error {
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Authorization", "Bearer "+server.ClientToken)
+	bearer, err := serverBearer(&cli.Globals, server)
+	if err != nil {
+		return err
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
 	client := getHttpClient(0)
 	resp, err := client.Do(req)
 	defer httpSupport.HandleRespClose(resp)

--- a/cmd/goSignals/commands.go
+++ b/cmd/goSignals/commands.go
@@ -1317,6 +1317,18 @@ type GetCmd struct {
 	SubjectFilter GetSubjectFilterCmd `cmd:"" aliases:"sf" help:"Get a stream's subject-filter config (operator-tunable knobs)."`
 }
 
+type DeleteServerCmd struct {
+	Alias string `arg:"" help:"The alias of a server to delete"`
+}
+
+func (d *DeleteServerCmd) Run(cli *CLI) error {
+	if err := cli.Data.DeleteServer(d.Alias, &cli.Globals); err != nil {
+		return err
+	}
+	fmt.Println(d.Alias + " deleted.")
+	return nil
+}
+
 type DeleteStreamCmd struct {
 	Alias string `arg:"" help:"The alias of a stream to delete"`
 }
@@ -1357,6 +1369,7 @@ func (d *DeleteStreamCmd) Run(cli *CLI) error {
 
 type DeleteCmd struct {
 	Stream DeleteStreamCmd `cmd:"" aliases:"s" help:"Delete a stream"`
+	Server DeleteServerCmd `cmd:"" aliases:"r" help:"Delete local server definition"`
 }
 
 type SetStreamConfigCmd struct {

--- a/cmd/goSignals/commands.go
+++ b/cmd/goSignals/commands.go
@@ -114,17 +114,35 @@ func (as *AddServerCmd) Run(c *CLI) error {
 	}
 	server.ServerConfiguration = &transmitterConfiguration
 
+	// bootstrapOnly is set when the IAT was obtained via the shared bootstrap
+	// secret rather than an existing client token. In that case we do NOT
+	// auto-register an admin client (the privilege ceiling caps registration
+	// below stream_admin); instead we leave ClientToken empty so subsequent
+	// bootstrap-capable commands (create key / create iat) fall back to the
+	// bootstrap secret, which the server resolves to the narrow "key" scope.
+	bootstrapOnly := false
+
 	if as.Iat != "" {
 		server.IatToken = cleanQuotes(as.Iat)
 	} else if as.Token == "" {
-		// Load tokens and register client
+		// The anonymous /iat path is closed. Obtain an IAT using the bootstrap
+		// secret (I2SIG_BOOTSTRAP_TOKEN) when no client token is configured.
+		boot := os.Getenv("I2SIG_BOOTSTRAP_TOKEN")
+		if boot == "" {
+			return errors.New("no client token and no I2SIG_BOOTSTRAP_TOKEN set; cannot obtain an IAT (anonymous /iat is disabled)")
+		}
 		iatUrl, _ := serverUrl.Parse("/iat")
-		fmt.Println("Obtaining authorization...")
-		resp, err = client.Get(iatUrl.String())
+		fmt.Println("Obtaining authorization via bootstrap secret...")
+		iatReq, _ := http.NewRequest(http.MethodGet, iatUrl.String(), nil)
+		iatReq.Header.Set("Authorization", "Bearer "+boot)
+		resp, err = client.Do(iatReq)
 		defer httpSupport.HandleRespClose(resp)
+		if err != nil {
+			return err
+		}
 		if resp.StatusCode != http.StatusOK {
 			fmt.Println("Error: unable to obtain registration IAT token")
-			return err
+			return errors.New("unexpected status obtaining IAT: " + resp.Status)
 		}
 		regBytes, err := io.ReadAll(resp.Body)
 		var registration model.RegisterResponse
@@ -133,10 +151,15 @@ func (as *AddServerCmd) Run(c *CLI) error {
 			return err
 		}
 		server.IatToken = registration.Token
+		bootstrapOnly = true
 	}
 
 	if as.Token != "" {
 		server.ClientToken = as.Token
+	} else if bootstrapOnly {
+		// Skip auto-registration: the bootstrap identity is key-scoped and may
+		// only mint keys/IATs, not a stream-admin client. ClientToken stays empty.
+		fmt.Println("Bootstrap mode: skipping client auto-registration for " + as.Alias)
 	} else {
 		as.Desc = cleanQuotes(as.Desc)
 		regUrl, _ := serverUrl.Parse("/register")
@@ -826,6 +849,18 @@ type CreateStreamCmd struct {
 	Events     []string            `optional:"" default:"*" help:"The event uris (types) requested for a stream. Use '*' to match by wildcard."`
 }
 
+// bootstrapBearer returns the bearer to present on bootstrap-capable calls
+// (create key / create iat). A configured client token wins; otherwise the
+// shared bootstrap secret (I2SIG_BOOTSTRAP_TOKEN) is used. Returns "" when
+// neither is available, in which case the now-non-anonymous server rejects the
+// request.
+func bootstrapBearer(clientToken string) string {
+	if clientToken != "" {
+		return clientToken
+	}
+	return os.Getenv("I2SIG_BOOTSTRAP_TOKEN")
+}
+
 type CreateKeyCmd struct {
 	Alias    string `arg:"" required:"" help:"The alias of the server to issue the key (default is selected server)"`
 	IssuerId string `arg:"" required:"" help:"The issuer value associated with the key (e.g. example.com)"`
@@ -846,10 +881,10 @@ func (c *CreateKeyCmd) Run(g *Globals) error {
 		certUrl.RawQuery = q.Encode()
 	}
 	req, _ := http.NewRequest(http.MethodPost, certUrl.String(), nil)
-	if server.ClientToken != "" {
-		req.Header.Set("Authorization", "Bearer "+server.ClientToken)
+	if bearer := bootstrapBearer(server.ClientToken); bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
 	} else {
-		fmt.Println(fmt.Sprintf("No authorization information for %s, attempting anonymous request.", server.Alias))
+		fmt.Println(fmt.Sprintf("No authorization information for %s and no I2SIG_BOOTSTRAP_TOKEN set; request will be rejected.", server.Alias))
 	}
 	client := getHttpClient(0)
 	defer client.CloseIdleConnections()
@@ -898,11 +933,14 @@ func (g *CreateIatCmd) Run(c *CLI) error {
 	}
 	iatUrl := hostUrl.JoinPath("/iat")
 	req, _ := http.NewRequest(http.MethodGet, iatUrl.String(), nil)
-	if !g.New {
-		// This will cause the IAT to be associated with the current client token (same project id)
-		if server.ClientToken != "" {
-			req.Header.Set("Authorization", "Bearer "+server.ClientToken)
-		}
+	// The anonymous /iat door is gone: /iat now requires a key/admin/root bearer.
+	// When a client token is present and --new is not set, reuse it so the IAT is
+	// associated with the current project; otherwise fall back to the bootstrap
+	// secret (I2SIG_BOOTSTRAP_TOKEN), which the server resolves to key scope.
+	if !g.New && server.ClientToken != "" {
+		req.Header.Set("Authorization", "Bearer "+server.ClientToken)
+	} else if boot := os.Getenv("I2SIG_BOOTSTRAP_TOKEN"); boot != "" {
+		req.Header.Set("Authorization", "Bearer "+boot)
 	}
 	client := getHttpClient(0)
 	defer client.CloseIdleConnections()

--- a/cmd/goSignals/config.go
+++ b/cmd/goSignals/config.go
@@ -131,6 +131,7 @@ func (c *ConfigData) ResetStreamConfig(streamAlias string) {
 		c.streamConfigs[streamAlias] = nil
 	}
 }
+
 func (c *ConfigData) GetStreamConfig(streamAlias string) (*model.StreamConfiguration, error) {
 	if c.streamConfigs == nil {
 		c.streamConfigs = map[string]*model.StreamConfiguration{}
@@ -201,6 +202,19 @@ func (c *ConfigData) GetServer(alias string) (*SsfServer, error) {
 
 	server := c.Servers[c.Selected]
 	return &server, nil
+}
+
+// DeleteServer removes a server definition from the configuration
+func (c *ConfigData) DeleteServer(alias string, g *Globals) error {
+	if alias != "" {
+		if _, exists := c.Servers[alias]; !exists {
+			return fmt.Errorf("specified alias '%s' is not defined", alias)
+		}
+		delete(c.Servers, alias)
+		return c.Save(g)
+	}
+
+	return nil
 }
 
 func (c *ConfigData) checkConfigPath(g *Globals) error {

--- a/cmd/goSignals/config.go
+++ b/cmd/goSignals/config.go
@@ -22,12 +22,19 @@ import (
 var ConfigFile = "config.json"
 
 type SsfServer struct {
-	Alias               string
-	Host                string
-	ClientToken         string // Used to administer streams (scope admin) within a project
-	IatToken            string // Used to register new client in the same project
-	ProjectId           string
-	Streams             map[string]Stream
+	Alias       string
+	Host        string
+	ClientToken string // Used to administer streams (scope admin) within a project
+	IatToken    string // Used to register new client in the same project
+	ProjectId   string
+	Streams     map[string]Stream
+	// AuthorizationServers caches the OAuth authorization_servers advertised by
+	// the server's Protected Resource Metadata. Non-secret; safe for config.json.
+	AuthorizationServers []string `json:",omitempty"`
+	// ActiveIssuer is the issuer the CLI is currently logged in against for this
+	// server. The actual session (tokens) lives in credentials.json keyed by
+	// issuer; only this pointer is cached here.
+	ActiveIssuer        string `json:",omitempty"`
 	ServerConfiguration *model.TransmitterConfiguration
 }
 

--- a/cmd/goSignals/credentials.go
+++ b/cmd/goSignals/credentials.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+    "encoding/json"
+    "errors"
+    "fmt"
+    "os"
+    "os/user"
+    "path/filepath"
+    "time"
+)
+
+// credentialsFileName is the secrets file living alongside config.json. It is
+// kept separate from config.json so that OAuth secrets never land in the
+// (potentially shared/checked-in) server configuration cache.
+const credentialsFileName = "credentials.json"
+
+// Session is a logged-in OAuth session keyed by issuer in the credential store.
+// It holds the bearer material and the resolved identity returned by the IdP.
+type Session struct {
+    AccessToken  string    `json:"accessToken"`
+    RefreshToken string    `json:"refreshToken,omitempty"`
+    Expiry       time.Time `json:"expiry"`
+    Subject      string    `json:"subject,omitempty"`
+    Email        string    `json:"email,omitempty"`
+    Scopes       []string  `json:"scopes,omitempty"`
+    ClientId     string    `json:"clientId,omitempty"`
+}
+
+// Expired reports whether the access token is at/after its expiry (with a small
+// skew so we refresh slightly early rather than racing the edge).
+func (s *Session) Expired() bool {
+    if s == nil {
+        return true
+    }
+    if s.Expiry.IsZero() {
+        return false
+    }
+    return time.Now().Add(30 * time.Second).After(s.Expiry)
+}
+
+// CredentialStore is a 0600 on-disk map of issuer -> Session. Secrets live here
+// only; config.json never holds tokens.
+type CredentialStore struct {
+    Path     string              `json:"-"`
+    Sessions map[string]*Session `json:"sessions"`
+}
+
+// credentialsPath returns the default credentials.json location, resolved
+// alongside the active config.json (honoring GOSIGNALS_HOME), else
+// ~/.goSignals/credentials.json.
+func credentialsPath(g *Globals) string {
+    if g != nil && g.ConfigFile != "" {
+        return filepath.Join(filepath.Dir(g.ConfigFile), credentialsFileName)
+    }
+    base := ".goSignals"
+    if usr, err := user.Current(); err == nil {
+        base = filepath.Join(usr.HomeDir, base)
+    }
+    return filepath.Join(base, credentialsFileName)
+}
+
+// LoadCredentialStore opens (or initializes) the credential store for the
+// current Globals.
+func LoadCredentialStore(g *Globals) (*CredentialStore, error) {
+    store := &CredentialStore{Path: credentialsPath(g)}
+    if err := store.Load(); err != nil {
+        return nil, err
+    }
+    return store, nil
+}
+
+// Load reads the store from disk. A missing file yields an empty store.
+func (c *CredentialStore) Load() error {
+    if c.Sessions == nil {
+        c.Sessions = map[string]*Session{}
+    }
+    if c.Path == "" {
+        return errors.New("credential store path not set")
+    }
+    bytes, err := os.ReadFile(c.Path)
+    if err != nil {
+        if os.IsNotExist(err) {
+            return nil
+        }
+        return err
+    }
+    if len(bytes) == 0 {
+        return nil
+    }
+    return json.Unmarshal(bytes, c)
+}
+
+// Save writes the store to disk at 0600, creating the parent directory if
+// necessary.
+func (c *CredentialStore) Save() error {
+    if c.Path == "" {
+        return errors.New("credential store path not set")
+    }
+    dir := filepath.Dir(c.Path)
+    if err := os.MkdirAll(dir, 0o700); err != nil {
+        return err
+    }
+    out, err := json.MarshalIndent(c, "", "  ")
+    if err != nil {
+        return err
+    }
+    // Write 0600 explicitly (and re-chmod in case the file pre-existed with
+    // looser permissions).
+    if err := os.WriteFile(c.Path, out, 0o600); err != nil {
+        return err
+    }
+    return os.Chmod(c.Path, 0o600)
+}
+
+// Get returns the session for an issuer, or nil if none is stored.
+func (c *CredentialStore) Get(issuer string) *Session {
+    if c.Sessions == nil {
+        return nil
+    }
+    return c.Sessions[issuer]
+}
+
+// Set stores (replacing any existing) a session for an issuer.
+func (c *CredentialStore) Set(issuer string, sess *Session) {
+    if c.Sessions == nil {
+        c.Sessions = map[string]*Session{}
+    }
+    c.Sessions[issuer] = sess
+}
+
+// Delete removes the session for an issuer (single-realm logout).
+func (c *CredentialStore) Delete(issuer string) {
+    if c.Sessions != nil {
+        delete(c.Sessions, issuer)
+    }
+}
+
+// describe returns a human-readable one-line summary of the session for whoami.
+func (s *Session) describe(issuer string) string {
+    who := s.Subject
+    if s.Email != "" {
+        who = fmt.Sprintf("%s <%s>", s.Subject, s.Email)
+    }
+    exp := "no-expiry"
+    if !s.Expiry.IsZero() {
+        exp = s.Expiry.Format(time.RFC3339)
+    }
+    return fmt.Sprintf("issuer=%s subject=%s scopes=%v expires=%s clientId=%s", issuer, who, s.Scopes, exp, s.ClientId)
+}

--- a/cmd/goSignals/credentials.go
+++ b/cmd/goSignals/credentials.go
@@ -25,6 +25,10 @@ type Session struct {
     Email        string    `json:"email,omitempty"`
     Scopes       []string  `json:"scopes,omitempty"`
     ClientId     string    `json:"clientId,omitempty"`
+    // LoggedInAt records when this session was established. It drives
+    // last-login-wins active-issuer defaulting when a server trusts several
+    // logged-in realms.
+    LoggedInAt time.Time `json:"loggedInAt,omitempty"`
 }
 
 // Expired reports whether the access token is at/after its expiry (with a small
@@ -127,6 +131,18 @@ func (c *CredentialStore) Set(issuer string, sess *Session) {
         c.Sessions = map[string]*Session{}
     }
     c.Sessions[issuer] = sess
+}
+
+// Issuers returns the set of issuers (realms) with a stored session.
+func (c *CredentialStore) Issuers() []string {
+    if c.Sessions == nil {
+        return nil
+    }
+    out := make([]string, 0, len(c.Sessions))
+    for iss := range c.Sessions {
+        out = append(out, iss)
+    }
+    return out
 }
 
 // Delete removes the session for an issuer (single-realm logout).

--- a/cmd/goSignals/credentials_test.go
+++ b/cmd/goSignals/credentials_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+    "os"
+    "path/filepath"
+    "runtime"
+    "testing"
+    "time"
+)
+
+func TestCredentialStore_SaveLoadRoundTrip(t *testing.T) {
+    dir := t.TempDir()
+    path := filepath.Join(dir, "credentials.json")
+
+    store := &CredentialStore{Path: path}
+    sess := &Session{
+        AccessToken:  "at-123",
+        RefreshToken: "rt-456",
+        Expiry:       time.Now().Add(time.Hour).UTC().Truncate(time.Second),
+        Subject:      "user-1",
+        Email:        "user@example.com",
+        Scopes:       []string{"admin", "stream"},
+        ClientId:     "gosignals-cli",
+    }
+    store.Set("https://idp.example.com", sess)
+    if err := store.Save(); err != nil {
+        t.Fatalf("save failed: %v", err)
+    }
+
+    // Reload from disk into a fresh store
+    reloaded := &CredentialStore{Path: path}
+    if err := reloaded.Load(); err != nil {
+        t.Fatalf("load failed: %v", err)
+    }
+    got := reloaded.Get("https://idp.example.com")
+    if got == nil {
+        t.Fatalf("expected session for issuer, got nil")
+    }
+    if got.AccessToken != "at-123" || got.RefreshToken != "rt-456" {
+        t.Errorf("tokens not round-tripped: %+v", got)
+    }
+    if got.Subject != "user-1" || got.Email != "user@example.com" {
+        t.Errorf("identity not round-tripped: %+v", got)
+    }
+    if len(got.Scopes) != 2 || got.ClientId != "gosignals-cli" {
+        t.Errorf("scopes/clientId not round-tripped: %+v", got)
+    }
+}
+
+func TestCredentialStore_FileIs0600(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("posix file permissions not enforced on windows")
+    }
+    dir := t.TempDir()
+    path := filepath.Join(dir, "credentials.json")
+    store := &CredentialStore{Path: path}
+    store.Set("https://idp.example.com", &Session{AccessToken: "at"})
+    if err := store.Save(); err != nil {
+        t.Fatalf("save failed: %v", err)
+    }
+    info, err := os.Stat(path)
+    if err != nil {
+        t.Fatalf("stat failed: %v", err)
+    }
+    if perm := info.Mode().Perm(); perm != 0o600 {
+        t.Errorf("expected credentials.json mode 0600, got %o", perm)
+    }
+}
+
+func TestCredentialStore_DeleteRemovesSession(t *testing.T) {
+    store := &CredentialStore{Path: filepath.Join(t.TempDir(), "credentials.json")}
+    store.Set("https://idp.example.com", &Session{AccessToken: "at"})
+    store.Delete("https://idp.example.com")
+    if store.Get("https://idp.example.com") != nil {
+        t.Errorf("expected session removed after Delete")
+    }
+}
+
+func TestCredentialStore_LoadMissingFileIsEmpty(t *testing.T) {
+    store := &CredentialStore{Path: filepath.Join(t.TempDir(), "nope.json")}
+    if err := store.Load(); err != nil {
+        t.Fatalf("loading a missing credentials file should not error, got %v", err)
+    }
+    if store.Get("anything") != nil {
+        t.Errorf("expected empty store for missing file")
+    }
+}

--- a/cmd/goSignals/device.go
+++ b/cmd/goSignals/device.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+    "encoding/json"
+    "fmt"
+    "io"
+    "net/url"
+    "strings"
+    "time"
+)
+
+// deviceCodeGrantType is the RFC 8628 grant_type used when polling the token
+// endpoint for a device-code authorization.
+const deviceCodeGrantType = "urn:ietf:params:oauth:grant-type:device_code"
+
+// deviceAuthorization is the subset of the RFC 8628 device authorization
+// response the CLI consumes.
+type deviceAuthorization struct {
+    DeviceCode              string `json:"device_code"`
+    UserCode                string `json:"user_code"`
+    VerificationURI         string `json:"verification_uri"`
+    VerificationURIComplete string `json:"verification_uri_complete"`
+    ExpiresIn               int    `json:"expires_in"`
+    Interval                int    `json:"interval"`
+}
+
+// requestDeviceAuthorization performs the RFC 8628 device authorization request,
+// posting the public client_id (and optional scopes) to the issuer's device
+// authorization endpoint. A missing interval defaults to 5 seconds per the spec.
+func requestDeviceAuthorization(deviceEndpoint, clientId string, scopes []string) (*deviceAuthorization, error) {
+    form := url.Values{}
+    form.Set("client_id", clientId)
+    scope := "openid email profile"
+    if len(scopes) > 0 {
+        scope = strings.Join(scopes, " ")
+    }
+    form.Set("scope", scope)
+
+    client := getHttpClient(30 * time.Second)
+    resp, err := client.PostForm(deviceEndpoint, form)
+    if err != nil {
+        return nil, err
+    }
+    defer func() { _ = resp.Body.Close() }()
+    body, _ := io.ReadAll(resp.Body)
+    if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+        return nil, fmt.Errorf("device authorization endpoint returned %s: %s", resp.Status, string(body))
+    }
+
+    var da deviceAuthorization
+    if err := json.Unmarshal(body, &da); err != nil {
+        return nil, fmt.Errorf("could not parse device authorization response: %w", err)
+    }
+    if da.DeviceCode == "" {
+        return nil, fmt.Errorf("device authorization response did not include a device_code")
+    }
+    if da.Interval <= 0 {
+        da.Interval = 5
+    }
+    return &da, nil
+}
+
+// loginMethod identifies which login flow the engine will run.
+type loginMethod int
+
+const (
+    loginMethodPKCE loginMethod = iota
+    loginMethodDevice
+)
+
+func (m loginMethod) String() string {
+    if m == loginMethodDevice {
+        return "device-code"
+    }
+    return "pkce-loopback"
+}
+
+// loginCapabilities describes what the current host can do, so the engine can
+// pick the appropriate login flow.
+type loginCapabilities struct {
+    // ForceDevice is set by the --device flag.
+    ForceDevice bool
+    // CanBindLoopback is true when an ephemeral 127.0.0.1 listener was bound.
+    CanBindLoopback bool
+    // CanOpenBrowser is true when the system browser can be launched.
+    CanOpenBrowser bool
+}
+
+// selectLoginMethod chooses between the PKCE loopback flow and the RFC 8628
+// device-code flow. --device always forces device-code; otherwise the
+// device-code flow is selected automatically whenever a loopback listener can't
+// be bound or a browser can't be opened (headless hosts, SSH sessions,
+// locked-down containers). When both capabilities are present, the richer PKCE
+// loopback flow is used.
+func selectLoginMethod(caps loginCapabilities) loginMethod {
+    if caps.ForceDevice {
+        return loginMethodDevice
+    }
+    if !caps.CanBindLoopback || !caps.CanOpenBrowser {
+        return loginMethodDevice
+    }
+    return loginMethodPKCE
+}
+
+// runDeviceLogin performs the RFC 8628 device authorization grant: it requests
+// a device/user code, prints the verification URL + user code for the operator
+// to complete on a second device, then polls the token endpoint until the
+// authorization completes. It produces a Session identical in shape to the PKCE
+// path by reusing sessionFromTokenResponse.
+func runDeviceLogin(opts loginOptions) (*Session, error) {
+    if opts.Endpoints == nil || opts.Endpoints.DeviceAuthorization == "" {
+        return nil, fmt.Errorf("issuer does not advertise a device_authorization_endpoint; device-code login is not available")
+    }
+
+    da, err := requestDeviceAuthorization(opts.Endpoints.DeviceAuthorization, opts.ClientId, opts.Scopes)
+    if err != nil {
+        return nil, err
+    }
+
+    fmt.Println("To complete login, on any device open:")
+    if da.VerificationURIComplete != "" {
+        fmt.Println("  " + da.VerificationURIComplete)
+        fmt.Println("(or open " + da.VerificationURI + " and enter code: " + da.UserCode + ")")
+    } else {
+        fmt.Println("  " + da.VerificationURI)
+        fmt.Println("and enter code: " + da.UserCode)
+    }
+    fmt.Println("Waiting for authorization...")
+
+    return pollDeviceToken(deviceTokenRequest{
+        TokenEndpoint: opts.Endpoints.Token,
+        ClientId:      opts.ClientId,
+        Device:        da,
+        clock:         opts.sleep,
+    })
+}
+
+// deviceTokenRequest carries the parameters for polling the token endpoint with
+// a device_code grant. clock is a seam so tests can drive the polling loop
+// without real time elapsing.
+type deviceTokenRequest struct {
+    TokenEndpoint string
+    ClientId      string
+    Device        *deviceAuthorization
+    // clock is invoked to wait between polls; defaults to time.Sleep.
+    clock func(time.Duration)
+}
+
+// pollDeviceToken implements the RFC 8628 token polling loop. It repeatedly
+// POSTs grant_type=device_code to the token endpoint, sleeping the advertised
+// interval between attempts. authorization_pending continues polling; slow_down
+// grows the interval by 5 seconds; expired_token (or the locally-tracked
+// expires_in deadline) aborts; any other error aborts. A successful response is
+// converted to a Session via the shared sessionFromTokenResponse helper.
+func pollDeviceToken(req deviceTokenRequest) (*Session, error) {
+    sleep := req.clock
+    if sleep == nil {
+        sleep = time.Sleep
+    }
+    interval := time.Duration(req.Device.Interval) * time.Second
+    if interval <= 0 {
+        interval = 5 * time.Second
+    }
+    deadline := time.Now().Add(time.Duration(req.Device.ExpiresIn) * time.Second)
+
+    client := getHttpClient(30 * time.Second)
+    for {
+        sleep(interval)
+
+        form := url.Values{}
+        form.Set("grant_type", deviceCodeGrantType)
+        form.Set("device_code", req.Device.DeviceCode)
+        form.Set("client_id", req.ClientId)
+
+        resp, err := client.PostForm(req.TokenEndpoint, form)
+        if err != nil {
+            return nil, err
+        }
+        body, _ := io.ReadAll(resp.Body)
+        _ = resp.Body.Close()
+
+        if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+            return sessionFromTokenBody(body, req.ClientId)
+        }
+
+        var errResp struct {
+            Error            string `json:"error"`
+            ErrorDescription string `json:"error_description"`
+        }
+        _ = json.Unmarshal(body, &errResp)
+
+        switch errResp.Error {
+        case "authorization_pending":
+            // keep polling at the current interval
+        case "slow_down":
+            interval += 5 * time.Second
+        case "expired_token":
+            return nil, fmt.Errorf("device code expired before authorization completed")
+        default:
+            return nil, fmt.Errorf("token endpoint returned %s: %s", resp.Status, string(body))
+        }
+
+        if time.Now().After(deadline) {
+            return nil, fmt.Errorf("device code expired before authorization completed")
+        }
+    }
+}

--- a/cmd/goSignals/device_test.go
+++ b/cmd/goSignals/device_test.go
@@ -1,0 +1,403 @@
+package main
+
+import (
+    "net/http"
+    "net/http/httptest"
+    "net/url"
+    "testing"
+    "time"
+)
+
+// TestRequestDeviceAuthorization_ParsesResponse verifies the RFC 8628 device
+// authorization request: it POSTs client_id + scope to the device
+// authorization endpoint and parses device_code, user_code, verification_uri,
+// verification_uri_complete, interval and expires_in.
+func TestRequestDeviceAuthorization_ParsesResponse(t *testing.T) {
+    var gotForm url.Values
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        _ = r.ParseForm()
+        gotForm = r.Form
+        w.Header().Set("Content-Type", "application/json")
+        _, _ = w.Write([]byte(`{
+            "device_code":"dev-123",
+            "user_code":"WDJB-MJHT",
+            "verification_uri":"https://idp.example.com/device",
+            "verification_uri_complete":"https://idp.example.com/device?user_code=WDJB-MJHT",
+            "expires_in":900,
+            "interval":5
+        }`))
+    }))
+    defer srv.Close()
+
+    da, err := requestDeviceAuthorization(srv.URL, "gosignals-cli", []string{"openid", "admin"})
+    if err != nil {
+        t.Fatalf("requestDeviceAuthorization failed: %v", err)
+    }
+    if gotForm.Get("client_id") != "gosignals-cli" {
+        t.Errorf("expected client_id in request, got %q", gotForm.Get("client_id"))
+    }
+    if gotForm.Get("scope") != "openid admin" {
+        t.Errorf("expected space-joined scope, got %q", gotForm.Get("scope"))
+    }
+    if da.DeviceCode != "dev-123" || da.UserCode != "WDJB-MJHT" {
+        t.Errorf("unexpected device authorization: %+v", da)
+    }
+    if da.VerificationURI != "https://idp.example.com/device" {
+        t.Errorf("unexpected verification_uri: %q", da.VerificationURI)
+    }
+    if da.VerificationURIComplete != "https://idp.example.com/device?user_code=WDJB-MJHT" {
+        t.Errorf("unexpected verification_uri_complete: %q", da.VerificationURIComplete)
+    }
+    if da.Interval != 5 || da.ExpiresIn != 900 {
+        t.Errorf("unexpected interval/expires_in: %+v", da)
+    }
+}
+
+// TestRequestDeviceAuthorization_DefaultsInterval verifies that when the IdP
+// omits interval, RFC 8628's default of 5 seconds is applied.
+func TestRequestDeviceAuthorization_DefaultsInterval(t *testing.T) {
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+        _, _ = w.Write([]byte(`{"device_code":"d","user_code":"u","verification_uri":"https://x/device","expires_in":600}`))
+    }))
+    defer srv.Close()
+
+    da, err := requestDeviceAuthorization(srv.URL, "c", nil)
+    if err != nil {
+        t.Fatalf("requestDeviceAuthorization failed: %v", err)
+    }
+    if da.Interval != 5 {
+        t.Errorf("expected default interval 5, got %d", da.Interval)
+    }
+}
+
+// TestRequestDeviceAuthorization_ErrorStatus surfaces a non-2xx response as an
+// error rather than a malformed device authorization.
+func TestRequestDeviceAuthorization_ErrorStatus(t *testing.T) {
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.WriteHeader(http.StatusBadRequest)
+        _, _ = w.Write([]byte(`{"error":"invalid_client"}`))
+    }))
+    defer srv.Close()
+
+    if _, err := requestDeviceAuthorization(srv.URL, "c", nil); err == nil {
+        t.Error("expected error on non-2xx device authorization response")
+    }
+}
+
+// TestPollDeviceToken_PendingThenSuccess drives the polling loop: the token
+// endpoint first returns authorization_pending, then a successful token
+// response. The loop must keep polling and yield a Session.
+func TestPollDeviceToken_PendingThenSuccess(t *testing.T) {
+    idToken := makeUnsignedIDToken(map[string]any{"sub": "bob", "email": "bob@example.com"})
+    var calls int
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        _ = r.ParseForm()
+        if r.Form.Get("grant_type") != "urn:ietf:params:oauth:grant-type:device_code" {
+            t.Errorf("expected device_code grant_type, got %q", r.Form.Get("grant_type"))
+        }
+        if r.Form.Get("device_code") != "dev-xyz" {
+            t.Errorf("expected device_code, got %q", r.Form.Get("device_code"))
+        }
+        calls++
+        w.Header().Set("Content-Type", "application/json")
+        if calls < 2 {
+            w.WriteHeader(http.StatusBadRequest)
+            _, _ = w.Write([]byte(`{"error":"authorization_pending"}`))
+            return
+        }
+        _, _ = w.Write([]byte(`{"access_token":"acc","refresh_token":"ref","expires_in":3600,"scope":"admin","id_token":"` + idToken + `"}`))
+    }))
+    defer srv.Close()
+
+    da := &deviceAuthorization{DeviceCode: "dev-xyz", Interval: 1, ExpiresIn: 60}
+    sess, err := pollDeviceToken(deviceTokenRequest{
+        TokenEndpoint: srv.URL,
+        ClientId:      "gosignals-cli",
+        Device:        da,
+        clock:         fakeClock(),
+    })
+    if err != nil {
+        t.Fatalf("pollDeviceToken failed: %v", err)
+    }
+    if calls < 2 {
+        t.Errorf("expected at least 2 polls (pending then success), got %d", calls)
+    }
+    if sess.AccessToken != "acc" || sess.Subject != "bob" {
+        t.Errorf("unexpected session: %+v", sess)
+    }
+}
+
+// TestPollDeviceToken_SlowDownBacksOff verifies that a slow_down error
+// increases the polling interval by 5 seconds per RFC 8628 and the loop
+// recovers on the next successful poll.
+func TestPollDeviceToken_SlowDownBacksOff(t *testing.T) {
+    var sleeps []time.Duration
+    clk := &recordingClock{}
+    var calls int
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        calls++
+        w.Header().Set("Content-Type", "application/json")
+        switch calls {
+        case 1:
+            w.WriteHeader(http.StatusBadRequest)
+            _, _ = w.Write([]byte(`{"error":"slow_down"}`))
+        default:
+            _, _ = w.Write([]byte(`{"access_token":"acc"}`))
+        }
+    }))
+    defer srv.Close()
+
+    da := &deviceAuthorization{DeviceCode: "d", Interval: 5, ExpiresIn: 120}
+    _, err := pollDeviceToken(deviceTokenRequest{
+        TokenEndpoint: srv.URL,
+        ClientId:      "c",
+        Device:        da,
+        clock:         clk.sleep,
+    })
+    if err != nil {
+        t.Fatalf("pollDeviceToken failed: %v", err)
+    }
+    sleeps = clk.sleeps
+    if len(sleeps) < 2 {
+        t.Fatalf("expected at least 2 sleeps, got %v", sleeps)
+    }
+    // First sleep is the initial interval (5s); after slow_down the next sleep
+    // must be 5s longer (10s).
+    if sleeps[0] != 5*time.Second {
+        t.Errorf("expected first sleep of 5s, got %v", sleeps[0])
+    }
+    if sleeps[1] != 10*time.Second {
+        t.Errorf("expected interval to grow to 10s after slow_down, got %v", sleeps[1])
+    }
+}
+
+// TestPollDeviceToken_ExpiredToken stops with an error when the IdP reports the
+// device code has expired.
+func TestPollDeviceToken_ExpiredToken(t *testing.T) {
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+        w.WriteHeader(http.StatusBadRequest)
+        _, _ = w.Write([]byte(`{"error":"expired_token"}`))
+    }))
+    defer srv.Close()
+
+    da := &deviceAuthorization{DeviceCode: "d", Interval: 1, ExpiresIn: 60}
+    if _, err := pollDeviceToken(deviceTokenRequest{
+        TokenEndpoint: srv.URL,
+        ClientId:      "c",
+        Device:        da,
+        clock:         fakeClock(),
+    }); err == nil {
+        t.Error("expected error when device code expired")
+    }
+}
+
+// TestPollDeviceToken_LocalDeadline stops polling once the device code's own
+// expires_in has elapsed, without depending on the IdP returning expired_token.
+func TestPollDeviceToken_LocalDeadline(t *testing.T) {
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+        w.WriteHeader(http.StatusBadRequest)
+        _, _ = w.Write([]byte(`{"error":"authorization_pending"}`))
+    }))
+    defer srv.Close()
+
+    // expires_in of 0 means the deadline is already reached after the first poll.
+    da := &deviceAuthorization{DeviceCode: "d", Interval: 1, ExpiresIn: 0}
+    if _, err := pollDeviceToken(deviceTokenRequest{
+        TokenEndpoint: srv.URL,
+        ClientId:      "c",
+        Device:        da,
+        clock:         fakeClock(),
+    }); err == nil {
+        t.Error("expected error when device code local deadline elapses")
+    }
+}
+
+// TestRunDeviceLogin_EndToEnd drives the full device-code flow against a mock
+// IdP: request device authorization, then poll the token endpoint (pending then
+// success). It verifies the resulting Session has the same shape as the PKCE
+// path (access/refresh token, subject from id_token).
+func TestRunDeviceLogin_EndToEnd(t *testing.T) {
+    idToken := makeUnsignedIDToken(map[string]any{"sub": "carol", "email": "carol@example.com"})
+    var polls int
+    mux := http.NewServeMux()
+    mux.HandleFunc("/device", func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+        _, _ = w.Write([]byte(`{"device_code":"dc","user_code":"ABCD-EFGH","verification_uri":"https://idp/device","verification_uri_complete":"https://idp/device?user_code=ABCD-EFGH","expires_in":120,"interval":1}`))
+    })
+    mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+        polls++
+        w.Header().Set("Content-Type", "application/json")
+        if polls < 2 {
+            w.WriteHeader(http.StatusBadRequest)
+            _, _ = w.Write([]byte(`{"error":"authorization_pending"}`))
+            return
+        }
+        _, _ = w.Write([]byte(`{"access_token":"acc","refresh_token":"ref","expires_in":3600,"scope":"admin","id_token":"` + idToken + `"}`))
+    })
+    srv := httptest.NewServer(mux)
+    defer srv.Close()
+
+    sess, err := runDeviceLogin(loginOptions{
+        Issuer:   "https://idp.example.com",
+        ClientId: "gosignals-cli",
+        Scopes:   []string{"openid", "admin"},
+        Endpoints: &oidcEndpoints{
+            Token:               srv.URL + "/token",
+            DeviceAuthorization: srv.URL + "/device",
+            Issuer:              "https://idp.example.com",
+        },
+        sleep: fakeClock(),
+    })
+    if err != nil {
+        t.Fatalf("runDeviceLogin failed: %v", err)
+    }
+    if sess.AccessToken != "acc" || sess.RefreshToken != "ref" || sess.Subject != "carol" {
+        t.Errorf("device login produced unexpected session: %+v", sess)
+    }
+}
+
+// TestRunDeviceLogin_RequiresDeviceEndpoint errors clearly when the issuer does
+// not advertise a device authorization endpoint.
+func TestRunDeviceLogin_RequiresDeviceEndpoint(t *testing.T) {
+    _, err := runDeviceLogin(loginOptions{
+        ClientId:  "c",
+        Endpoints: &oidcEndpoints{Token: "https://idp/token"},
+    })
+    if err == nil {
+        t.Error("expected error when device_authorization_endpoint is not advertised")
+    }
+}
+
+// TestRunLogin_ForceDeviceRoutesToDeviceFlow verifies the public dispatcher:
+// with ForceDevice set, runLogin runs the device-code flow even on a host that
+// could bind loopback and open a browser.
+func TestRunLogin_ForceDeviceRoutesToDeviceFlow(t *testing.T) {
+    idToken := makeUnsignedIDToken(map[string]any{"sub": "dave"})
+    mux := http.NewServeMux()
+    mux.HandleFunc("/device", func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+        _, _ = w.Write([]byte(`{"device_code":"dc","user_code":"U","verification_uri":"https://idp/device","expires_in":120,"interval":1}`))
+    })
+    mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+        _ = r.ParseForm()
+        if r.Form.Get("grant_type") != "urn:ietf:params:oauth:grant-type:device_code" {
+            t.Errorf("expected device_code grant, got %q", r.Form.Get("grant_type"))
+        }
+        w.Header().Set("Content-Type", "application/json")
+        _, _ = w.Write([]byte(`{"access_token":"acc","id_token":"` + idToken + `"}`))
+    })
+    srv := httptest.NewServer(mux)
+    defer srv.Close()
+
+    sess, err := runLogin(loginOptions{
+        ClientId: "c",
+        Endpoints: &oidcEndpoints{
+            Token:               srv.URL + "/token",
+            DeviceAuthorization: srv.URL + "/device",
+        },
+        ForceDevice: true,
+        sleep:       fakeClock(),
+    })
+    if err != nil {
+        t.Fatalf("runLogin (force device) failed: %v", err)
+    }
+    if sess.AccessToken != "acc" || sess.Subject != "dave" {
+        t.Errorf("unexpected session from forced device flow: %+v", sess)
+    }
+}
+
+// TestRunLogin_AutoFallbackToDeviceWhenHeadless verifies the auto-fallback: with
+// no browser and no loopback bind available, runLogin selects the device-code
+// flow without --device.
+func TestRunLogin_AutoFallbackToDeviceWhenHeadless(t *testing.T) {
+    origBrowser := browserAvailable
+    origBind := canBindLoopback
+    defer func() {
+        browserAvailable = origBrowser
+        canBindLoopback = origBind
+    }()
+    browserAvailable = func() bool { return false }
+    canBindLoopback = func() bool { return false }
+
+    idToken := makeUnsignedIDToken(map[string]any{"sub": "erin"})
+    mux := http.NewServeMux()
+    mux.HandleFunc("/device", func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+        _, _ = w.Write([]byte(`{"device_code":"dc","user_code":"U","verification_uri":"https://idp/device","expires_in":120,"interval":1}`))
+    })
+    mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+        _, _ = w.Write([]byte(`{"access_token":"acc","id_token":"` + idToken + `"}`))
+    })
+    srv := httptest.NewServer(mux)
+    defer srv.Close()
+
+    sess, err := runLogin(loginOptions{
+        ClientId: "c",
+        Endpoints: &oidcEndpoints{
+            Token:               srv.URL + "/token",
+            DeviceAuthorization: srv.URL + "/device",
+        },
+        sleep: fakeClock(),
+    })
+    if err != nil {
+        t.Fatalf("runLogin (auto-fallback) failed: %v", err)
+    }
+    if sess.AccessToken != "acc" || sess.Subject != "erin" {
+        t.Errorf("auto-fallback did not produce device session: %+v", sess)
+    }
+}
+
+// TestSelectLoginMethod_ForceDevice forces the device path regardless of
+// loopback/browser availability.
+func TestSelectLoginMethod_ForceDevice(t *testing.T) {
+    m := selectLoginMethod(loginCapabilities{ForceDevice: true, CanBindLoopback: true, CanOpenBrowser: true})
+    if m != loginMethodDevice {
+        t.Errorf("--device should force device path, got %v", m)
+    }
+}
+
+// TestSelectLoginMethod_FallbackWhenNoLoopback chooses device-code when a
+// loopback listener cannot be bound (e.g. locked-down container).
+func TestSelectLoginMethod_FallbackWhenNoLoopback(t *testing.T) {
+    m := selectLoginMethod(loginCapabilities{CanBindLoopback: false, CanOpenBrowser: true})
+    if m != loginMethodDevice {
+        t.Errorf("missing loopback should fall back to device, got %v", m)
+    }
+}
+
+// TestSelectLoginMethod_FallbackWhenNoBrowser chooses device-code on a headless
+// host where no browser can be opened.
+func TestSelectLoginMethod_FallbackWhenNoBrowser(t *testing.T) {
+    m := selectLoginMethod(loginCapabilities{CanBindLoopback: true, CanOpenBrowser: false})
+    if m != loginMethodDevice {
+        t.Errorf("missing browser should fall back to device, got %v", m)
+    }
+}
+
+// TestSelectLoginMethod_PKCEWhenCapable uses the loopback PKCE path when both a
+// loopback listener and a browser are available and --device was not given.
+func TestSelectLoginMethod_PKCEWhenCapable(t *testing.T) {
+    m := selectLoginMethod(loginCapabilities{CanBindLoopback: true, CanOpenBrowser: true})
+    if m != loginMethodPKCE {
+        t.Errorf("capable host should use PKCE loopback, got %v", m)
+    }
+}
+
+// fakeClock returns a sleep func that does not actually sleep, so polling tests
+// run instantly.
+func fakeClock() func(time.Duration) {
+    return func(time.Duration) {}
+}
+
+// recordingClock records the durations it is asked to sleep without sleeping.
+type recordingClock struct {
+    sleeps []time.Duration
+}
+
+func (c *recordingClock) sleep(d time.Duration) {
+    c.sleeps = append(c.sleeps, d)
+}

--- a/cmd/goSignals/discovery.go
+++ b/cmd/goSignals/discovery.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+    "context"
+    "errors"
+    "fmt"
+    "time"
+
+    "github.com/i2-open/i2goSignals/pkg/ssfModels"
+    "github.com/i2-open/i2goSignals/pkg/wellKnownSupport"
+)
+
+// discoverProtectedResource fetches the server's RFC9728 Protected Resource
+// Metadata so the CLI can learn the advertised authorization_servers and the
+// recommended public client_id.
+func discoverProtectedResource(host string) (*model.ProtectedResourceMetadata, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+    defer cancel()
+    client := getHttpClient(30 * time.Second)
+    return wellKnownSupport.FetchProtectedResourceMetadata(ctx, client, host)
+}
+
+// resolveIssuer selects the OAuth issuer (authorization server) to log in
+// against. An explicit issuer (from --issuer) always wins. Otherwise, if the
+// metadata advertises exactly one authorization server it is used. Multiple
+// advertised servers with no explicit choice is ambiguous, and none advertised
+// is an error (the caller may fall back to the bootstrap-secret flow).
+func resolveIssuer(meta *model.ProtectedResourceMetadata, explicit string) (string, error) {
+    if explicit != "" {
+        return explicit, nil
+    }
+    if meta == nil || len(meta.AuthorizationServers) == 0 {
+        return "", errors.New("no authorization_servers advertised in protected resource metadata")
+    }
+    if len(meta.AuthorizationServers) == 1 {
+        return meta.AuthorizationServers[0], nil
+    }
+    return "", fmt.Errorf("multiple authorization servers advertised (%v); specify one with --issuer", meta.AuthorizationServers)
+}
+
+// resolveClientId selects the public OAuth client_id. An explicit value (from
+// --client-id) always wins; otherwise the advertised client_id is used.
+func resolveClientId(meta *model.ProtectedResourceMetadata, explicit string) string {
+    if explicit != "" {
+        return explicit
+    }
+    if meta != nil && meta.ClientID != nil {
+        return *meta.ClientID
+    }
+    return ""
+}
+
+// oidcEndpoints carries the discovered OIDC/OAuth endpoints for an issuer.
+type oidcEndpoints struct {
+    Authorization string
+    Token         string
+    Issuer        string
+}
+
+// discoverEndpoints fetches the issuer's OpenID Provider configuration to learn
+// its authorization and token endpoints.
+func discoverEndpoints(issuer string) (*oidcEndpoints, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+    defer cancel()
+    client := getHttpClient(30 * time.Second)
+    cfg, err := wellKnownSupport.FetchOpenIDConfiguration(ctx, client, issuer)
+    if err != nil {
+        return nil, err
+    }
+    if cfg.AuthorizationEndpoint == "" || cfg.TokenEndpoint == "" {
+        return nil, fmt.Errorf("issuer %s did not advertise authorization/token endpoints", issuer)
+    }
+    return &oidcEndpoints{
+        Authorization: cfg.AuthorizationEndpoint,
+        Token:         cfg.TokenEndpoint,
+        Issuer:        cfg.Issuer,
+    }, nil
+}

--- a/cmd/goSignals/discovery.go
+++ b/cmd/goSignals/discovery.go
@@ -55,6 +55,9 @@ type oidcEndpoints struct {
     Authorization string
     Token         string
     Issuer        string
+    // DeviceAuthorization is the RFC 8628 device authorization endpoint, when
+    // advertised. Empty if the issuer does not support the device-code grant.
+    DeviceAuthorization string
 }
 
 // discoverEndpoints fetches the issuer's OpenID Provider configuration to learn
@@ -71,8 +74,9 @@ func discoverEndpoints(issuer string) (*oidcEndpoints, error) {
         return nil, fmt.Errorf("issuer %s did not advertise authorization/token endpoints", issuer)
     }
     return &oidcEndpoints{
-        Authorization: cfg.AuthorizationEndpoint,
-        Token:         cfg.TokenEndpoint,
-        Issuer:        cfg.Issuer,
+        Authorization:       cfg.AuthorizationEndpoint,
+        Token:               cfg.TokenEndpoint,
+        Issuer:              cfg.Issuer,
+        DeviceAuthorization: cfg.DeviceAuthEndpoint,
     }, nil
 }

--- a/cmd/goSignals/discovery.go
+++ b/cmd/goSignals/discovery.go
@@ -55,6 +55,9 @@ type oidcEndpoints struct {
     Authorization string
     Token         string
     Issuer        string
+    // Revocation is the RFC 7009 token revocation endpoint, when advertised.
+    // Empty if the issuer does not support revocation.
+    Revocation string
     // DeviceAuthorization is the RFC 8628 device authorization endpoint, when
     // advertised. Empty if the issuer does not support the device-code grant.
     DeviceAuthorization string
@@ -77,6 +80,7 @@ func discoverEndpoints(issuer string) (*oidcEndpoints, error) {
         Authorization:       cfg.AuthorizationEndpoint,
         Token:               cfg.TokenEndpoint,
         Issuer:              cfg.Issuer,
+        Revocation:          cfg.RevocationEndpoint,
         DeviceAuthorization: cfg.DeviceAuthEndpoint,
     }, nil
 }

--- a/cmd/goSignals/discovery_test.go
+++ b/cmd/goSignals/discovery_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+    "net/http"
+    "net/http/httptest"
     "testing"
 
     "github.com/i2-open/i2goSignals/pkg/ssfModels"
@@ -61,5 +63,26 @@ func TestResolveClientId_OverrideWins(t *testing.T) {
     meta := &model.ProtectedResourceMetadata{ClientID: strp("gosignals-cli")}
     if got := resolveClientId(meta, "my-client"); got != "my-client" {
         t.Errorf("expected override client_id, got %q", got)
+    }
+}
+
+func TestDiscoverEndpoints_CapturesDeviceAuthorizationEndpoint(t *testing.T) {
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+        _, _ = w.Write([]byte(`{
+            "issuer":"https://idp.example.com",
+            "authorization_endpoint":"https://idp.example.com/auth",
+            "token_endpoint":"https://idp.example.com/token",
+            "device_authorization_endpoint":"https://idp.example.com/device"
+        }`))
+    }))
+    defer srv.Close()
+
+    ep, err := discoverEndpoints(srv.URL)
+    if err != nil {
+        t.Fatalf("discoverEndpoints failed: %v", err)
+    }
+    if ep.DeviceAuthorization != "https://idp.example.com/device" {
+        t.Errorf("expected device_authorization_endpoint to be discovered, got %q", ep.DeviceAuthorization)
     }
 }

--- a/cmd/goSignals/discovery_test.go
+++ b/cmd/goSignals/discovery_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+    "testing"
+
+    "github.com/i2-open/i2goSignals/pkg/ssfModels"
+)
+
+func strp(s string) *string { return &s }
+
+func TestResolveIssuer_SingleAdvertised(t *testing.T) {
+    meta := &model.ProtectedResourceMetadata{
+        AuthorizationServers: []string{"https://idp.example.com"},
+    }
+    iss, err := resolveIssuer(meta, "")
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    if iss != "https://idp.example.com" {
+        t.Errorf("expected single advertised issuer, got %q", iss)
+    }
+}
+
+func TestResolveIssuer_ExplicitOverridesAdvertised(t *testing.T) {
+    meta := &model.ProtectedResourceMetadata{
+        AuthorizationServers: []string{"https://a.example.com", "https://b.example.com"},
+    }
+    iss, err := resolveIssuer(meta, "https://b.example.com")
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    if iss != "https://b.example.com" {
+        t.Errorf("explicit --issuer should win, got %q", iss)
+    }
+}
+
+func TestResolveIssuer_MultipleWithoutExplicitIsAmbiguous(t *testing.T) {
+    meta := &model.ProtectedResourceMetadata{
+        AuthorizationServers: []string{"https://a.example.com", "https://b.example.com"},
+    }
+    if _, err := resolveIssuer(meta, ""); err == nil {
+        t.Errorf("expected ambiguity error when multiple AS and no --issuer")
+    }
+}
+
+func TestResolveIssuer_NoneIsError(t *testing.T) {
+    meta := &model.ProtectedResourceMetadata{}
+    if _, err := resolveIssuer(meta, ""); err == nil {
+        t.Errorf("expected error when no authorization_servers advertised")
+    }
+}
+
+func TestResolveClientId_AdvertisedUsedWhenNoOverride(t *testing.T) {
+    meta := &model.ProtectedResourceMetadata{ClientID: strp("gosignals-cli")}
+    if got := resolveClientId(meta, ""); got != "gosignals-cli" {
+        t.Errorf("expected advertised client_id, got %q", got)
+    }
+}
+
+func TestResolveClientId_OverrideWins(t *testing.T) {
+    meta := &model.ProtectedResourceMetadata{ClientID: strp("gosignals-cli")}
+    if got := resolveClientId(meta, "my-client"); got != "my-client" {
+        t.Errorf("expected override client_id, got %q", got)
+    }
+}

--- a/cmd/goSignals/goSignals_test.go
+++ b/cmd/goSignals/goSignals_test.go
@@ -75,6 +75,12 @@ func (suite *toolSuite) initialize(t *testing.T) error {
 	configName := fmt.Sprintf("%s/toolconfig.json", suite.testDir)
 	err = os.Setenv("GOSIGNALS_HOME", configName)
 
+	// The anonymous /iat path is closed (slice #121). Provide the shared
+	// bootstrap secret so bootstrap-capable CLI calls (create key / create iat /
+	// add server without a token) authenticate to the key scope. The in-process
+	// server reads the same env var via the bootstrap-secret resolver.
+	t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "tool-test-bootstrap")
+
 	cli := &CLI{}
 	cli.Globals.Config = configName
 
@@ -272,8 +278,11 @@ func (suite *toolSuite) Test0_MgmtTokens() {
 }
 func (suite *toolSuite) Test1_AddServers() {
 	testLog.Println("Test 1 - Add Server Test")
+	// Admin clients are provisioned out of band (slice #121: self-registration is
+	// capped below stream_admin). Supply the pre-issued admin token via --token so
+	// the saved client retains full stream management (including delete).
 	serverName := suite.servers[0].Name()
-	cmd := fmt.Sprintf("add server %s http://%s/ --desc=\"Add server test\" --email=test@example.com", serverName, suite.servers[0].server.Addr)
+	cmd := fmt.Sprintf("add server %s http://%s/ --desc=\"Add server test\" --email=test@example.com --token=%s", serverName, suite.servers[0].server.Addr, suite.servers[0].streamMgmtToken)
 
 	res, err := suite.executeCommand(cmd, false)
 	assert.NoError(suite.T(), err, "Add server successful")
@@ -283,7 +292,7 @@ func (suite *toolSuite) Test1_AddServers() {
 	assert.Equal(suite.T(), serverName, server.Alias, "Found server and matched")
 
 	serverName = suite.servers[1].Name()
-	cmd = fmt.Sprintf("add server %s http://%s/ --desc=\"Add server test\" --email=test@example.com", serverName, suite.servers[1].server.Addr)
+	cmd = fmt.Sprintf("add server %s http://%s/ --desc=\"Add server test\" --email=test@example.com --token=%s", serverName, suite.servers[1].server.Addr, suite.servers[1].streamMgmtToken)
 	res, err = suite.executeCommand(cmd, false)
 	assert.NoError(suite.T(), err, "Add server successful")
 	testLog.Printf("%s", res)

--- a/cmd/goSignals/login.go
+++ b/cmd/goSignals/login.go
@@ -1,0 +1,472 @@
+package main
+
+import (
+    "context"
+    "crypto/rand"
+    "crypto/sha256"
+    "encoding/base64"
+    "encoding/json"
+    "fmt"
+    "io"
+    "net"
+    "net/http"
+    "net/url"
+    "os/exec"
+    "runtime"
+    "strings"
+    "time"
+)
+
+// pkceParams carries an RFC 7636 PKCE pair for an authorization-code flow.
+type pkceParams struct {
+    Verifier  string
+    Challenge string
+    Method    string
+}
+
+// generatePKCE produces a cryptographically-random code_verifier and its
+// S256 code_challenge per RFC 7636. The verifier is 43 base64url chars
+// (32 random bytes), well within the 43-128 spec bounds.
+func generatePKCE() (*pkceParams, error) {
+    raw := make([]byte, 32)
+    if _, err := rand.Read(raw); err != nil {
+        return nil, err
+    }
+    verifier := base64.RawURLEncoding.EncodeToString(raw)
+    sum := sha256.Sum256([]byte(verifier))
+    challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+    return &pkceParams{
+        Verifier:  verifier,
+        Challenge: challenge,
+        Method:    "S256",
+    }, nil
+}
+
+// callbackResult carries the outcome of the OAuth redirect back to the
+// ephemeral loopback listener.
+type callbackResult struct {
+    code string
+    err  error
+}
+
+// loopbackCallback is the ephemeral 127.0.0.1 HTTP handler that receives the
+// authorization-code redirect. It validates the CSRF state, surfaces IdP
+// errors, and delivers the captured code on a channel so the login engine can
+// proceed to the token exchange.
+type loopbackCallback struct {
+    expectedState string
+    result        chan callbackResult
+}
+
+func newLoopbackCallback(expectedState string) *loopbackCallback {
+    return &loopbackCallback{
+        expectedState: expectedState,
+        result:        make(chan callbackResult, 1),
+    }
+}
+
+func (c *loopbackCallback) handler(w http.ResponseWriter, r *http.Request) {
+    q := r.URL.Query()
+
+    if e := q.Get("error"); e != "" {
+        desc := q.Get("error_description")
+        c.fail(w, fmt.Errorf("authorization failed: %s: %s", e, desc))
+        return
+    }
+
+    if q.Get("state") != c.expectedState {
+        c.fail(w, fmt.Errorf("state mismatch: possible CSRF, aborting login"))
+        return
+    }
+
+    code := q.Get("code")
+    if code == "" {
+        c.fail(w, fmt.Errorf("authorization response missing code"))
+        return
+    }
+
+    w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+    w.WriteHeader(http.StatusOK)
+    _, _ = w.Write([]byte("<html><body><h3>goSignals login complete.</h3><p>You may close this window and return to the terminal.</p></body></html>"))
+    c.result <- callbackResult{code: code}
+}
+
+func (c *loopbackCallback) fail(w http.ResponseWriter, err error) {
+    w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+    w.WriteHeader(http.StatusBadRequest)
+    _, _ = w.Write([]byte("<html><body><h3>goSignals login failed.</h3><p>" + err.Error() + "</p></body></html>"))
+    c.result <- callbackResult{err: err}
+}
+
+// tokenResponse is the subset of the OAuth2 token endpoint response we consume.
+type tokenResponse struct {
+    AccessToken  string `json:"access_token"`
+    RefreshToken string `json:"refresh_token"`
+    TokenType    string `json:"token_type"`
+    ExpiresIn    int    `json:"expires_in"`
+    Scope        string `json:"scope"`
+    IDToken      string `json:"id_token"`
+}
+
+// exchangeRequest carries the parameters for an authorization_code + PKCE token
+// exchange.
+type exchangeRequest struct {
+    TokenEndpoint string
+    ClientId      string
+    Code          string
+    Verifier      string
+    RedirectURI   string
+}
+
+// exchangeCodeForSession performs the RFC6749/RFC7636 authorization_code grant
+// (with PKCE code_verifier) at the token endpoint and builds a Session from the
+// response, extracting the subject/email from the id_token when present.
+func exchangeCodeForSession(req exchangeRequest) (*Session, error) {
+    form := url.Values{}
+    form.Set("grant_type", "authorization_code")
+    form.Set("code", req.Code)
+    form.Set("code_verifier", req.Verifier)
+    form.Set("client_id", req.ClientId)
+    form.Set("redirect_uri", req.RedirectURI)
+
+    client := getHttpClient(30 * time.Second)
+    resp, err := client.PostForm(req.TokenEndpoint, form)
+    if err != nil {
+        return nil, err
+    }
+    defer func() { _ = resp.Body.Close() }()
+    body, _ := io.ReadAll(resp.Body)
+    if resp.StatusCode != http.StatusOK {
+        return nil, fmt.Errorf("token endpoint returned %s: %s", resp.Status, string(body))
+    }
+
+    var tr tokenResponse
+    if err := json.Unmarshal(body, &tr); err != nil {
+        return nil, fmt.Errorf("could not parse token response: %w", err)
+    }
+    if tr.AccessToken == "" {
+        return nil, fmt.Errorf("token response did not include an access_token")
+    }
+
+    sess := sessionFromTokenResponse(&tr, req.ClientId)
+    return sess, nil
+}
+
+// sessionFromTokenResponse converts a token endpoint response into a Session.
+func sessionFromTokenResponse(tr *tokenResponse, clientId string) *Session {
+    sess := &Session{
+        AccessToken:  tr.AccessToken,
+        RefreshToken: tr.RefreshToken,
+        ClientId:     clientId,
+    }
+    if tr.ExpiresIn > 0 {
+        sess.Expiry = time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second).UTC()
+    }
+    if tr.Scope != "" {
+        sess.Scopes = strings.Fields(tr.Scope)
+    }
+    sub, email := claimsFromJWT(tr.IDToken)
+    sess.Subject = sub
+    sess.Email = email
+    return sess
+}
+
+// claimsFromJWT extracts the sub and email claims from a JWT payload without
+// verifying the signature. The CLI uses these only for display; authorization
+// is enforced server-side against the access token.
+func claimsFromJWT(token string) (subject, email string) {
+    if token == "" {
+        return "", ""
+    }
+    parts := strings.Split(token, ".")
+    if len(parts) < 2 {
+        return "", ""
+    }
+    payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+    if err != nil {
+        return "", ""
+    }
+    var claims struct {
+        Sub               string `json:"sub"`
+        Email             string `json:"email"`
+        PreferredUsername string `json:"preferred_username"`
+    }
+    if err := json.Unmarshal(payload, &claims); err != nil {
+        return "", ""
+    }
+    sub := claims.Sub
+    if sub == "" {
+        sub = claims.PreferredUsername
+    }
+    return sub, claims.Email
+}
+
+// randomState returns a cryptographically-random opaque CSRF state value.
+func randomState() (string, error) {
+    raw := make([]byte, 24)
+    if _, err := rand.Read(raw); err != nil {
+        return "", err
+    }
+    return base64.RawURLEncoding.EncodeToString(raw), nil
+}
+
+// openBrowser is the hook used to launch the system browser at the authorization
+// URL. It is a package var so tests (and headless environments) can override it.
+var openBrowser = func(target string) error {
+    var cmd string
+    var args []string
+    switch runtime.GOOS {
+    case "darwin":
+        cmd = "open"
+    case "windows":
+        cmd = "rundll32"
+        args = []string{"url.dll,FileProtocolHandler"}
+    default:
+        cmd = "xdg-open"
+    }
+    args = append(args, target)
+    return exec.Command(cmd, args...).Start()
+}
+
+// loginOptions parameterize the interactive PKCE login flow.
+type loginOptions struct {
+    Issuer    string
+    ClientId  string
+    Scopes    []string
+    Endpoints *oidcEndpoints
+    // Timeout bounds how long we wait for the browser round-trip.
+    Timeout time.Duration
+}
+
+// runLogin performs the docker-login-style PKCE loopback flow: it generates a
+// PKCE pair + CSRF state, starts an ephemeral 127.0.0.1 listener, opens the
+// browser at the authorization endpoint, awaits the redirect, then exchanges the
+// code for a session. The flow is structured so a device-code path (#124) can be
+// slotted in as an alternative without touching the token-exchange/session code.
+func runLogin(opts loginOptions) (*Session, error) {
+    if opts.Endpoints == nil {
+        return nil, fmt.Errorf("login requires discovered OIDC endpoints")
+    }
+    pkce, err := generatePKCE()
+    if err != nil {
+        return nil, err
+    }
+    state, err := randomState()
+    if err != nil {
+        return nil, err
+    }
+
+    // Ephemeral loopback listener on an OS-assigned port.
+    listener, err := net.Listen("tcp", "127.0.0.1:0")
+    if err != nil {
+        return nil, fmt.Errorf("could not start loopback listener: %w", err)
+    }
+    defer func() { _ = listener.Close() }()
+
+    redirectURI := fmt.Sprintf("http://%s/callback", listener.Addr().String())
+
+    cb := newLoopbackCallback(state)
+    mux := http.NewServeMux()
+    mux.HandleFunc("/callback", cb.handler)
+    srv := &http.Server{Handler: mux}
+    go func() { _ = srv.Serve(listener) }()
+    defer func() {
+        ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+        defer cancel()
+        _ = srv.Shutdown(ctx)
+    }()
+
+    authURL := buildAuthorizationURL(opts.Endpoints.Authorization, opts.ClientId, redirectURI, state, pkce, opts.Scopes)
+
+    fmt.Println("Opening browser to log in:")
+    fmt.Println("  " + authURL)
+    if err := openBrowser(authURL); err != nil {
+        fmt.Printf("(could not open browser automatically: %v)\n", err)
+        fmt.Println("Please open the URL above manually to continue.")
+    }
+
+    timeout := opts.Timeout
+    if timeout == 0 {
+        timeout = 3 * time.Minute
+    }
+
+    select {
+    case res := <-cb.result:
+        if res.err != nil {
+            return nil, res.err
+        }
+        sess, err := exchangeCodeForSession(exchangeRequest{
+            TokenEndpoint: opts.Endpoints.Token,
+            ClientId:      opts.ClientId,
+            Code:          res.code,
+            Verifier:      pkce.Verifier,
+            RedirectURI:   redirectURI,
+        })
+        if err != nil {
+            return nil, err
+        }
+        return sess, nil
+    case <-time.After(timeout):
+        return nil, fmt.Errorf("timed out waiting for browser login after %s", timeout)
+    }
+}
+
+// buildAuthorizationURL constructs the RFC6749 authorization-code request URL
+// with PKCE parameters.
+func buildAuthorizationURL(authEndpoint, clientId, redirectURI, state string, pkce *pkceParams, scopes []string) string {
+    q := url.Values{}
+    q.Set("response_type", "code")
+    q.Set("client_id", clientId)
+    q.Set("redirect_uri", redirectURI)
+    q.Set("state", state)
+    q.Set("code_challenge", pkce.Challenge)
+    q.Set("code_challenge_method", pkce.Method)
+    scope := "openid email profile"
+    if len(scopes) > 0 {
+        scope = strings.Join(scopes, " ")
+    }
+    q.Set("scope", scope)
+
+    sep := "?"
+    if strings.Contains(authEndpoint, "?") {
+        sep = "&"
+    }
+    return authEndpoint + sep + q.Encode()
+}
+
+// LoginCmd performs an interactive docker-login-style PKCE login against the
+// IdP advertised by the server's Protected Resource Metadata, storing the
+// resulting session in credentials.json (keyed by issuer).
+type LoginCmd struct {
+    Alias    string `arg:"" help:"The alias of the server to log in to."`
+    Issuer   string `optional:"" help:"Override the OAuth issuer (when multiple are advertised)."`
+    ClientId string `optional:"" name:"client-id" help:"Override the advertised public OAuth client_id."`
+    Scopes   string `optional:"" help:"Space-separated OAuth scopes to request (default: openid email profile)."`
+}
+
+func (l *LoginCmd) Run(c *CLI) error {
+    server, err := c.Data.GetServer(l.Alias)
+    if err != nil {
+        return err
+    }
+
+    prm, err := discoverProtectedResource(server.Host)
+    if err != nil {
+        return fmt.Errorf("could not fetch protected resource metadata from %s: %w; the server may not advertise OAuth (use --bootstrap/--token on 'add server')", server.Host, err)
+    }
+
+    issuer, err := resolveIssuer(prm, l.Issuer)
+    if err != nil {
+        return err
+    }
+    clientId := resolveClientId(prm, l.ClientId)
+    if clientId == "" {
+        return fmt.Errorf("no client_id advertised and none provided; pass --client-id")
+    }
+
+    endpoints, err := discoverEndpoints(issuer)
+    if err != nil {
+        return err
+    }
+
+    var scopes []string
+    if l.Scopes != "" {
+        scopes = strings.Fields(l.Scopes)
+    }
+
+    sess, err := runLogin(loginOptions{
+        Issuer:    issuer,
+        ClientId:  clientId,
+        Scopes:    scopes,
+        Endpoints: endpoints,
+    })
+    if err != nil {
+        return err
+    }
+
+    store, err := LoadCredentialStore(&c.Globals)
+    if err != nil {
+        return err
+    }
+    store.Set(issuer, sess)
+    if err := store.Save(); err != nil {
+        return err
+    }
+
+    // Cache the (non-secret) active issuer + advertised servers on the server
+    // record; never store tokens in config.json.
+    server.ActiveIssuer = issuer
+    server.AuthorizationServers = prm.AuthorizationServers
+    c.Data.Servers[l.Alias] = *server
+    if err := c.Data.Save(&c.Globals); err != nil {
+        return err
+    }
+
+    fmt.Printf("Logged in to %s as %s\n", l.Alias, sess.describe(issuer))
+    return nil
+}
+
+// WhoamiCmd prints the active session for a server (issuer, subject/email,
+// scopes, expiry).
+type WhoamiCmd struct {
+    Alias string `arg:"" optional:"" help:"The alias of the server (defaults to the selected server)."`
+}
+
+func (cmd *WhoamiCmd) Run(c *CLI) error {
+    server, err := c.Data.GetServer(cmd.Alias)
+    if err != nil {
+        return err
+    }
+    if server.ActiveIssuer == "" {
+        fmt.Printf("Not logged in to %s. Run 'login %s'.\n", server.Alias, server.Alias)
+        return nil
+    }
+    store, err := LoadCredentialStore(&c.Globals)
+    if err != nil {
+        return err
+    }
+    sess := store.Get(server.ActiveIssuer)
+    if sess == nil {
+        fmt.Printf("No stored session for issuer %s. Run 'login %s'.\n", server.ActiveIssuer, server.Alias)
+        return nil
+    }
+    status := "valid"
+    if sess.Expired() {
+        status = "expired (will refresh on next call)"
+    }
+    fmt.Printf("%s\nstatus: %s\n", sess.describe(server.ActiveIssuer), status)
+    c.GetOutputWriter().WriteString(sess.describe(server.ActiveIssuer), true)
+    return nil
+}
+
+// LogoutCmd clears the stored session for a server's active issuer.
+type LogoutCmd struct {
+    Alias string `arg:"" optional:"" help:"The alias of the server (defaults to the selected server)."`
+}
+
+func (cmd *LogoutCmd) Run(c *CLI) error {
+    server, err := c.Data.GetServer(cmd.Alias)
+    if err != nil {
+        return err
+    }
+    if server.ActiveIssuer == "" {
+        fmt.Printf("Not logged in to %s.\n", server.Alias)
+        return nil
+    }
+    store, err := LoadCredentialStore(&c.Globals)
+    if err != nil {
+        return err
+    }
+    issuer := server.ActiveIssuer
+    store.Delete(issuer)
+    if err := store.Save(); err != nil {
+        return err
+    }
+    server.ActiveIssuer = ""
+    c.Data.Servers[server.Alias] = *server
+    if err := c.Data.Save(&c.Globals); err != nil {
+        return err
+    }
+    fmt.Printf("Logged out of %s (issuer %s).\n", server.Alias, issuer)
+    return nil
+}

--- a/cmd/goSignals/login.go
+++ b/cmd/goSignals/login.go
@@ -452,6 +452,8 @@ func (l *LoginCmd) Run(c *CLI) error {
         return err
     }
 
+    sess.LoggedInAt = time.Now().UTC()
+
     store, err := LoadCredentialStore(&c.Globals)
     if err != nil {
         return err
@@ -481,6 +483,19 @@ type WhoamiCmd struct {
 }
 
 func (cmd *WhoamiCmd) Run(c *CLI) error {
+    // No alias: list every realm session (gcloud `auth list` style), showing
+    // which configured server aliases trust each realm.
+    if cmd.Alias == "" {
+        store, err := LoadCredentialStore(&c.Globals)
+        if err != nil {
+            return err
+        }
+        out := renderWhoami(store, c.Data.Servers)
+        fmt.Print(out)
+        c.GetOutputWriter().WriteString(out, true)
+        return nil
+    }
+
     server, err := c.Data.GetServer(cmd.Alias)
     if err != nil {
         return err
@@ -507,34 +522,90 @@ func (cmd *WhoamiCmd) Run(c *CLI) error {
     return nil
 }
 
-// LogoutCmd clears the stored session for a server's active issuer.
+// LogoutCmd drops one or more realm sessions. A realm logout affects every
+// server using that realm: its credential-store session is removed (with a
+// best-effort IdP refresh-token revocation) and every server's ActiveIssuer
+// pointer that referenced it is cleared. Targeting is one of: <alias> (the
+// server's active issuer), --issuer <url> (one realm), or --all (every realm).
 type LogoutCmd struct {
-    Alias string `arg:"" optional:"" help:"The alias of the server (defaults to the selected server)."`
+    Alias  string `arg:"" optional:"" help:"The alias of the server whose active issuer to log out."`
+    Issuer string `optional:"" help:"Log out a specific realm (issuer URL), affecting every server using it."`
+    All    bool   `optional:"" help:"Log out of every realm session."`
 }
 
 func (cmd *LogoutCmd) Run(c *CLI) error {
+    store, err := LoadCredentialStore(&c.Globals)
+    if err != nil {
+        return err
+    }
+    issuers, err := resolveLogoutIssuers(store, c.Data.Servers, cmd.Alias, cmd.Issuer, cmd.All)
+    if err != nil {
+        return err
+    }
+    if len(issuers) == 0 {
+        fmt.Println("No matching realm sessions to log out.")
+        return nil
+    }
+
+    for _, issuer := range issuers {
+        // Best-effort RFC 7009 revocation before dropping the local session.
+        if sess := store.Get(issuer); sess != nil && sess.RefreshToken != "" {
+            if ep, derr := discoverEndpoints(issuer); derr == nil {
+                revokeRefreshToken(ep.Revocation, sess)
+            }
+        }
+        store.Delete(issuer)
+        // Clear the ActiveIssuer pointer on every server that referenced this
+        // realm — a realm logout affects every server using it.
+        for alias, server := range c.Data.Servers {
+            if server.ActiveIssuer == issuer {
+                server.ActiveIssuer = ""
+                c.Data.Servers[alias] = server
+            }
+        }
+        fmt.Printf("Logged out of realm %s.\n", issuer)
+    }
+
+    if err := store.Save(); err != nil {
+        return err
+    }
+    return c.Data.Save(&c.Globals)
+}
+
+// UseServerCmd sets the active issuer (realm) for a server so subsequent
+// management calls authorize against that realm's session. The issuer should be
+// one the server advertises (AuthorizationServers); a non-advertised issuer is
+// accepted with a warning so manual overrides remain possible.
+type UseServerCmd struct {
+    Alias  string `arg:"" help:"The alias of the server to set the active issuer for."`
+    Issuer string `required:"" help:"The realm issuer URL to make active for this server."`
+}
+
+func (cmd *UseServerCmd) Run(c *CLI) error {
     server, err := c.Data.GetServer(cmd.Alias)
     if err != nil {
         return err
     }
-    if server.ActiveIssuer == "" {
-        fmt.Printf("Not logged in to %s.\n", server.Alias)
-        return nil
+    if !serverTrustsIssuer(*server, cmd.Issuer) {
+        fmt.Printf("Warning: %s does not advertise issuer %s; setting it anyway.\n", server.Alias, cmd.Issuer)
     }
     store, err := LoadCredentialStore(&c.Globals)
     if err != nil {
         return err
     }
-    issuer := server.ActiveIssuer
-    store.Delete(issuer)
-    if err := store.Save(); err != nil {
-        return err
+    if store.Get(cmd.Issuer) == nil {
+        fmt.Printf("Note: no stored session for %s yet; run 'login %s --issuer %s'.\n", cmd.Issuer, server.Alias, cmd.Issuer)
     }
-    server.ActiveIssuer = ""
+    server.ActiveIssuer = cmd.Issuer
     c.Data.Servers[server.Alias] = *server
     if err := c.Data.Save(&c.Globals); err != nil {
         return err
     }
-    fmt.Printf("Logged out of %s (issuer %s).\n", server.Alias, issuer)
+    fmt.Printf("Active issuer for %s set to %s.\n", server.Alias, cmd.Issuer)
     return nil
+}
+
+// UseCmd groups the `use` subcommands.
+type UseCmd struct {
+    Server UseServerCmd `cmd:"" help:"Set the active issuer (realm) for a server."`
 }

--- a/cmd/goSignals/login.go
+++ b/cmd/goSignals/login.go
@@ -11,6 +11,7 @@ import (
     "net"
     "net/http"
     "net/url"
+    "os"
     "os/exec"
     "runtime"
     "strings"
@@ -140,6 +141,13 @@ func exchangeCodeForSession(req exchangeRequest) (*Session, error) {
         return nil, fmt.Errorf("token endpoint returned %s: %s", resp.Status, string(body))
     }
 
+    return sessionFromTokenBody(body, req.ClientId)
+}
+
+// sessionFromTokenBody parses a successful token endpoint response body into a
+// Session, validating that an access_token is present. Shared by the PKCE
+// authorization_code exchange and the device-code polling loop.
+func sessionFromTokenBody(body []byte, clientId string) (*Session, error) {
     var tr tokenResponse
     if err := json.Unmarshal(body, &tr); err != nil {
         return nil, fmt.Errorf("could not parse token response: %w", err)
@@ -147,9 +155,7 @@ func exchangeCodeForSession(req exchangeRequest) (*Session, error) {
     if tr.AccessToken == "" {
         return nil, fmt.Errorf("token response did not include an access_token")
     }
-
-    sess := sessionFromTokenResponse(&tr, req.ClientId)
-    return sess, nil
+    return sessionFromTokenResponse(&tr, clientId), nil
 }
 
 // sessionFromTokenResponse converts a token endpoint response into a Session.
@@ -228,6 +234,39 @@ var openBrowser = func(target string) error {
     return exec.Command(cmd, args...).Start()
 }
 
+// browserAvailable reports whether a system browser can plausibly be launched.
+// On a headless host (no DISPLAY/WAYLAND on Linux, or no browser launcher on
+// PATH) this returns false so the engine auto-falls back to the device-code
+// flow. It is a package var so tests can override it.
+var browserAvailable = func() bool {
+    switch runtime.GOOS {
+    case "darwin", "windows":
+        // The OS-provided launcher (open / rundll32) is always present.
+        return true
+    default:
+        // On Linux/Unix a GUI requires a display server; xdg-open is useless
+        // without one (typical of SSH sessions and containers).
+        if os.Getenv("DISPLAY") == "" && os.Getenv("WAYLAND_DISPLAY") == "" {
+            return false
+        }
+        _, err := exec.LookPath("xdg-open")
+        return err == nil
+    }
+}
+
+// canBindLoopback reports whether an ephemeral 127.0.0.1 listener can be bound.
+// Sandboxed containers and locked-down hosts may forbid this; in that case the
+// engine auto-falls back to the device-code flow. It is a package var so tests
+// can override it.
+var canBindLoopback = func() bool {
+    l, err := net.Listen("tcp", "127.0.0.1:0")
+    if err != nil {
+        return false
+    }
+    _ = l.Close()
+    return true
+}
+
 // loginOptions parameterize the interactive PKCE login flow.
 type loginOptions struct {
     Issuer    string
@@ -236,17 +275,44 @@ type loginOptions struct {
     Endpoints *oidcEndpoints
     // Timeout bounds how long we wait for the browser round-trip.
     Timeout time.Duration
+    // ForceDevice forces the RFC 8628 device-code flow even when a browser and
+    // loopback listener are available (the --device flag).
+    ForceDevice bool
+    // sleep is a test seam for the device-code polling loop; nil means
+    // time.Sleep.
+    sleep func(time.Duration)
 }
 
-// runLogin performs the docker-login-style PKCE loopback flow: it generates a
-// PKCE pair + CSRF state, starts an ephemeral 127.0.0.1 listener, opens the
-// browser at the authorization endpoint, awaits the redirect, then exchanges the
-// code for a session. The flow is structured so a device-code path (#124) can be
-// slotted in as an alternative without touching the token-exchange/session code.
+// runLogin selects and runs the appropriate login flow. With both a browser and
+// a loopback listener available (and no --device override) it runs the
+// docker-login-style PKCE loopback flow. On a headless host — no browser, no
+// bindable loopback listener — or when --device is given, it runs the RFC 8628
+// device-code flow instead. Both paths yield an identically-shaped Session.
 func runLogin(opts loginOptions) (*Session, error) {
     if opts.Endpoints == nil {
         return nil, fmt.Errorf("login requires discovered OIDC endpoints")
     }
+
+    method := selectLoginMethod(loginCapabilities{
+        ForceDevice:     opts.ForceDevice,
+        CanBindLoopback: canBindLoopback(),
+        CanOpenBrowser:  browserAvailable(),
+    })
+
+    if method == loginMethodDevice {
+        if opts.Endpoints.DeviceAuthorization == "" {
+            return nil, fmt.Errorf("device-code login required (no browser/loopback available or --device given) but issuer %s does not advertise a device_authorization_endpoint", opts.Endpoints.Issuer)
+        }
+        return runDeviceLogin(opts)
+    }
+    return runLoopbackLogin(opts)
+}
+
+// runLoopbackLogin performs the docker-login-style PKCE loopback flow: it
+// generates a PKCE pair + CSRF state, starts an ephemeral 127.0.0.1 listener,
+// opens the browser at the authorization endpoint, awaits the redirect, then
+// exchanges the code for a session.
+func runLoopbackLogin(opts loginOptions) (*Session, error) {
     pkce, err := generatePKCE()
     if err != nil {
         return nil, err
@@ -342,6 +408,7 @@ type LoginCmd struct {
     Issuer   string `optional:"" help:"Override the OAuth issuer (when multiple are advertised)."`
     ClientId string `optional:"" name:"client-id" help:"Override the advertised public OAuth client_id."`
     Scopes   string `optional:"" help:"Space-separated OAuth scopes to request (default: openid email profile)."`
+    Device   bool   `optional:"" help:"Force the OAuth device-code flow (headless: prints a URL + code to complete on another device)."`
 }
 
 func (l *LoginCmd) Run(c *CLI) error {
@@ -375,10 +442,11 @@ func (l *LoginCmd) Run(c *CLI) error {
     }
 
     sess, err := runLogin(loginOptions{
-        Issuer:    issuer,
-        ClientId:  clientId,
-        Scopes:    scopes,
-        Endpoints: endpoints,
+        Issuer:      issuer,
+        ClientId:    clientId,
+        Scopes:      scopes,
+        Endpoints:   endpoints,
+        ForceDevice: l.Device,
     })
     if err != nil {
         return err

--- a/cmd/goSignals/login_flow_test.go
+++ b/cmd/goSignals/login_flow_test.go
@@ -13,6 +13,19 @@ import (
 // loopback callback with a code, and a fake token endpoint. This exercises the
 // listener + callback + exchange seam without a real browser.
 func TestRunLogin_EndToEndLoopback(t *testing.T) {
+    // Pin the capability detection so this test deterministically exercises the
+    // PKCE loopback path on any host. Without this it passes on a desktop (where
+    // browserAvailable() is true) but on a headless CI runner the engine
+    // auto-falls back to device-code and the loopback seam is never tested.
+    origBrowser := browserAvailable
+    origBind := canBindLoopback
+    defer func() {
+        browserAvailable = origBrowser
+        canBindLoopback = origBind
+    }()
+    browserAvailable = func() bool { return true }
+    canBindLoopback = func() bool { return true }
+
     idToken := makeUnsignedIDToken(map[string]any{"sub": "alice", "email": "alice@example.com"})
 
     token := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/goSignals/login_flow_test.go
+++ b/cmd/goSignals/login_flow_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+    "net/http"
+    "net/http/httptest"
+    "net/url"
+    "testing"
+    "time"
+)
+
+// TestRunLogin_EndToEndLoopback drives the full PKCE loopback flow with a
+// synthetic "browser" (the openBrowser hook) that immediately redirects to the
+// loopback callback with a code, and a fake token endpoint. This exercises the
+// listener + callback + exchange seam without a real browser.
+func TestRunLogin_EndToEndLoopback(t *testing.T) {
+    idToken := makeUnsignedIDToken(map[string]any{"sub": "alice", "email": "alice@example.com"})
+
+    token := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        _ = r.ParseForm()
+        if r.Form.Get("grant_type") != "authorization_code" || r.Form.Get("code") != "the-code" {
+            w.WriteHeader(http.StatusBadRequest)
+            return
+        }
+        if r.Form.Get("code_verifier") == "" {
+            t.Error("expected code_verifier in token exchange")
+        }
+        w.Header().Set("Content-Type", "application/json")
+        _, _ = w.Write([]byte(`{"access_token":"acc","refresh_token":"ref","expires_in":3600,"scope":"admin","id_token":"` + idToken + `"}`))
+    }))
+    defer token.Close()
+
+    // Replace the browser opener with one that posts the synthetic code back to
+    // the loopback redirect_uri, preserving the state value.
+    origOpen := openBrowser
+    defer func() { openBrowser = origOpen }()
+    openBrowser = func(target string) error {
+        u, err := url.Parse(target)
+        if err != nil {
+            return err
+        }
+        q := u.Query()
+        redirect := q.Get("redirect_uri")
+        state := q.Get("state")
+        go func() {
+            cbURL := redirect + "?code=the-code&state=" + url.QueryEscape(state)
+            resp, err := http.Get(cbURL)
+            if err == nil {
+                _ = resp.Body.Close()
+            }
+        }()
+        return nil
+    }
+
+    sess, err := runLogin(loginOptions{
+        Issuer:   "https://idp.example.com",
+        ClientId: "gosignals-cli",
+        Scopes:   []string{"openid", "admin"},
+        Endpoints: &oidcEndpoints{
+            Authorization: "https://idp.example.com/auth",
+            Token:         token.URL,
+            Issuer:        "https://idp.example.com",
+        },
+        Timeout: 5 * time.Second,
+    })
+    if err != nil {
+        t.Fatalf("runLogin failed: %v", err)
+    }
+    if sess.AccessToken != "acc" || sess.Subject != "alice" {
+        t.Errorf("login did not yield expected session: %+v", sess)
+    }
+}

--- a/cmd/goSignals/logout_test.go
+++ b/cmd/goSignals/logout_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+    "net/http"
+    "net/http/httptest"
+    "path/filepath"
+    "sort"
+    "testing"
+    "time"
+)
+
+// AC3: logout targeting matrix. resolveLogoutIssuers maps the (alias, issuer,
+// all) inputs to the set of realm issuers to drop.
+func TestResolveLogoutIssuers(t *testing.T) {
+    store := &CredentialStore{Path: filepath.Join(t.TempDir(), "c.json")}
+    store.Set("https://r1", &Session{AccessToken: "1"})
+    store.Set("https://r2", &Session{AccessToken: "2"})
+    servers := map[string]SsfServer{
+        "gs1": {Alias: "gs1", ActiveIssuer: "https://r1"},
+        "gs2": {Alias: "gs2", ActiveIssuer: "https://r2"},
+    }
+
+    // --all drops every stored issuer.
+    got, err := resolveLogoutIssuers(store, servers, "", "", true)
+    if err != nil {
+        t.Fatalf("--all error: %v", err)
+    }
+    sort.Strings(got)
+    if len(got) != 2 || got[0] != "https://r1" || got[1] != "https://r2" {
+        t.Errorf("--all expected both issuers, got %v", got)
+    }
+
+    // --issuer drops exactly that realm.
+    got, err = resolveLogoutIssuers(store, servers, "", "https://r1", false)
+    if err != nil || len(got) != 1 || got[0] != "https://r1" {
+        t.Errorf("--issuer expected [r1], got %v err=%v", got, err)
+    }
+
+    // <alias> resolves via that server's active issuer.
+    got, err = resolveLogoutIssuers(store, servers, "gs2", "", false)
+    if err != nil || len(got) != 1 || got[0] != "https://r2" {
+        t.Errorf("alias gs2 expected [r2], got %v err=%v", got, err)
+    }
+
+    // no target at all is an error (avoid accidental全logout).
+    if _, err := resolveLogoutIssuers(store, servers, "", "", false); err == nil {
+        t.Errorf("expected error when no logout target specified")
+    }
+}
+
+// AC4: best-effort RFC 7009 revocation. The revocation request must POST the
+// refresh token with token_type_hint=refresh_token and the client_id.
+func TestRevokeRefreshToken_RequestShape(t *testing.T) {
+    var gotToken, gotHint, gotClient string
+    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        _ = r.ParseForm()
+        gotToken = r.Form.Get("token")
+        gotHint = r.Form.Get("token_type_hint")
+        gotClient = r.Form.Get("client_id")
+        w.WriteHeader(http.StatusOK)
+    }))
+    defer ts.Close()
+
+    sess := &Session{RefreshToken: "rt-xyz", ClientId: "cli-app"}
+    revokeRefreshToken(ts.URL, sess)
+
+    if gotToken != "rt-xyz" {
+        t.Errorf("expected token=rt-xyz, got %q", gotToken)
+    }
+    if gotHint != "refresh_token" {
+        t.Errorf("expected token_type_hint=refresh_token, got %q", gotHint)
+    }
+    if gotClient != "cli-app" {
+        t.Errorf("expected client_id=cli-app, got %q", gotClient)
+    }
+}
+
+// AC4: revocation is best-effort — a server error or unreachable endpoint must
+// not surface as a failure (logout still succeeds).
+func TestRevokeRefreshToken_BestEffortSwallowsFailure(t *testing.T) {
+    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.WriteHeader(http.StatusInternalServerError)
+    }))
+    defer ts.Close()
+
+    // Should not panic or block; failures are ignored.
+    revokeRefreshToken(ts.URL, &Session{RefreshToken: "rt"})
+    // Empty endpoint / no refresh token must also be no-ops.
+    revokeRefreshToken("", &Session{RefreshToken: "rt"})
+    revokeRefreshToken(ts.URL, &Session{})
+    _ = time.Now()
+}

--- a/cmd/goSignals/loopback_test.go
+++ b/cmd/goSignals/loopback_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+    "net/http"
+    "net/http/httptest"
+    "testing"
+    "time"
+)
+
+func TestLoopbackCallback_CapturesCodeOnMatchingState(t *testing.T) {
+    cb := newLoopbackCallback("expected-state")
+    rec := httptest.NewRecorder()
+    req := httptest.NewRequest(http.MethodGet, "/callback?code=auth-code-123&state=expected-state", nil)
+
+    cb.handler(rec, req)
+
+    select {
+    case res := <-cb.result:
+        if res.err != nil {
+            t.Fatalf("unexpected callback error: %v", res.err)
+        }
+        if res.code != "auth-code-123" {
+            t.Errorf("expected code 'auth-code-123', got %q", res.code)
+        }
+    case <-time.After(time.Second):
+        t.Fatal("callback did not deliver a result")
+    }
+    if rec.Code != http.StatusOK {
+        t.Errorf("expected 200 to the browser, got %d", rec.Code)
+    }
+}
+
+func TestLoopbackCallback_RejectsStateMismatch(t *testing.T) {
+    cb := newLoopbackCallback("expected-state")
+    rec := httptest.NewRecorder()
+    req := httptest.NewRequest(http.MethodGet, "/callback?code=x&state=wrong", nil)
+
+    cb.handler(rec, req)
+
+    select {
+    case res := <-cb.result:
+        if res.err == nil {
+            t.Errorf("expected error on state mismatch (CSRF protection)")
+        }
+    case <-time.After(time.Second):
+        t.Fatal("callback did not deliver a result")
+    }
+}
+
+func TestLoopbackCallback_SurfacesIdPError(t *testing.T) {
+    cb := newLoopbackCallback("s")
+    rec := httptest.NewRecorder()
+    req := httptest.NewRequest(http.MethodGet, "/callback?error=access_denied&error_description=nope&state=s", nil)
+
+    cb.handler(rec, req)
+
+    select {
+    case res := <-cb.result:
+        if res.err == nil {
+            t.Errorf("expected error when IdP returns error param")
+        }
+    case <-time.After(time.Second):
+        t.Fatal("callback did not deliver a result")
+    }
+}

--- a/cmd/goSignals/main.go
+++ b/cmd/goSignals/main.go
@@ -41,6 +41,9 @@ type Globals struct {
 type CLI struct {
 	Globals
 	Add           AddCmd           `cmd:"" help:"Define a new server to be managed"`
+	Login         LoginCmd         `cmd:"" help:"Interactively log in to a server's advertised IdP (PKCE)."`
+	Whoami        WhoamiCmd        `cmd:"" help:"Show the current logged-in session for a server."`
+	Logout        LogoutCmd        `cmd:"" help:"Clear the stored session for a server."`
 	Create        CreateCmd        `cmd:"" help:"Create an issuer KEY, or STREAM"`
 	Delete        DeleteCmd        `cmd:"" help:"Delete a stream"`
 	Select        SelectCmd        `cmd:"" help:"Select a defined server or stream/server to perform operations against"`

--- a/cmd/goSignals/main.go
+++ b/cmd/goSignals/main.go
@@ -43,7 +43,8 @@ type CLI struct {
 	Add           AddCmd           `cmd:"" help:"Define a new server to be managed"`
 	Login         LoginCmd         `cmd:"" help:"Interactively log in to a server's advertised IdP (PKCE)."`
 	Whoami        WhoamiCmd        `cmd:"" help:"Show the current logged-in session for a server."`
-	Logout        LogoutCmd        `cmd:"" help:"Clear the stored session for a server."`
+	Logout        LogoutCmd        `cmd:"" help:"Clear stored realm session(s): <alias>, --issuer <url>, or --all."`
+	Use           UseCmd           `cmd:"" help:"Set the active issuer (realm) for a server."`
 	Create        CreateCmd        `cmd:"" help:"Create an issuer KEY, or STREAM"`
 	Delete        DeleteCmd        `cmd:"" help:"Delete a stream"`
 	Select        SelectCmd        `cmd:"" help:"Select a defined server or stream/server to perform operations against"`

--- a/cmd/goSignals/main.go
+++ b/cmd/goSignals/main.go
@@ -40,22 +40,22 @@ type Globals struct {
 
 type CLI struct {
 	Globals
-	Add           AddCmd           `cmd:"" help:"Define a new server to be managed"`
-	Login         LoginCmd         `cmd:"" help:"Interactively log in to a server's advertised IdP (PKCE)."`
-	Whoami        WhoamiCmd        `cmd:"" help:"Show the current logged-in session for a server."`
-	Logout        LogoutCmd        `cmd:"" help:"Clear stored realm session(s): <alias>, --issuer <url>, or --all."`
-	Use           UseCmd           `cmd:"" help:"Set the active issuer (realm) for a server."`
-	Create        CreateCmd        `cmd:"" help:"Create an issuer KEY, or STREAM"`
-	Delete        DeleteCmd        `cmd:"" help:"Delete a stream"`
-	Select        SelectCmd        `cmd:"" help:"Select a defined server or stream/server to perform operations against"`
-	Get           GetCmd           `cmd:"" help:"Get information from SSF servers"`
-	Generate      GenerateCmd      `cmd:"" help:"Generate an event for testing"`
-	Poll          PollCmd          `cmd:"" help:"Activate a polling client stream with a server identified by <alias>."`
-	Set           SetCmd           `cmd:"" help:"Set configuration items on server"`
-	Show          ShowCmd          `cmd:"" help:"Show locally configured information"`
-	Token         TokenCmd         `cmd:"" help:"Manage issued tokens"`
-	Exit          ExitCmd          `cmd:"" help:"Exit the shell"`
-	Help          HelpCmd          `cmd:"" help:"Show help on a command"`
+	Add      AddCmd      `cmd:"" help:"Define a new server to be managed"`
+	Login    LoginCmd    `cmd:"" help:"Interactively log in to a server's advertised IdP (PKCE)."`
+	Whoami   WhoamiCmd   `cmd:"" help:"Show the current logged-in session for a server."`
+	Logout   LogoutCmd   `cmd:"" help:"Clear stored realm session(s): <alias>, --issuer <url>, or --all."`
+	Use      UseCmd      `cmd:"" help:"Set the active issuer (realm) for a server."`
+	Create   CreateCmd   `cmd:"" help:"Create an issuer KEY, or STREAM"`
+	Delete   DeleteCmd   `cmd:"" help:"Delete a stream or server"`
+	Select   SelectCmd   `cmd:"" help:"Select a defined server or stream/server to perform operations against"`
+	Get      GetCmd      `cmd:"" help:"Get information from SSF servers"`
+	Generate GenerateCmd `cmd:"" help:"Generate an event for testing"`
+	Poll     PollCmd     `cmd:"" help:"Activate a polling client stream with a server identified by <alias>."`
+	Set      SetCmd      `cmd:"" help:"Set configuration items on server"`
+	Show     ShowCmd     `cmd:"" help:"Show locally configured information"`
+	Token    TokenCmd    `cmd:"" help:"Manage issued tokens"`
+	Exit     ExitCmd     `cmd:"" help:"Exit the shell"`
+	Help     HelpCmd     `cmd:"" help:"Show help on a command"`
 }
 
 var SessionGlobals Globals

--- a/cmd/goSignals/multisession_test.go
+++ b/cmd/goSignals/multisession_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+    "path/filepath"
+    "testing"
+    "time"
+)
+
+// AC1: Logging into two different realms produces two stored sessions; neither
+// overwrites the other, and the most-recently-logged-in realm is identifiable.
+func TestCredentialStore_TwoRealmsCoexist(t *testing.T) {
+    store := &CredentialStore{Path: filepath.Join(t.TempDir(), "credentials.json")}
+
+    earlier := time.Now().Add(-time.Hour)
+    later := time.Now()
+    store.Set("https://realm-a.example.com", &Session{AccessToken: "a", LoggedInAt: earlier})
+    store.Set("https://realm-b.example.com", &Session{AccessToken: "b", LoggedInAt: later})
+
+    a := store.Get("https://realm-a.example.com")
+    b := store.Get("https://realm-b.example.com")
+    if a == nil || b == nil {
+        t.Fatalf("expected both realm sessions to persist, got a=%v b=%v", a, b)
+    }
+    if a.AccessToken != "a" || b.AccessToken != "b" {
+        t.Errorf("sessions overwrote each other: a=%q b=%q", a.AccessToken, b.AccessToken)
+    }
+    if len(store.Issuers()) != 2 {
+        t.Errorf("expected 2 issuers in store, got %v", store.Issuers())
+    }
+}

--- a/cmd/goSignals/pkce_test.go
+++ b/cmd/goSignals/pkce_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+    "crypto/sha256"
+    "encoding/base64"
+    "regexp"
+    "testing"
+)
+
+// RFC 7636: verifier is 43-128 chars from the unreserved set [A-Za-z0-9-._~].
+var pkceVerifierPattern = regexp.MustCompile(`^[A-Za-z0-9._~-]{43,128}$`)
+
+func TestGeneratePKCE_VerifierFormat(t *testing.T) {
+    p, err := generatePKCE()
+    if err != nil {
+        t.Fatalf("generatePKCE error: %v", err)
+    }
+    if !pkceVerifierPattern.MatchString(p.Verifier) {
+        t.Errorf("verifier %q does not match RFC7636 charset/length", p.Verifier)
+    }
+}
+
+func TestGeneratePKCE_ChallengeIsS256OfVerifier(t *testing.T) {
+    p, err := generatePKCE()
+    if err != nil {
+        t.Fatalf("generatePKCE error: %v", err)
+    }
+    if p.Method != "S256" {
+        t.Errorf("expected method S256, got %q", p.Method)
+    }
+    sum := sha256.Sum256([]byte(p.Verifier))
+    want := base64.RawURLEncoding.EncodeToString(sum[:])
+    if p.Challenge != want {
+        t.Errorf("challenge is not BASE64URL(SHA256(verifier)); got %q want %q", p.Challenge, want)
+    }
+}
+
+func TestGeneratePKCE_VerifiersAreUnique(t *testing.T) {
+    p1, _ := generatePKCE()
+    p2, _ := generatePKCE()
+    if p1.Verifier == p2.Verifier {
+        t.Errorf("two PKCE verifiers were identical; randomness broken")
+    }
+}

--- a/cmd/goSignals/realm.go
+++ b/cmd/goSignals/realm.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+    "fmt"
+    "sort"
+    "strings"
+    "time"
+)
+
+// serversTrustingIssuer returns, in stable alias order, the aliases of every
+// configured server that trusts the given realm issuer. A server trusts a realm
+// when the issuer appears in its advertised AuthorizationServers, or (as a
+// fallback for servers that never cached PRM) when it is the server's
+// ActiveIssuer pointer.
+func serversTrustingIssuer(servers map[string]SsfServer, issuer string) []string {
+    var out []string
+    for alias, server := range servers {
+        if serverTrustsIssuer(server, issuer) {
+            out = append(out, alias)
+        }
+    }
+    sort.Strings(out)
+    return out
+}
+
+// serverTrustsIssuer reports whether a single server trusts the given realm.
+func serverTrustsIssuer(server SsfServer, issuer string) bool {
+    if issuer == "" {
+        return false
+    }
+    for _, as := range server.AuthorizationServers {
+        if as == issuer {
+            return true
+        }
+    }
+    return server.ActiveIssuer == issuer
+}
+
+// resolveLogoutIssuers maps logout inputs to the set of realm issuers to drop.
+// Exactly one targeting mode applies, in precedence order: --all (every stored
+// realm), --issuer (one named realm), or <alias> (the server's active issuer).
+// Specifying no target is an error so an empty `logout` never silently wipes
+// every session.
+func resolveLogoutIssuers(store *CredentialStore, servers map[string]SsfServer, alias, issuer string, all bool) ([]string, error) {
+    switch {
+    case all:
+        return store.Issuers(), nil
+    case issuer != "":
+        return []string{issuer}, nil
+    case alias != "":
+        server, ok := servers[alias]
+        if !ok {
+            return nil, fmt.Errorf("server alias %q is not defined", alias)
+        }
+        if server.ActiveIssuer == "" {
+            return nil, fmt.Errorf("server %q is not logged in to any realm", alias)
+        }
+        return []string{server.ActiveIssuer}, nil
+    default:
+        return nil, fmt.Errorf("specify a target: <alias>, --issuer <url>, or --all")
+    }
+}
+
+// renderWhoami produces a gcloud-`auth list`-style listing of every stored
+// realm session: issuer, subject/email, scopes, expiry, and which server
+// aliases trust the realm. It is a pure function over the credential store and
+// the configured servers so the rendering is unit-testable.
+func renderWhoami(store *CredentialStore, servers map[string]SsfServer) string {
+    issuers := store.Issuers()
+    if len(issuers) == 0 {
+        return "No active realm sessions. Run 'login <alias>' to authenticate."
+    }
+    sort.Strings(issuers)
+
+    var b strings.Builder
+    b.WriteString(fmt.Sprintf("%d active realm session(s):\n", len(issuers)))
+    for _, issuer := range issuers {
+        sess := store.Get(issuer)
+        who := sess.Subject
+        if sess.Email != "" {
+            if who != "" {
+                who = fmt.Sprintf("%s <%s>", sess.Subject, sess.Email)
+            } else {
+                who = sess.Email
+            }
+        }
+        if who == "" {
+            who = "(unknown)"
+        }
+        exp := "no-expiry"
+        if !sess.Expiry.IsZero() {
+            exp = sess.Expiry.Format(time.RFC3339)
+        }
+        status := "valid"
+        if sess.Expired() {
+            status = "expired (will refresh on next call)"
+        }
+        trusting := serversTrustingIssuer(servers, issuer)
+        trust := "(no configured server)"
+        if len(trusting) > 0 {
+            trust = strings.Join(trusting, ", ")
+        }
+        b.WriteString(fmt.Sprintf(
+            "  issuer=%s  subject=%s  scopes=%v  expires=%s  status=%s  servers=[%s]\n",
+            issuer, who, sess.Scopes, exp, status, trust,
+        ))
+    }
+    return b.String()
+}
+
+// selectIssuerForServer resolves which realm session should authorize a call to
+// the given server. The server's ActiveIssuer wins when it has a live session;
+// otherwise the most-recently-logged-in trusted realm is chosen (last-login-
+// wins). Returns "" when no trusted logged-in realm exists.
+func selectIssuerForServer(store *CredentialStore, server *SsfServer) string {
+    if server == nil {
+        return ""
+    }
+    if server.ActiveIssuer != "" && store.Get(server.ActiveIssuer) != nil {
+        return server.ActiveIssuer
+    }
+    best := ""
+    for _, issuer := range store.Issuers() {
+        if !serverTrustsIssuer(*server, issuer) {
+            continue
+        }
+        if best == "" || store.Get(issuer).LoggedInAt.After(store.Get(best).LoggedInAt) {
+            best = issuer
+        }
+    }
+    return best
+}

--- a/cmd/goSignals/realm_select_test.go
+++ b/cmd/goSignals/realm_select_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+    "path/filepath"
+    "testing"
+    "time"
+)
+
+// AC2 helper: a server "trusts" a realm when the issuer is among its advertised
+// AuthorizationServers (falling back to its ActiveIssuer pointer).
+func TestServersTrustingIssuer(t *testing.T) {
+    servers := map[string]SsfServer{
+        "alpha": {Alias: "alpha", AuthorizationServers: []string{"https://r1", "https://r2"}},
+        "beta":  {Alias: "beta", AuthorizationServers: []string{"https://r2"}},
+        "gamma": {Alias: "gamma", ActiveIssuer: "https://r3"},
+    }
+    got := serversTrustingIssuer(servers, "https://r2")
+    if len(got) != 2 {
+        t.Fatalf("expected alpha+beta to trust r2, got %v", got)
+    }
+    if got := serversTrustingIssuer(servers, "https://r3"); len(got) != 1 || got[0] != "gamma" {
+        t.Errorf("expected gamma to trust r3 via ActiveIssuer fallback, got %v", got)
+    }
+    if got := serversTrustingIssuer(servers, "https://none"); len(got) != 0 {
+        t.Errorf("expected no servers trust unknown issuer, got %v", got)
+    }
+}
+
+// AC6: when ActiveIssuer is set and has a session, it is selected.
+func TestSelectIssuerForServer_PrefersActiveIssuer(t *testing.T) {
+    store := &CredentialStore{Path: filepath.Join(t.TempDir(), "c.json")}
+    store.Set("https://r1", &Session{AccessToken: "a1", LoggedInAt: time.Now()})
+    store.Set("https://r2", &Session{AccessToken: "a2", LoggedInAt: time.Now()})
+    server := &SsfServer{ActiveIssuer: "https://r1", AuthorizationServers: []string{"https://r1", "https://r2"}}
+    if iss := selectIssuerForServer(store, server); iss != "https://r1" {
+        t.Errorf("expected active issuer r1, got %q", iss)
+    }
+}
+
+// AC6: when ActiveIssuer is empty, fall back to the most-recently-logged-in
+// trusted realm.
+func TestSelectIssuerForServer_FallbackMostRecent(t *testing.T) {
+    store := &CredentialStore{Path: filepath.Join(t.TempDir(), "c.json")}
+    store.Set("https://r1", &Session{AccessToken: "a1", LoggedInAt: time.Now().Add(-time.Hour)})
+    store.Set("https://r2", &Session{AccessToken: "a2", LoggedInAt: time.Now()})
+    server := &SsfServer{AuthorizationServers: []string{"https://r1", "https://r2"}}
+    if iss := selectIssuerForServer(store, server); iss != "https://r2" {
+        t.Errorf("expected most-recent trusted realm r2, got %q", iss)
+    }
+}
+
+// AC6: an ActiveIssuer with no stored session falls back to a trusted realm.
+func TestSelectIssuerForServer_ActiveIssuerNoSession(t *testing.T) {
+    store := &CredentialStore{Path: filepath.Join(t.TempDir(), "c.json")}
+    store.Set("https://r2", &Session{AccessToken: "a2", LoggedInAt: time.Now()})
+    server := &SsfServer{ActiveIssuer: "https://stale", AuthorizationServers: []string{"https://r2"}}
+    if iss := selectIssuerForServer(store, server); iss != "https://r2" {
+        t.Errorf("expected fallback to trusted r2 when active issuer has no session, got %q", iss)
+    }
+}

--- a/cmd/goSignals/server_bearer_test.go
+++ b/cmd/goSignals/server_bearer_test.go
@@ -37,6 +37,35 @@ func TestServerBearer_PrefersSessionToken(t *testing.T) {
     }
 }
 
+// AC6: with no ActiveIssuer set, serverBearer falls back to a trusted
+// logged-in realm (issuer advertised in AuthorizationServers).
+func TestServerBearer_FallsBackToTrustedRealm(t *testing.T) {
+    dir := t.TempDir()
+    g := &Globals{ConfigFile: filepath.Join(dir, "config.json")}
+
+    store := &CredentialStore{Path: credentialsPath(g)}
+    store.Set("https://idp.example.com", &Session{
+        AccessToken: "trusted-token",
+        Expiry:      time.Now().Add(time.Hour),
+        LoggedInAt:  time.Now(),
+    })
+    if err := store.Save(); err != nil {
+        t.Fatalf("save store: %v", err)
+    }
+
+    server := &SsfServer{
+        Alias:                "gs1",
+        AuthorizationServers: []string{"https://idp.example.com"},
+    }
+    bearer, err := serverBearer(g, server)
+    if err != nil {
+        t.Fatalf("serverBearer error: %v", err)
+    }
+    if bearer != "trusted-token" {
+        t.Errorf("expected fallback to trusted realm session token, got %q", bearer)
+    }
+}
+
 // TestServerBearer_FallsBackToClientToken verifies that when there is no active
 // session, the resolver falls back to a configured client token (non-interactive
 // path), preserving existing behavior.

--- a/cmd/goSignals/server_bearer_test.go
+++ b/cmd/goSignals/server_bearer_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+    "path/filepath"
+    "testing"
+    "time"
+)
+
+// TestServerBearer_PrefersSessionToken verifies the management-call bearer
+// resolver returns the logged-in session access token when a valid session
+// exists for the server's active issuer.
+func TestServerBearer_PrefersSessionToken(t *testing.T) {
+    dir := t.TempDir()
+    g := &Globals{ConfigFile: filepath.Join(dir, "config.json")}
+
+    store := &CredentialStore{Path: credentialsPath(g)}
+    store.Set("https://idp.example.com", &Session{
+        AccessToken: "session-token",
+        Expiry:      time.Now().Add(time.Hour),
+    })
+    if err := store.Save(); err != nil {
+        t.Fatalf("save store: %v", err)
+    }
+
+    server := &SsfServer{
+        Alias:        "gs1",
+        ActiveIssuer: "https://idp.example.com",
+        ClientToken:  "legacy-client-token",
+    }
+
+    bearer, err := serverBearer(g, server)
+    if err != nil {
+        t.Fatalf("serverBearer error: %v", err)
+    }
+    if bearer != "session-token" {
+        t.Errorf("expected session access token, got %q", bearer)
+    }
+}
+
+// TestServerBearer_FallsBackToClientToken verifies that when there is no active
+// session, the resolver falls back to a configured client token (non-interactive
+// path), preserving existing behavior.
+func TestServerBearer_FallsBackToClientToken(t *testing.T) {
+    dir := t.TempDir()
+    g := &Globals{ConfigFile: filepath.Join(dir, "config.json")}
+
+    server := &SsfServer{Alias: "gs1", ClientToken: "legacy-client-token"}
+    bearer, err := serverBearer(g, server)
+    if err != nil {
+        t.Fatalf("serverBearer error: %v", err)
+    }
+    if bearer != "legacy-client-token" {
+        t.Errorf("expected fallback to client token, got %q", bearer)
+    }
+}

--- a/cmd/goSignals/token_exchange_test.go
+++ b/cmd/goSignals/token_exchange_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+    "encoding/base64"
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "net/url"
+    "strings"
+    "testing"
+)
+
+// makeUnsignedIDToken builds a JWT-shaped token (header.payload.sig) whose
+// payload carries the given claims. The CLI only parses the payload for
+// display (the access token, not the id_token, is what authorizes calls), so an
+// unsigned shape is sufficient for exercising claim extraction.
+func makeUnsignedIDToken(claims map[string]any) string {
+    hdr := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+    pb, _ := json.Marshal(claims)
+    payload := base64.RawURLEncoding.EncodeToString(pb)
+    return hdr + "." + payload + ".sig"
+}
+
+func TestExchangeCodeForSession_BuildsSessionFromTokenResponse(t *testing.T) {
+    idToken := makeUnsignedIDToken(map[string]any{
+        "sub":   "user-42",
+        "email": "user42@example.com",
+    })
+
+    var gotForm url.Values
+    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        _ = r.ParseForm()
+        gotForm = r.Form
+        w.Header().Set("Content-Type", "application/json")
+        _, _ = w.Write([]byte(`{
+            "access_token":"access-xyz",
+            "refresh_token":"refresh-xyz",
+            "token_type":"Bearer",
+            "expires_in":3600,
+            "scope":"admin stream",
+            "id_token":"` + idToken + `"
+        }`))
+    }))
+    defer ts.Close()
+
+    sess, err := exchangeCodeForSession(exchangeRequest{
+        TokenEndpoint: ts.URL,
+        ClientId:      "gosignals-cli",
+        Code:          "synthetic-code",
+        Verifier:      "verifier-abc",
+        RedirectURI:   "http://127.0.0.1:5555/callback",
+    })
+    if err != nil {
+        t.Fatalf("exchange failed: %v", err)
+    }
+
+    // Verify it sent a proper authorization_code + PKCE request.
+    if gotForm.Get("grant_type") != "authorization_code" {
+        t.Errorf("expected grant_type=authorization_code, got %q", gotForm.Get("grant_type"))
+    }
+    if gotForm.Get("code") != "synthetic-code" || gotForm.Get("code_verifier") != "verifier-abc" {
+        t.Errorf("PKCE code/verifier not sent: %v", gotForm)
+    }
+    if gotForm.Get("client_id") != "gosignals-cli" {
+        t.Errorf("client_id not sent: %q", gotForm.Get("client_id"))
+    }
+
+    if sess.AccessToken != "access-xyz" || sess.RefreshToken != "refresh-xyz" {
+        t.Errorf("tokens not populated: %+v", sess)
+    }
+    if sess.Subject != "user-42" || sess.Email != "user42@example.com" {
+        t.Errorf("identity not extracted from id_token: %+v", sess)
+    }
+    if strings.Join(sess.Scopes, " ") != "admin stream" {
+        t.Errorf("scopes not parsed: %v", sess.Scopes)
+    }
+    if sess.Expiry.IsZero() {
+        t.Errorf("expiry should be set from expires_in")
+    }
+    if sess.ClientId != "gosignals-cli" {
+        t.Errorf("clientId not recorded on session: %q", sess.ClientId)
+    }
+}

--- a/cmd/goSignals/use_logout_cmd_test.go
+++ b/cmd/goSignals/use_logout_cmd_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+    "path/filepath"
+    "testing"
+    "time"
+)
+
+func newTestCLI(t *testing.T) *CLI {
+    t.Helper()
+    dir := t.TempDir()
+    g := Globals{ConfigFile: filepath.Join(dir, "config.json")}
+    c := &CLI{Globals: g}
+    c.Data.Servers = map[string]SsfServer{}
+    return c
+}
+
+// AC3: a realm logout clears the ActiveIssuer pointer on EVERY server using it.
+func TestLogoutCmd_IssuerAffectsAllServers(t *testing.T) {
+    c := newTestCLI(t)
+    store := &CredentialStore{Path: credentialsPath(&c.Globals)}
+    store.Set("https://shared", &Session{AccessToken: "tok", LoggedInAt: time.Now()})
+    if err := store.Save(); err != nil {
+        t.Fatalf("save store: %v", err)
+    }
+    c.Data.Servers["gs1"] = SsfServer{Alias: "gs1", ActiveIssuer: "https://shared", AuthorizationServers: []string{"https://shared"}}
+    c.Data.Servers["gs2"] = SsfServer{Alias: "gs2", ActiveIssuer: "https://shared", AuthorizationServers: []string{"https://shared"}}
+
+    cmd := &LogoutCmd{Issuer: "https://shared"}
+    if err := cmd.Run(c); err != nil {
+        t.Fatalf("logout: %v", err)
+    }
+
+    reloaded := &CredentialStore{Path: credentialsPath(&c.Globals)}
+    _ = reloaded.Load()
+    if reloaded.Get("https://shared") != nil {
+        t.Errorf("expected shared realm session removed")
+    }
+    if c.Data.Servers["gs1"].ActiveIssuer != "" || c.Data.Servers["gs2"].ActiveIssuer != "" {
+        t.Errorf("expected ActiveIssuer cleared on both servers, got gs1=%q gs2=%q",
+            c.Data.Servers["gs1"].ActiveIssuer, c.Data.Servers["gs2"].ActiveIssuer)
+    }
+}
+
+// AC3: --all drops every realm session.
+func TestLogoutCmd_AllDropsEverySession(t *testing.T) {
+    c := newTestCLI(t)
+    store := &CredentialStore{Path: credentialsPath(&c.Globals)}
+    store.Set("https://r1", &Session{AccessToken: "1"})
+    store.Set("https://r2", &Session{AccessToken: "2"})
+    if err := store.Save(); err != nil {
+        t.Fatalf("save store: %v", err)
+    }
+
+    cmd := &LogoutCmd{All: true}
+    if err := cmd.Run(c); err != nil {
+        t.Fatalf("logout --all: %v", err)
+    }
+    reloaded := &CredentialStore{Path: credentialsPath(&c.Globals)}
+    _ = reloaded.Load()
+    if len(reloaded.Issuers()) != 0 {
+        t.Errorf("expected all sessions dropped, got %v", reloaded.Issuers())
+    }
+}
+
+// AC5: use server --issuer overrides the active issuer (last-login-wins default
+// is overridable).
+func TestUseServerCmd_OverridesActiveIssuer(t *testing.T) {
+    c := newTestCLI(t)
+    store := &CredentialStore{Path: credentialsPath(&c.Globals)}
+    store.Set("https://r1", &Session{AccessToken: "1", LoggedInAt: time.Now().Add(-time.Hour)})
+    store.Set("https://r2", &Session{AccessToken: "2", LoggedInAt: time.Now()})
+    if err := store.Save(); err != nil {
+        t.Fatalf("save store: %v", err)
+    }
+    // Default would be r2 (most recent); override to r1.
+    c.Data.Servers["gs1"] = SsfServer{Alias: "gs1", ActiveIssuer: "https://r2", AuthorizationServers: []string{"https://r1", "https://r2"}}
+
+    cmd := &UseServerCmd{Alias: "gs1", Issuer: "https://r1"}
+    if err := cmd.Run(c); err != nil {
+        t.Fatalf("use server: %v", err)
+    }
+    if c.Data.Servers["gs1"].ActiveIssuer != "https://r1" {
+        t.Errorf("expected active issuer overridden to r1, got %q", c.Data.Servers["gs1"].ActiveIssuer)
+    }
+
+    // And serverBearer should now resolve via r1.
+    server := c.Data.Servers["gs1"]
+    bearer, err := serverBearer(&c.Globals, &server)
+    if err != nil {
+        t.Fatalf("serverBearer: %v", err)
+    }
+    if bearer != "1" {
+        t.Errorf("expected r1 token after override, got %q", bearer)
+    }
+}

--- a/cmd/goSignals/whoami_test.go
+++ b/cmd/goSignals/whoami_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+    "path/filepath"
+    "strings"
+    "testing"
+    "time"
+)
+
+// AC2: whoami lists ALL sessions and shows which server aliases trust each
+// realm. renderWhoami is a pure function so we can assert its output directly.
+func TestRenderWhoami_ListsAllSessionsWithTrustingServers(t *testing.T) {
+    store := &CredentialStore{Path: filepath.Join(t.TempDir(), "c.json")}
+    store.Set("https://realm-a", &Session{
+        AccessToken: "a", Subject: "alice", Email: "alice@example.com",
+        Scopes: []string{"admin"}, Expiry: time.Now().Add(time.Hour), LoggedInAt: time.Now(),
+    })
+    store.Set("https://realm-b", &Session{
+        AccessToken: "b", Subject: "bob", Scopes: []string{"stream"},
+        Expiry: time.Now().Add(time.Hour), LoggedInAt: time.Now(),
+    })
+    servers := map[string]SsfServer{
+        "gs1": {Alias: "gs1", AuthorizationServers: []string{"https://realm-a"}, ActiveIssuer: "https://realm-a"},
+        "gs2": {Alias: "gs2", AuthorizationServers: []string{"https://realm-a", "https://realm-b"}, ActiveIssuer: "https://realm-b"},
+    }
+
+    out := renderWhoami(store, servers)
+
+    for _, want := range []string{"https://realm-a", "https://realm-b", "alice@example.com", "bob", "admin", "stream"} {
+        if !strings.Contains(out, want) {
+            t.Errorf("whoami output missing %q:\n%s", want, out)
+        }
+    }
+    // realm-a is trusted by gs1 and gs2; realm-b only by gs2.
+    lines := strings.Split(out, "\n")
+    var aLine, bLine string
+    for _, l := range lines {
+        if strings.Contains(l, "https://realm-a") {
+            aLine = l
+        }
+        if strings.Contains(l, "https://realm-b") {
+            bLine = l
+        }
+    }
+    if !strings.Contains(aLine, "gs1") || !strings.Contains(aLine, "gs2") {
+        t.Errorf("expected realm-a trusted by gs1+gs2, line: %q", aLine)
+    }
+    if strings.Contains(bLine, "gs1") || !strings.Contains(bLine, "gs2") {
+        t.Errorf("expected realm-b trusted only by gs2, line: %q", bLine)
+    }
+}
+
+// AC2: empty store renders a clear not-logged-in message rather than a blank.
+func TestRenderWhoami_EmptyStore(t *testing.T) {
+    store := &CredentialStore{Path: filepath.Join(t.TempDir(), "c.json")}
+    out := renderWhoami(store, map[string]SsfServer{})
+    if !strings.Contains(strings.ToLower(out), "no ") {
+        t.Errorf("expected an empty-state message, got %q", out)
+    }
+}

--- a/config/goSignals1-spiffe.env
+++ b/config/goSignals1-spiffe.env
@@ -9,6 +9,12 @@ ADMIN_UI_DIR=/app/adminUI/build
 KEYCLOAK_URL=https://keycloak:9080/realms/gosignals
 I2SIG_STORE_MONGO_RESUME_FILE=/app/resources/mongo_token_1.json
 LOG_LEVEL=DEBUG
+# Authenticated bootstrap (PRD #120 / slice #121, generalized in #123). The
+# app-layer bootstrap secret and transport-layer SPIFFE mTLS are independent and
+# coexist: SPIFFE secures the connection, this secret authorizes the narrow
+# "key" scope used by scimSsfSetup to mint an issuer key + IAT unattended.
+I2SIG_BOOTSTRAP_TOKEN=dev-bootstrap-secret
+I2SIG_CLI_CLIENT_ID=gosignals-cli
 I2SIG_STORE_MONGO_BACKGROUND_RECONNECT=true
 I2SIG_TLS_ENABLED=true
 I2SIG_TLS_CERT_PATH=/app/config/certs/server-cert.pem

--- a/config/goSignals1.env
+++ b/config/goSignals1.env
@@ -6,6 +6,14 @@ PORT=8888
 BASE_URL=https://goSignals1:8888/
 I2SIG_AUTH_OAUTH_SERVERS=https://keycloak:9080/realms/gosignals/.well-known/openid-configuration
 
+# Authenticated bootstrap (PRD #120 / slice #121, generalized in #123): the
+# anonymous /iat door is closed. A bearer equal to I2SIG_BOOTSTRAP_TOKEN
+# resolves to the narrow "key" scope so scimSsfSetup can mint an issuer key +
+# IAT unattended. I2SIG_CLI_CLIENT_ID names the delegated-OAuth CLI client.
+# This value must match the secret presented by scimSsfSetup / register*.sh.
+I2SIG_BOOTSTRAP_TOKEN=dev-bootstrap-secret
+I2SIG_CLI_CLIENT_ID=gosignals-cli
+
 ADMIN_PORT=8899
 ADMIN_UI_DIR=/Users/pjdhunt/git/i2goSignals/adminUI/build
 

--- a/config/goSignals2-spiffe.env
+++ b/config/goSignals2-spiffe.env
@@ -7,6 +7,10 @@ I2SIG_AUTH_OAUTH_SERVERS=https://keycloak:9080/realms/gosignals/.well-known/open
 KEYCLOAK_URL=https://keycloak:9080/realms/gosignals
 I2SIG_STORE_MONGO_RESUME_FILE=/app/resources/mongo_token_2.json
 LOG_LEVEL=DEBUG
+# Authenticated bootstrap (PRD #120 / slice #121, generalized in #123). App-layer
+# bootstrap secret coexists with transport-layer SPIFFE mTLS (independent layers).
+I2SIG_BOOTSTRAP_TOKEN=dev-bootstrap-secret
+I2SIG_CLI_CLIENT_ID=gosignals-cli
 I2SIG_STORE_MONGO_BACKGROUND_RECONNECT=true
 I2SIG_TLS_ENABLED=true
 I2SIG_TLS_CERT_PATH=/app/config/certs/server-cert.pem

--- a/config/goSignals2.env
+++ b/config/goSignals2.env
@@ -5,6 +5,11 @@
   BASE_URL=https://goSignals2:8889/
   I2SIG_AUTH_OAUTH_SERVERS=https://keycloak:9080/realms/gosignals/.well-known/openid-configuration
 
+  # Authenticated bootstrap (PRD #120 / slice #121, generalized in #123): same
+  # narrow "key" scope secret as goSignals1; the CLI client id for delegated OAuth.
+  I2SIG_BOOTSTRAP_TOKEN=dev-bootstrap-secret
+  I2SIG_CLI_CLIENT_ID=gosignals-cli
+
   KEYCLOAK_URL=https://keycloak:9080/realms/gosignals
 
   I2SIG_STORE_MONGO_RESUME_FILE=/app/resources/mongo_token_2.json

--- a/config/goSsf1-spiffe.env
+++ b/config/goSsf1-spiffe.env
@@ -8,6 +8,10 @@ KEYCLOAK_URL=https://keycloak:9080/realms/gosignals
 I2SIG_STORE_MEM_DIRECTORY=/app/config/SsfServer1
 I2SIG_STORE_MEM_SAVE_RATE=30
 LOG_LEVEL=DEBUG
+# Authenticated bootstrap (PRD #120 / slice #121, generalized in #123). App-layer
+# bootstrap secret coexists with transport-layer SPIFFE mTLS (independent layers).
+I2SIG_BOOTSTRAP_TOKEN=dev-bootstrap-secret
+I2SIG_CLI_CLIENT_ID=gosignals-cli
 I2SIG_STORE_MONGO_BACKGROUND_RECONNECT=true
 I2SIG_TLS_ENABLED=true
 I2SIG_TLS_CERT_PATH=/app/config/certs/server-cert.pem

--- a/config/goSsf1.env
+++ b/config/goSsf1.env
@@ -9,6 +9,11 @@ I2SIG_STORE_MEM_DIRECTORY=/app/config/SsfServer1
 I2SIG_STORE_MEM_SAVE_RATE=30
 LOG_LEVEL=DEBUG
 
+# Authenticated bootstrap (PRD #120 / slice #121, generalized in #123): same
+# narrow "key" scope secret as the goSignals nodes; CLI client id for delegated OAuth.
+I2SIG_BOOTSTRAP_TOKEN=dev-bootstrap-secret
+I2SIG_CLI_CLIENT_ID=gosignals-cli
+
 I2SIG_TLS_ENABLED=true
 I2SIG_TLS_CERT_PATH=/app/config/certs/server-cert.pem
 I2SIG_TLS_KEY_PATH=/app/config/certs/server-key.pem

--- a/config/keycloak/realm/gosignals-realm.json
+++ b/config/keycloak/realm/gosignals-realm.json
@@ -80,6 +80,47 @@
       "optionalClientScopes": []
     },
     {
+      "clientId": "gosignals-cli",
+      "name": "GoSignals CLI",
+      "description": "Public PKCE client for the goSignals admin CLI (docker-login style loopback)",
+      "enabled": true,
+      "publicClient": true,
+      "protocol": "openid-connect",
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "http://127.0.0.1/*",
+        "http://localhost/*"
+      ],
+      "webOrigins": [],
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "protocolMappers": [
+        {
+          "name": "aud-goSignalsClient",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "included.client.audience": "goSignalsClient",
+            "included.custom.audience": "goSignalsClient"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": []
+    },
+    {
       "clientId": "goSignalsAdminService",
       "name": "GoSignals Admin Service",
       "description": "Service client for Admin UI token exchange to service bearer tokens",

--- a/config/scim/scripts/auto-reg.gosignals
+++ b/config/scim/scripts/auto-reg.gosignals
@@ -1,3 +1,9 @@
+# Dev bootstrap script for the goSignals CLI.
+# The anonymous /iat path is closed (PRD #120 / slice #121). `create iat` and
+# `create key` below authenticate with the shared bootstrap secret, which the
+# CLI reads from the I2SIG_BOOTSTRAP_TOKEN environment variable (injected by
+# docker-compose-dev.yml and re-exported by register-dev.sh). The secret
+# resolves to the narrow "key" scope on the server: create-only key, reg-only IAT.
 add server gosignals1 https://goSignals1:8888
 add server gosignals2 https://goSignals2:8889
 create iat gosignals1 --output=/scim/iat-gosignals1.jwt

--- a/config/scim/scripts/register-dev.sh
+++ b/config/scim/scripts/register-dev.sh
@@ -3,6 +3,16 @@
 # The compose files were swept to the new name in #72; this script consumes it.
 CA_CERT="${CA_CERT:-$I2SIG_TLS_CA_CERT}"
 
+# Authenticated bootstrap (PRD #120 / slice #121): the anonymous /iat path is
+# gone. The goSignals CLI reads I2SIG_BOOTSTRAP_TOKEN from the environment and
+# presents it as the bearer on `create key` / `create iat` (see auto-reg.gosignals).
+# compose injects I2SIG_BOOTSTRAP_TOKEN into this container; fail fast if missing.
+if [ -z "$I2SIG_BOOTSTRAP_TOKEN" ]; then
+    echo "ERROR: I2SIG_BOOTSTRAP_TOKEN is not set; cannot bootstrap without the anonymous /iat path."
+    exit 1
+fi
+export I2SIG_BOOTSTRAP_TOKEN
+
 if [ -s /scim/iat1.txt ]; then
     echo "Registration IAT file already exists, skipping token generation"
     exit 0

--- a/config/scim/scripts/register.sh
+++ b/config/scim/scripts/register.sh
@@ -3,6 +3,17 @@
 # The compose files were swept to the new name in #72; this script consumes it.
 CA_CERT="${CA_CERT:-$I2SIG_TLS_CA_CERT}"
 
+# Authenticated bootstrap (PRD #120 / slice #121, generalized to all variants in
+# #123): the anonymous /iat path is gone. The goSignals CLI reads
+# I2SIG_BOOTSTRAP_TOKEN from the environment and presents it as the bearer on
+# `create key` / `create iat` (see auto-reg.gosignals). Compose injects
+# I2SIG_BOOTSTRAP_TOKEN into this container; fail fast if missing.
+if [ -z "$I2SIG_BOOTSTRAP_TOKEN" ]; then
+    echo "ERROR: I2SIG_BOOTSTRAP_TOKEN is not set; cannot bootstrap without the anonymous /iat path."
+    exit 1
+fi
+export I2SIG_BOOTSTRAP_TOKEN
+
 if [ -s /scim/iat1.txt ]; then
     echo "Registration IAT file already exists, skipping token generation"
     exit 0

--- a/docker-compose-cluster-dev.yml
+++ b/docker-compose-cluster-dev.yml
@@ -272,6 +272,10 @@ services:
       - ISSUER=cluster.scim.example.com
       - GOSIGNALS_HOME=/scim/config.json
       - I2SIG_TLS_CA_CERT=/scim/certs/ca-cert.pem
+      # Present the bootstrap secret on `create key` / `create iat` instead of
+      # the now-removed anonymous /iat path (PRD #120 / slice #121, generalized
+      # in #123). Must match the value configured on the goSignals nodes.
+      - I2SIG_BOOTSTRAP_TOKEN=${I2SIG_BOOTSTRAP_TOKEN:-dev-bootstrap-secret}
     entrypoint: [ "sh", "/scim/scripts/register.sh"]
 
   scim_cluster1:

--- a/docker-compose-cluster.yml
+++ b/docker-compose-cluster.yml
@@ -238,6 +238,10 @@ services:
       - ISSUER=cluster.scim.example.com
       - GOSIGNALS_HOME=/scim/config.json
       - I2SIG_TLS_CA_CERT=/scim/certs/ca-cert.pem
+      # Present the bootstrap secret on `create key` / `create iat` instead of
+      # the now-removed anonymous /iat path (PRD #120 / slice #121, generalized
+      # in #123). Must match the value configured on the goSignals nodes.
+      - I2SIG_BOOTSTRAP_TOKEN=${I2SIG_BOOTSTRAP_TOKEN:-dev-bootstrap-secret}
     entrypoint: [ "sh", "/scim/scripts/register.sh"]
 
   scim_cluster1:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -282,6 +282,11 @@ services:
       - LOG_FORMAT=json
       - I2SIG_CLUSTER_NAME=dev-local
       - I2SIG_SUBJECT_FILTERING=ENABLED
+      # Authenticated bootstrap (PRD #120 / slice #121): the anonymous /iat door
+      # is closed. A bearer equal to I2SIG_BOOTSTRAP_TOKEN resolves to the narrow
+      # "key" scope so scimSsfSetup can mint an issuer key + IAT unattended.
+      - I2SIG_BOOTSTRAP_TOKEN=${I2SIG_BOOTSTRAP_TOKEN:-dev-bootstrap-secret}
+      - I2SIG_CLI_CLIENT_ID=gosignals-cli
     healthcheck:
       test: ["CMD", "sh", "-c", "curl -skf https://localhost:8888/health || curl -sf http://localhost:8888/health"]
       interval: 10s
@@ -319,6 +324,9 @@ services:
       - LOG_FORMAT=json
       - I2SIG_CLUSTER_NAME=dev-local
       - I2SIG_SUBJECT_FILTERING=ENABLED
+      # Same authenticated-bootstrap secret as goSignals1 (PRD #120 / slice #121).
+      - I2SIG_BOOTSTRAP_TOKEN=${I2SIG_BOOTSTRAP_TOKEN:-dev-bootstrap-secret}
+      - I2SIG_CLI_CLIENT_ID=gosignals-cli
     healthcheck:
       test: ["CMD", "sh", "-c", "curl -skf https://localhost:8889/health || curl -sf http://localhost:8889/health"]
       interval: 10s
@@ -387,6 +395,10 @@ services:
       - ISSUER=cluster.scim.example.com
       - GOSIGNALS_HOME=/scim/config.json
       - I2SIG_TLS_CA_CERT=/scim/certs/ca-cert.pem
+      # Present the bootstrap secret on `create key` / `create iat` instead of
+      # the now-removed anonymous /iat path (PRD #120 / slice #121). Must match
+      # the value configured on the goSignals nodes.
+      - I2SIG_BOOTSTRAP_TOKEN=${I2SIG_BOOTSTRAP_TOKEN:-dev-bootstrap-secret}
    #   - GOSIGNALS_SCRIPT=/scim/auto-reg.gosignals
     entrypoint: [ "sh", "/scim/scripts/register-dev.sh"]
 

--- a/docker-compose-spiffe-dev.yml
+++ b/docker-compose-spiffe-dev.yml
@@ -644,6 +644,10 @@ services:
       - I2SIG_TLS_CA_CERT=/scim/certs/ca-cert.pem
       - SPIFFE_ENDPOINT_SOCKET=unix:///run/spire/sockets/agent.sock
       - I2SIG_SPIFFE_TRUST_DOMAIN=cluster.i2gosignals.internal
+      # App-layer bootstrap secret (PRD #120 / slice #121, generalized in #123)
+      # coexists with transport-layer SPIFFE mTLS above. Presented on
+      # `create key` / `create iat`; must match the goSignals nodes.
+      - I2SIG_BOOTSTRAP_TOKEN=${I2SIG_BOOTSTRAP_TOKEN:-dev-bootstrap-secret}
     entrypoint: [ "sh", "/scim/scripts/register-dev.sh"]
 
   scim_cluster1:

--- a/docker-compose-spiffe.yml
+++ b/docker-compose-spiffe.yml
@@ -616,6 +616,10 @@ services:
       - I2SIG_TLS_CA_CERT=/scim/certs/ca-cert.pem
       - SPIFFE_ENDPOINT_SOCKET=unix:///run/spire/sockets/agent.sock
       - I2SIG_SPIFFE_TRUST_DOMAIN=cluster.i2gosignals.internal
+      # App-layer bootstrap secret (PRD #120 / slice #121, generalized in #123)
+      # coexists with transport-layer SPIFFE mTLS above. Presented on
+      # `create key` / `create iat`; must match the goSignals nodes.
+      - I2SIG_BOOTSTRAP_TOKEN=${I2SIG_BOOTSTRAP_TOKEN:-dev-bootstrap-secret}
     entrypoint: [ "sh", "/scim/scripts/register-dev.sh"]
 
   scim_cluster1:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -284,6 +284,10 @@ services:
       - ISSUER=cluster.scim.example.com
       - GOSIGNALS_HOME=/scim/config.json
       - I2SIG_TLS_CA_CERT=/scim/certs/ca-cert.pem
+      # Present the bootstrap secret on `create key` / `create iat` instead of
+      # the now-removed anonymous /iat path (PRD #120 / slice #121, generalized
+      # in #123). Must match the value configured on the goSignals nodes.
+      - I2SIG_BOOTSTRAP_TOKEN=${I2SIG_BOOTSTRAP_TOKEN:-dev-bootstrap-secret}
    #   - GOSIGNALS_SCRIPT=/scim/auto-reg.gosignals
     entrypoint: [ "sh", "/scim/scripts/register.sh"]
 

--- a/docs/adr/0005-delegated-cli-authentication-rfc9728.md
+++ b/docs/adr/0005-delegated-cli-authentication-rfc9728.md
@@ -1,0 +1,91 @@
+<!-- gosignals-brand-hero -->
+<picture><source media="(prefers-color-scheme: dark)" srcset="../../brand/logo/gosignals-hero-primary.svg"><img src="../../brand/logo/gosignals-hero-on-light.svg" alt="goSignals" height="77"></picture>
+
+# Delegated CLI authentication via RFC 9728 (no built-in AS)
+
+The `goSignals` CLI authenticates a human against a server's management plane by
+**delegating** to an external OAuth/OIDC authorization server, discovered through
+the server's **RFC 9728 Protected Resource Metadata (PRM)**. goSignals does not
+ship its own authorization server, browser-based login UI, or password store. It
+is purely an OAuth *protected resource*: it advertises which authorization
+servers it trusts and which public client the CLI should use, and validates the
+access tokens those authorization servers issue (`OAUTH_SERVERS` →
+`I2SIG_AUTH_OAUTH_SERVERS`, validated in
+`internal/authUtil/auth_token.go:ValidateAuthorizationAny`).
+
+The login flow (`cmd/goSignals/login.go`, `discovery.go`, `device.go`):
+
+1. `add server <alias>` is **connect-only**. It does SSF discovery, fetches the
+   PRM (`/.well-known/oauth-protected-resource`), and caches the advertised
+   `authorization_servers` on the local server record. It mints no credential.
+2. `login <alias>` fetches the PRM, resolves the issuer (the sole advertised AS,
+   or `--issuer`) and the public `client_id`
+   (`buildProtectedResourceMetadata` advertises `I2SIG_CLI_CLIENT_ID`, default
+   `gosignals-cli`, or `--client-id`), then discovers the issuer's OpenID
+   Provider configuration.
+3. With a browser and a bindable loopback listener available, it runs a
+   `docker login`-style **OAuth authorization code + PKCE** flow (RFC 6749 /
+   RFC 7636) over an ephemeral `127.0.0.1` listener with a CSRF `state`.
+4. On a headless host (no browser, or no bindable loopback), or with `--device`,
+   it falls back to the **RFC 8628 device-code** flow
+   (`selectLoginMethod` in `device.go`).
+5. The resulting session (access + refresh token, identity claims) is stored
+   per-issuer in `credentials.json` (mode `0600`), separate from `config.json`.
+   Management calls present the access token, silently refreshing via the
+   RFC 6749 refresh-token grant (`cmd/goSignals/bearer.go`); `logout` makes a
+   best-effort RFC 7009 revocation.
+
+Sessions are keyed by **issuer (realm)**, not by server alias, so a single login
+serves every server that trusts that realm, and one server may accumulate
+sessions across several realms (last-login-wins active-issuer defaulting,
+`cmd/goSignals/realm.go:selectIssuerForServer`).
+
+## Status
+
+Accepted. Shipped across PRD #120 slices #122 (single-realm PKCE), #124
+(device-code fallback), #125 (multi-realm sessions / `whoami` / `logout` /
+`use server`).
+
+## Considered options
+
+- **Build a first-party authorization server / password login into goSignals.**
+  Rejected: re-implements a security-critical component (token issuance, MFA,
+  account lifecycle, brute-force protection) that mature IdPs already provide;
+  contradicts the project's role as an SSF *protected resource*; and forces every
+  deployment to manage another credential store. Delegating to Keycloak (or any
+  OIDC AS) is strictly less code and less attack surface.
+- **Long-lived static admin tokens pasted into the CLI (`--token` only).**
+  Rejected as the *primary* path: long-lived bearer tokens on disk are a standing
+  liability, can't be silently refreshed, and give no per-user identity for
+  audit. Retained as a *non-interactive* escape hatch for SSF servers and CI.
+- **A device-code-only flow for every host.** Rejected: the loopback PKCE flow is
+  a materially better UX on a desktop (no copy-paste of a user code), so the CLI
+  prefers it and only falls back to device-code when the host can't support it.
+- **Out-of-band issuer/client configuration on the CLI (flags or a config file
+  the operator fills in).** Rejected as the default: the server already knows
+  which AS it trusts, so advertising it via RFC 9728 PRM removes a configuration
+  step and a class of mismatched-issuer errors. `--issuer`/`--client-id` remain
+  as overrides.
+
+## Consequences
+
+- goSignals must advertise PRM (`ProtectedResourceMetadataHandler` in
+  `internal/server/api_out_of_band.go`) and validate externally-issued access
+  tokens — it already does both, routing by token `kid`.
+- The CLI gains an OAuth client implementation (PKCE, device-code, refresh,
+  revocation) but no server-side auth code; the protocol libraries stay free of
+  `internal/` imports.
+- Tokens never land in `config.json`; only the non-secret active issuer and
+  advertised servers are cached there. `credentials.json` is `0600`.
+- A deployment must run/trust an OIDC AS and configure
+  `I2SIG_AUTH_OAUTH_SERVERS` (+ optionally `I2SIG_CLI_CLIENT_ID`). Where no human
+  or AS is available (CI, demo bootstrap), the bootstrap-secret path
+  (ADR 0006) covers the gap.
+- Operator-facing documentation lives in [`docs/cli_login.md`](../cli_login.md)
+  and [`docs/security_model.md`](../security_model.md); this ADR is the design
+  record.
+
+---
+
+<!-- gosignals-brand-footer -->
+<p align="center"><sub>(C)2026 Independent Identity Inc.</sub></p>

--- a/docs/adr/0006-key-scope-and-closing-anonymous-iat.md
+++ b/docs/adr/0006-key-scope-and-closing-anonymous-iat.md
@@ -1,0 +1,101 @@
+<!-- gosignals-brand-hero -->
+<picture><source media="(prefers-color-scheme: dark)" srcset="../../brand/logo/gosignals-hero-primary.svg"><img src="../../brand/logo/gosignals-hero-on-light.svg" alt="goSignals" height="77"></picture>
+
+# The `key` scope and closing anonymous `/iat`
+
+Historically `GET /iat` was **anonymous**: any unauthenticated caller could mint
+an Initial Access Token and thereby start a project and register a client. That
+is a standing un-authenticated write surface. This ADR records (a) closing that
+door and (b) introducing a narrow `key` scope so unattended deployments can still
+bootstrap themselves without it.
+
+## Closing anonymous `/iat`
+
+`GET /iat` and `POST /key/<issuer>` now require a bearer with one of
+`{key, admin, root}` (`IssuerProjectIatHandler` / `CreateKeyHandler` in
+`internal/server/api_out_of_band.go`, via
+`ValidateAuthorizationAny([]string{ScopeKey, ScopeStreamAdmin, ScopeRoot})`).
+A missing or invalid bearer is rejected. There is no longer an
+unauthenticated path to either endpoint — the change **fails closed**.
+
+## The `key` scope
+
+`authSupport.ScopeKey` (`"key"`, `pkg/authSupport/auth_token.go`) is a new scope
+sitting **between `reg` and `admin`**:
+
+- A `key`-scoped caller may mint a **new** issuer signing key, but a key
+  **takeover** — `force=replace`, `force=rotate`, or `?rotate` — is denied for a
+  caller that holds *only* `key` (no `admin`/`root`). The guard is `keyScopeOnly`
+  + `requestIsKeyTakeover` in `api_out_of_band.go:CreateKeyHandler`. This prevents
+  substituting an attacker key under an existing issuer and forging events.
+- A `key`-scoped caller may obtain an IAT, but the minted IAT is always
+  **`reg`-only** — `IssueProjectIat` always sets `Roles: [reg]`. The
+  key/admin capability does not propagate into the IAT.
+- `key` carries **no** stream/event capability.
+
+`reg` itself is privilege-ceilinged at the registration door: a `reg` caller's
+self-registration caps at `stream`+`event` (`RegisterClientHandler` silently
+drops `admin`/unknown scopes). The tiers form a ladder — `key` → `reg` →
+`stream`/`event`, with `admin` provisioned out of band.
+
+## The bootstrap secret as the `key`-scope grant
+
+The shared secret `I2SIG_BOOTSTRAP_TOKEN` is how an unattended deployment obtains
+`key` scope without a JWT. `AuthIssuer.resolveBootstrapBearer`
+(`internal/authUtil/bootstrap_resolver.go`) runs **before** any JWT/kid
+classification in `ValidateAuthorizationAny`: a presented bearer that
+**constant-time-equals** the configured secret is synthesized into a `key`-scope
+`AuthContext`. When the env var is unset, the resolver short-circuits and returns
+`nil` (so an empty bearer can never match an empty secret) — the bootstrap path is
+closed. The PRM advertises `key` among `scopes_supported`.
+
+The secret is an **app-layer** authorization mechanism, independent of and
+coexisting with transport-layer identity (TLS / SPIFFE mTLS): SPIFFE secures the
+connection, the secret authorizes the narrow capability.
+
+## Status
+
+Accepted. Shipped in PRD #120 slice #121, generalized across all compose variants
+in slice #123. The demo stacks bootstrap via `config/scim/scripts/register.sh` +
+`auto-reg.gosignals` using `I2SIG_BOOTSTRAP_TOKEN`.
+
+## Considered options
+
+- **Keep `/iat` anonymous.** Rejected: an un-authenticated endpoint that creates
+  projects and registration tokens is an obvious abuse and resource-exhaustion
+  vector, and is incompatible with the delegated-auth model (ADR 0005).
+- **Require full `admin` for `/iat` and `/key`.** Rejected: forces an unattended
+  bootstrap (CI, init container, demo `scimSsfSetup`) to either run a human login
+  or hold an over-broad admin credential. The whole point of `key` is to grant
+  *exactly* "seed an issuer key + a reg IAT" and nothing more.
+- **Let the bootstrap secret grant `admin`/`root`.** Rejected: a shared static
+  secret with full administrative power is too dangerous; capping it at create-only
+  `key` (no takeover, no stream/event, reg-only IAT) bounds the blast radius if the
+  secret leaks.
+- **A dedicated bootstrap endpoint instead of reusing `/iat` + `/key`.**
+  Rejected: needless new surface; the existing endpoints already do exactly what
+  bootstrap needs once they require a credential, and the scope check is the right
+  place to express "create-only".
+
+## Consequences
+
+- New scope constant `ScopeKey`; `IsScopeMatch`/`IsAuthorized` continue to treat
+  `root` as a superset.
+- `CreateKeyHandler` gains the takeover guard; `IssuerProjectIatHandler` accepts
+  `{key, admin, root}` and always mints `reg`-only IATs.
+- A new fail-closed code path (`resolveBootstrapBearer`) runs ahead of JWT
+  validation; an unset secret accepts no bootstrap bearer.
+- Deployments must set `I2SIG_BOOTSTRAP_TOKEN` (server **and** CLI/automation env)
+  to bootstrap unattended; the demo default `dev-bootstrap-secret` is for demos
+  only and must be replaced in production.
+- IAT default lifetime tightened to 24h (`I2SIG_IAT_LIFETIME`,
+  `defaultIatLifetime` in `auth_token.go`), down from a hard-coded 90 days —
+  IATs are short-lived bootstrap credentials.
+- Operator-facing documentation lives in
+  [`docs/security_model.md`](../security_model.md) and
+  [`docs/cli_login.md`](../cli_login.md); this ADR is the design record.
+
+---
+
+<!-- gosignals-brand-footer -->
+<p align="center"><sub>(C)2026 Independent Identity Inc.</sub></p>

--- a/docs/cli_login.md
+++ b/docs/cli_login.md
@@ -1,0 +1,261 @@
+<!-- gosignals-brand-hero -->
+<picture><source media="(prefers-color-scheme: dark)" srcset="../brand/logo/gosignals-hero-primary.svg"><img src="../brand/logo/gosignals-hero-on-light.svg" alt="goSignals" height="77"></picture>
+
+# goSignals CLI Login &amp; Bootstrap Guide
+
+This guide walks the two ways the `goSignals` CLI authenticates against a
+server's **management plane**:
+
+1. **Delegated OAuth login** (`login`) — an interactive, `docker login`-style
+   browser flow (RFC 9728 Protected Resource Metadata → OAuth authorization
+   code + PKCE, RFC 7636) that produces a per-realm session. This is the path
+   for humans.
+2. **Unattended bootstrap** (`I2SIG_BOOTSTRAP_TOKEN`) — a shared secret that a
+   CI/automation context presents directly as a bearer to mint an issuer signing
+   key and an Initial Access Token (IAT). This is the path for scripts and the
+   demo compose stacks.
+
+> [!IMPORTANT]
+> The anonymous `/iat` endpoint is **closed**. A request to `/iat` (or
+> `/key`) with no usable bearer is rejected. Either log in (delegated OAuth)
+> or present the bootstrap secret.
+
+See [`security_model.md`](security_model.md) for the underlying auth model and
+[`gosignals_tool.md`](gosignals_tool.md) for the full command reference.
+
+---
+
+## 1. Delegated OAuth login (interactive)
+
+This is the end-to-end path from a clean checkout.
+
+### Build the CLI
+
+```shell
+make console-build      # builds cmd/goSignals
+# or:
+go build -o goSignals ./cmd/goSignals
+```
+
+### `add server` — connect only
+
+`add server` is **connect-only**: it performs SSF discovery
+(`/.well-known/ssf-configuration`), caches the advertised OAuth
+`authorization_servers` from the server's Protected Resource Metadata, and
+records the server under a local alias. It mints **no** credential.
+
+```shell
+goSignals> add server gs1 https://goSignals1:8888
+```
+
+On success the CLI prints the discovered authorization server(s) and prompts
+you to log in:
+
+```
+Discovered authorization server(s): [https://keycloak:9080/realms/gosignals]
+Run 'login gs1' to authenticate.
+```
+
+If the server advertises no `authorization_servers`, the CLI tells you to use
+`--bootstrap` or `--token` instead (the non-interactive paths below).
+
+### `login` — browser PKCE
+
+```shell
+goSignals> login gs1
+```
+
+The CLI:
+
+1. Fetches the server's RFC 9728 Protected Resource Metadata and resolves the
+   issuer (the single advertised authorization server, or `--issuer` if several
+   are advertised) and the public `client_id` (advertised, or `--client-id`).
+2. Discovers the issuer's OpenID Provider configuration (authorization, token,
+   revocation, and device-authorization endpoints).
+3. Generates a PKCE `code_verifier`/`code_challenge` (S256) and a CSRF `state`,
+   starts an ephemeral `127.0.0.1` loopback listener, and opens your browser at
+   the authorization endpoint:
+
+   ```
+   Opening browser to log in:
+     https://keycloak:9080/realms/gosignals/protocol/openid-connect/auth?...
+   ```
+
+4. Receives the authorization-code redirect on the loopback listener, exchanges
+   the code (with the PKCE verifier) at the token endpoint, and stores the
+   resulting session.
+
+On a **headless host** (no browser / no bindable loopback listener), or when you
+pass `--device`, the CLI automatically falls back to the RFC 8628 device-code
+flow, printing a verification URL and user code to complete on another device:
+
+```
+To complete login, on any device open:
+  https://keycloak:9080/realms/gosignals/device?user_code=ABCD-EFGH
+Waiting for authorization...
+```
+
+Tokens are written to `credentials.json` (mode `0600`) keyed by **issuer**, next
+to `config.json`. The non-secret active issuer and advertised servers are cached
+on the server record in `config.json`; **tokens are never written to
+`config.json`**.
+
+```
+Logged in to gs1 as issuer=https://keycloak:9080/realms/gosignals subject=alice <alice@example.com> scopes=[...] expires=... clientId=gosignals-cli
+```
+
+### `whoami` — show sessions
+
+With an alias, `whoami` shows the active realm session for that server:
+
+```shell
+goSignals> whoami gs1
+```
+
+With no alias, it lists every stored realm session (gcloud `auth list`-style),
+including which configured server aliases trust each realm:
+
+```shell
+goSignals> whoami
+2 active realm session(s):
+  issuer=https://keycloak:9080/realms/gosignals  subject=alice <alice@example.com>  scopes=[openid email profile]  expires=...  status=valid  servers=[gs1]
+```
+
+### Run a management command
+
+Once logged in, management calls present the realm session's access token as the
+bearer, silently refreshing it (RFC 6749 refresh-token grant) when expired:
+
+```shell
+goSignals> get stream config <streamAlias>
+goSignals> create stream push receiver gs1 ...
+```
+
+If the session has expired and its refresh token is dead, the CLI surfaces a
+clear "re-login required" message — run `login gs1` again.
+
+### `logout`
+
+A realm logout drops the session for that realm everywhere it is used:
+
+```shell
+goSignals> logout gs1                 # the server's active issuer
+goSignals> logout --issuer https://keycloak:9080/realms/gosignals
+goSignals> logout --all               # every stored realm session
+```
+
+Logout makes a best-effort RFC 7009 refresh-token revocation against the IdP,
+deletes the local session, and clears the `ActiveIssuer` pointer on every server
+that referenced that realm. An empty `logout` with no target is an error so you
+never accidentally wipe every session.
+
+### Multi-realm sessions
+
+`credentials.json` accumulates one session **per issuer (realm)**. A single
+server may trust several realms; `login` adds a session without disturbing
+others. Which realm authorizes a call to a given server is resolved as:
+
+1. the server's `ActiveIssuer` pointer, when it has a live session; otherwise
+2. the most-recently-logged-in realm the server trusts (**last-login-wins**).
+
+Set the active realm explicitly with `use server`:
+
+```shell
+goSignals> use server gs1 --issuer https://keycloak:9080/realms/gosignals
+```
+
+A non-advertised issuer is accepted with a warning so manual overrides remain
+possible.
+
+---
+
+## 2. Unattended bootstrap (non-interactive)
+
+When there is no human and no browser — CI, the demo compose stacks, an
+init container — use the shared **bootstrap secret**. Set
+`I2SIG_BOOTSTRAP_TOKEN` on **both** the server (so it accepts the secret) and
+the CLI's environment (so it presents it).
+
+On the server, a bearer that constant-time-equals `I2SIG_BOOTSTRAP_TOKEN`
+resolves to the narrow **`key` scope**: enough to create a *new* issuer signing
+key and obtain a `reg`-only IAT, but **not** to take over an existing key
+(`force=replace`/`rotate` is denied) and **not** any stream/event capability.
+When `I2SIG_BOOTSTRAP_TOKEN` is unset on the server, the bootstrap path is closed
+and no bootstrap bearer is ever accepted (fail closed).
+
+### `add server --bootstrap`
+
+`--bootstrap` opts in to minting an IAT at `add server` time using the secret:
+
+```shell
+export I2SIG_BOOTSTRAP_TOKEN=dev-bootstrap-secret
+goSignals> add server gs1 https://goSignals1:8888 --bootstrap
+```
+
+This presents `Bearer $I2SIG_BOOTSTRAP_TOKEN` to `/iat`, records the returned
+`reg`-only IAT on the server entry, and skips client auto-registration.
+`--bootstrap` errors out if `I2SIG_BOOTSTRAP_TOKEN` is unset.
+
+### `create key` and `create iat`
+
+`create key` and `create iat` present a bearer resolved as: a configured client
+token if one exists, otherwise the `I2SIG_BOOTSTRAP_TOKEN` secret. With neither,
+the (now non-anonymous) server rejects the request.
+
+```shell
+export I2SIG_BOOTSTRAP_TOKEN=dev-bootstrap-secret
+goSignals> create key gs1 cluster.scim.example.com --file=issuer.pem
+goSignals> create iat gs1
+```
+
+This is exactly what the demo stacks do. The `scimSsfSetup` container exports
+`I2SIG_BOOTSTRAP_TOKEN` and runs `config/scim/scripts/auto-reg.gosignals`:
+
+```
+add server gosignals1 https://goSignals1:8888
+add server gosignals2 https://goSignals2:8889
+create iat gosignals1 --output=/scim/iat-gosignals1.jwt
+create bundle --output=/scim/spire-bundle.pem
+create key gosignals1 cluster.scim.example.com --file=/scim/cluster-scim-issuer.pem
+exit
+```
+
+### Which credential does each scenario use?
+
+| Scenario                              | Credential presented                                  | Server-side scope |
+| :------------------------------------ | :---------------------------------------------------- | :---------------- |
+| `login` then management command       | Per-realm OAuth access token (from `credentials.json`)| Whatever the IdP grants the user |
+| `add server --bootstrap` → IAT        | `I2SIG_BOOTSTRAP_TOKEN` secret                        | `key` → mints `reg`-only IAT |
+| `create key` / `create iat` (no token)| `I2SIG_BOOTSTRAP_TOKEN` secret                        | `key` (create-only) |
+| `create key` / `create iat` (token)   | Stored `ClientToken` (`--token`/`--client-secret`)    | as the token's scope |
+| `add server --token` / `--iat`        | Supplied admin token / IAT, stored on the server entry| as supplied |
+
+---
+
+## 3. Docker Compose variant matrix
+
+There are six compose variants. All of them share the same auth model — the
+bootstrap secret is wired the same way; the SPIFFE variants add transport-layer
+mTLS that coexists with (and is independent of) the app-layer bootstrap secret.
+
+| File                              | Adds over base                                                                 | Login &amp; bootstrap behavior |
+| :-------------------------------- | :----------------------------------------------------------------------------- | :----------------------------- |
+| `docker-compose.yml`              | Base demo: 2 goSignals nodes + `goSsfServer`, MongoDB replica set, Keycloak, Prometheus/Grafana, 2 i2scim nodes. | goSignals nodes read `I2SIG_BOOTSTRAP_TOKEN` + `I2SIG_CLI_CLIENT_ID` from their `config/*.env` files; `scimSsfSetup` injects `I2SIG_BOOTSTRAP_TOKEN` and bootstraps via `register.sh`. Interactive `login` works against the `gosignals` Keycloak realm. |
+| `docker-compose-dev.yml`          | Dev image (`i2gosignals-dev`), source mounted, Delve on `2345`/`2346`/`2347`, Loki/Alloy log stack. | Same bootstrap secret; goSignals services additionally set `I2SIG_BOOTSTRAP_TOKEN` + `I2SIG_CLI_CLIENT_ID` inline in compose. Uses `register-dev.sh`. |
+| `docker-compose-cluster.yml`      | Nginx load balancer + redundant nodes (`goSignals1`, `goSignals1b`, `goSignals2`, `goSsfServer`) for HA; `I2SIG_CLUSTER_NODE_ID` per node. | Same bootstrap model; `scimSsfSetup` injects `I2SIG_BOOTSTRAP_TOKEN`. Login flows route through the Nginx front door. |
+| `docker-compose-cluster-dev.yml`  | Cluster topology on the dev image; `goSsfServer` runs under Delve (`dlv debug … :2345`). | Same as cluster, dev build. |
+| `docker-compose-spiffe.yml`       | SPIRE server/agent + workload registration; MongoDB and inter-node calls use SPIFFE X.509-SVID mTLS (`SPIFFE_ENDPOINT_SOCKET`, `I2SIG_SPIFFE_TRUST_DOMAIN`). | SPIFFE secures the **transport**; the app-layer bootstrap secret is **independent** and still required to mint keys/IATs (`I2SIG_BOOTSTRAP_TOKEN` set in `*-spiffe.env`). The two coexist. |
+| `docker-compose-spiffe-dev.yml`   | SPIFFE topology on the dev image; Delve on `2345`/`2346`/`2347`, `goSsfServer` under `dlv debug`, `cluster-monitor` via `go run`. | Same as spiffe, dev build. |
+
+> [!NOTE]
+> `I2SIG_BOOTSTRAP_TOKEN` defaults to `dev-bootstrap-secret` in the compose
+> files (`${I2SIG_BOOTSTRAP_TOKEN:-dev-bootstrap-secret}`). This is a **demo**
+> value — set a real secret in production and never commit it.
+
+---
+
+## See also
+
+- [GoSignals Administration Tool](gosignals_tool.md) — full CLI command/flag reference.
+- [Security Model](security_model.md) — management-plane vs data-plane auth, the `key` scope, machine tiers.
+- [Configuration Properties](configuration_properties.md) — `I2SIG_BOOTSTRAP_TOKEN`, `I2SIG_CLI_CLIENT_ID`, `I2SIG_IAT_LIFETIME`.

--- a/docs/configuration_properties.md
+++ b/docs/configuration_properties.md
@@ -126,6 +126,8 @@ understands. They are documented in their natural section below.
 | `I2SIG_AUTH_STS_AUDIENCE`         | `audience` parameter requested from the STS (RFC 8693).                                                      | _none_  |
 | `I2SIG_AUTH_STS_RESOURCE`         | `resource` parameter requested from the STS (RFC 8707).                                                      | _none_  |
 | `I2SIG_AUTH_STS_SCOPES`           | Space-separated scopes requested from the STS.                                                               | _none_  |
+| `I2SIG_BOOTSTRAP_TOKEN`           | Shared bootstrap secret. A bearer that constant-time-equals this value resolves to the narrow `key` scope (create a new issuer key + obtain a `reg`-only IAT). When unset, the anonymous `/iat` path is closed and no bootstrap bearer is accepted (fail closed). | _none_  |
+| `I2SIG_IAT_LIFETIME`              | Validity of minted Initial Access Tokens (IATs), as a Go duration (e.g. `24h`, `30m`). Invalid/empty falls back to the default. | `24h`   |
 
 ## Cluster
 

--- a/docs/configuration_properties.md
+++ b/docs/configuration_properties.md
@@ -127,6 +127,7 @@ understands. They are documented in their natural section below.
 | `I2SIG_AUTH_STS_RESOURCE`         | `resource` parameter requested from the STS (RFC 8707).                                                      | _none_  |
 | `I2SIG_AUTH_STS_SCOPES`           | Space-separated scopes requested from the STS.                                                               | _none_  |
 | `I2SIG_BOOTSTRAP_TOKEN`           | Shared bootstrap secret. A bearer that constant-time-equals this value resolves to the narrow `key` scope (create a new issuer key + obtain a `reg`-only IAT). When unset, the anonymous `/iat` path is closed and no bootstrap bearer is accepted (fail closed). | _none_  |
+| `I2SIG_CLI_CLIENT_ID`             | Public OAuth `client_id` advertised in the server's RFC 9728 Protected Resource Metadata as the recommended client for the interactive `goSignals login` flow. | `gosignals-cli` |
 | `I2SIG_IAT_LIFETIME`              | Validity of minted Initial Access Tokens (IATs), as a Go duration (e.g. `24h`, `30m`). Invalid/empty falls back to the default. | `24h`   |
 
 ## Cluster

--- a/docs/gosignals_tool.md
+++ b/docs/gosignals_tool.md
@@ -11,8 +11,13 @@ The following table lists currently available commands in the goSignals tool.  N
 | Command                                        | Works with<BR>SSF Servers | Description                                                                                                                    |
 |------------------------------------------------|---------------------------|--------------------------------------------------------------------------------------------------------------------------------|
 | <BR>**Defining Servers**                       |                           | <BR>Commands which are used to define i2goSignals and SSF servers to be administered                                           |
-| [add server](#adding-a-server)                 | Yes                       | Add an SSF or i2goSignals server to be administered. Calls and queries the SSF well-known endpoint and generates a local alias |
+| [add server](#adding-a-server)                 | Yes                       | Connect-only: add an SSF or i2goSignals server to be administered. Calls the SSF well-known endpoint, caches advertised OAuth servers, generates a local alias. Mints no credential. |
 | show server                                    | Yes                       | Shows a currently defined server and any known associated streams                                                              |
+| <BR>**Login &amp; Sessions**                   |                           | <BR>Delegated-OAuth login and per-realm session management (see [CLI Login Guide](cli_login.md))                              |
+| [login](#login)                                | Yes                       | Interactively log in to a server's advertised IdP (browser PKCE, or device-code fallback)                                     |
+| [whoami](#whoami)                              | Yes                       | Show the active session for a server, or list every stored realm session                                                      |
+| [logout](#logout)                              | Yes                       | Clear stored realm session(s): `<alias>`, `--issuer <url>`, or `--all`                                                        |
+| [use server](#use-server)                      | Yes                       | Set the active issuer (realm) for a server                                                                                     |
 | <BR>**Key and Token Management**               |                           | <BR>Generating and obtaining signing keys and initial access tokens                                                            |
 | create key                                     | No                        | Generate a key pair which can be used by a transmitter. i2goSignals provides a JWKS_URL endpoint for the public key            |
 | get key                                        | N/A                       | Returns a public key from a specified URL or i2goSignals server                                                                |
@@ -65,19 +70,30 @@ information is stored in the local session store.
 > <alias>   A unique name to identify the server
 > <host>    Http URL for a goSignals server
 > Flags:
-> --server-url=STRING          The URL of an i2goServer or use an environment variable GOSIGNALS_URL ($GOSIGNALS_URL)
 > -o, --output=STRING          To redirect output to a file
 > -a, --append-output          When true, output to file (--output) will be appended
-> 
+>
 >       --desc=STRING          Description of project
 >       --email=STRING         Contact email for project
->       --iat=STRING           Registration Initial Access Auth if provided
->       --token=STRING         Administration authorization token
+>       --iat=STRING           Registration Initial Access Token (non-interactive)
+>       --token=STRING         Administration authorization token (non-interactive)
+>       --client-secret=STRING OAuth client secret for non-interactive client-credentials use
+>       --bootstrap            Use the I2SIG_BOOTSTRAP_TOKEN shared secret to mint an IAT (non-interactive)
 > ```
 
-Example:
+`add server` is **connect-only** by default. Provide an interactive session
+later with [`login`](#login); the `--iat` / `--token` / `--client-secret` /
+`--bootstrap` flags remain for non-interactive (CI/bootstrap) use.
+
+Example (connect-only):
 ```shell
-goSignals> add server go1 http://goSignals1:8888 --iat=eyJhbGciOiJSUzI1...p9aw6935efcgEKmA
+goSignals> add server gs1 https://goSignals1:8888
+```
+
+Example (non-interactive bootstrap):
+```shell
+export I2SIG_BOOTSTRAP_TOKEN=dev-bootstrap-secret
+goSignals> add server gs1 https://goSignals1:8888 --bootstrap
 ```
 
 If successful the response will be similar to:
@@ -124,23 +140,31 @@ ServerUrl configured:
 
 ### What Add Server Does
 
-`add Server` connects with server URL provided and interrogates the `/.well-known/ssf-configuration` data to determine
-endpoints and capabilities. In the case of **i2goSignals** servers, the command will register the **gosignals** as a
-an administrative client enabling management of streams.
+`add server` connects to the server URL provided and interrogates the
+`/.well-known/ssf-configuration` data to determine endpoints and capabilities.
+By default it is **connect-only**: it also fetches the server's RFC 9728
+Protected Resource Metadata, caches the advertised OAuth `authorization_servers`
+on the local server record, and records the alias. It mints **no** credential —
+authenticate later with [`login`](#login).
 
-When a request is made with an alias and URL (e.g. `add server goserver1 http://gosignals1.example.com`), the **gosignals**  
-administration tool connects to the SSF or i2goSignals server and retrieves the `/.well-known/ssf-configuration` information. 
+If the server advertises `authorization_servers`, the tool prints them and
+suggests `login <alias>`. If it advertises none, the tool suggests `--bootstrap`
+or `--token` for non-interactive auth.
 
-If neither `--iat` nor `--token` parameters are provided, the goSignals tool will attempt to obtain an Initial Access Token from
-the server at the endpoint `/iat` (for i2goSignals servers only). 
+The non-interactive flags select an alternative, exactly one applying:
 
-> [!Note]
-> For SSF servers, you would need to obtain a token
-> from the SSF server's token provider and provide it with the `--token` parameter.
+- `--iat=<token>` — record a supplied Initial Access Token on the server entry
+  (used to register a stream client).
+- `--token=<token>` / `--client-secret=<secret>` — record an administration /
+  client-credentials token used directly as the management bearer (typical for
+  SSF servers where the token is obtained out of band).
+- `--bootstrap` — present `Bearer $I2SIG_BOOTSTRAP_TOKEN` to `/iat` and record
+  the returned `reg`-only IAT. Errors if `I2SIG_BOOTSTRAP_TOKEN` is unset. Client
+  auto-registration is skipped.
 
-If the `--iat` parameter is provided, the **gosignals** tool will use that token to attempt to register to obtain a client token using 
-the endpoint identified in the server configuration as `client_registration_endpoint` (e.g. `/registration`). In response
-i2goSignals server will return an administration token (client authorization token) to be used in subsequent requests.
+> [!IMPORTANT]
+> The anonymous `/iat` path is **closed**. `add server` no longer auto-fetches an
+> IAT without a credential. Use `login` (delegated OAuth) or `--bootstrap`.
 
 > [!Note]
 > While an IAT is not needed, IATs may be used to bootstrap multiple servers in a project to obtain unique client tokens. 
@@ -154,6 +178,83 @@ The token parameter is typically used with SSF servers where the authorization t
 the SSF service provider.
 
 When registering with an i2goSignals server, the `--desc` and `--email` parameters can be used to provide additional contact or use data.
+
+## Login
+
+`login <alias>` runs a `docker login`-style delegated-OAuth flow against the
+IdP advertised by the server's RFC 9728 Protected Resource Metadata. With a
+browser and a bindable loopback listener it runs the OAuth authorization-code
+flow with PKCE (RFC 7636); on a headless host, or when `--device` is given, it
+falls back to the RFC 8628 device-code flow. The resulting session is stored in
+`credentials.json` (mode `0600`) keyed by issuer. See the
+[CLI Login Guide](cli_login.md) for the full walk-through.
+
+> ```
+> Arguments:
+> <alias>   The alias of the server to log in to.
+> Flags:
+>       --issuer=STRING        Override the OAuth issuer (when multiple are advertised).
+>       --client-id=STRING     Override the advertised public OAuth client_id.
+>       --scopes=STRING        Space-separated OAuth scopes to request (default: openid email profile).
+>       --device               Force the OAuth device-code flow (headless).
+> ```
+
+```shell
+goSignals> login gs1
+goSignals> login gs1 --issuer https://keycloak:9080/realms/gosignals
+goSignals> login gs1 --device
+```
+
+## whoami
+
+`whoami [<alias>]` shows session state. With an alias it prints the active realm
+session for that server. With no alias it lists every stored realm session
+(gcloud `auth list`-style), including which configured server aliases trust each
+realm.
+
+```shell
+goSignals> whoami            # list all realm sessions
+goSignals> whoami gs1        # active session for gs1
+```
+
+## logout
+
+`logout` clears stored realm session(s). Exactly one targeting mode applies, in
+precedence order `--all` &gt; `--issuer` &gt; `<alias>`. An empty `logout` with no
+target is an error. A realm logout makes a best-effort RFC 7009 refresh-token
+revocation, deletes the local session, and clears the `ActiveIssuer` pointer on
+every server that referenced that realm.
+
+> ```
+> Arguments:
+> <alias>   (optional) The alias of the server whose active issuer to log out.
+> Flags:
+>       --issuer=STRING        Log out a specific realm (issuer URL), affecting every server using it.
+>       --all                  Log out of every realm session.
+> ```
+
+```shell
+goSignals> logout gs1
+goSignals> logout --issuer https://keycloak:9080/realms/gosignals
+goSignals> logout --all
+```
+
+## use server
+
+`use server <alias> --issuer <url>` sets the active issuer (realm) for a server
+so subsequent management calls authorize against that realm's session. A
+non-advertised issuer is accepted with a warning.
+
+> ```
+> Arguments:
+> <alias>   The alias of the server to set the active issuer for.
+> Flags:
+>       --issuer=STRING        (required) The realm issuer URL to make active for this server.
+> ```
+
+```shell
+goSignals> use server gs1 --issuer https://keycloak:9080/realms/gosignals
+```
 
 ## Show Server
 

--- a/docs/security_model.md
+++ b/docs/security_model.md
@@ -9,38 +9,119 @@ The client may be given an Initial Access Token (IAT) which permits registration
 a permanent token used to retrieve events and manage its stream. Of particular note, the SSF endpoints
 use a common endpoint with no direct stream identifier; instead, the stream identifier is typically encoded in the access token.
 
-## GoSignals Command Line 
-At present, GoSignals only has a command line utility.  It accepts IATs, but if not, it will try to get an IAT.  From
-the goSignalsServer perspective, each IAT starts a new project under which one or more streams can be created. 
+## Management plane vs data plane
+
+goSignals authorization splits into two planes:
+
+- **Management plane** — administering a server: defining streams, creating
+  issuer keys, minting IATs, registering clients. Authorized by either a
+  delegated-OAuth user session (interactive humans) or the shared bootstrap
+  secret / configured admin token (automation).
+- **Data plane** — moving events: a transmitter pushing SETs, a receiver polling
+  for them. Authorized by per-stream/per-client tokens carrying the
+  `stream`/`event` scopes, scoped to a project.
+
+The two are independent. Logging in (management plane) never grants event
+delivery, and a stream's delivery token cannot administer the server.
+
+## Authorization scopes
+
+The server recognises a small set of scopes (roles claim or OAuth `scope`
+claim; `root` matches everything):
+
+| Scope    | Constant            | Capability |
+| :------- | :------------------ | :--------- |
+| `event`  | `ScopeEventDelivery`| Deliver / receive events on a stream (data plane). |
+| `stream` | `ScopeStreamMgmt`   | Manage a stream's own configuration (data plane / self-service). |
+| `reg`    | `ScopeRegister`     | Register a client using an IAT. Capped at `stream`+`event` — a `reg` caller cannot self-grant `admin`. |
+| `key`    | `ScopeKey`          | **Create a new issuer signing key, and obtain a `reg`-only IAT.** Create-only: denied key takeover. No stream/event capability. |
+| `admin`  | `ScopeStreamAdmin`  | Full project administration (management plane). |
+| `root`   | `ScopeRoot`         | Superset; matches every scope check. |
+
+### The `key` scope and machine tiers
+
+`key` is a narrow capability sitting between `reg` and `admin`, intended for an
+unattended deployment that must bootstrap itself without a human:
+
+- A `key`-scoped caller may `POST /key/<issuer>` to mint a **new** issuer signing
+  key, but a key **takeover** (`force=replace`, `force=rotate`, or `?rotate`) is
+  rejected for a key-scope-only caller — preventing key substitution / event
+  forgery.
+- A `key`-scoped caller may `GET /iat` to obtain an IAT, but the minted IAT is
+  always **`reg`-only**: the `key`/admin capability does not propagate into it.
+
+This is the machine tier ladder: a bootstrap identity (`key`) seeds an issuer key
+and a `reg` IAT; the `reg` IAT registers a client that caps at `stream`+`event`;
+`admin` clients are provisioned out of band, not through the registration door.
+
+### The bootstrap secret
+
+`I2SIG_BOOTSTRAP_TOKEN` is a shared secret. On the server, a bearer that
+**constant-time-equals** the configured value is synthesized into a `key`-scope
+context before any JWT validation runs. When the variable is **unset**, the
+bootstrap path is closed and no bootstrap bearer is ever accepted (fail closed).
+The bootstrap secret is an app-layer authorization mechanism: it is orthogonal to
+transport-layer identity (TLS / SPIFFE mTLS) and coexists with it.
+
+> [!IMPORTANT]
+> **The anonymous `/iat` endpoint is removed.** `GET /iat` now requires a
+> `{key, admin, root}` bearer; a missing/invalid bearer is rejected. With
+> `I2SIG_BOOTSTRAP_TOKEN` unset there is no door at all — the endpoint fails
+> closed. `POST /key` likewise requires `{key, admin, root}`.
+
+The advertised public client for the interactive CLI login is named by
+`I2SIG_CLI_CLIENT_ID` (default `gosignals-cli`) in the server's RFC 9728
+Protected Resource Metadata, which also advertises the supported scopes
+(including `key`).
+
+## GoSignals Command Line
+
+The `goSignals` CLI authorizes management calls one of two ways, detailed in the
+[CLI Login Guide](cli_login.md):
+
+1. **Delegated OAuth login** — `add server <alias>` connects to a server
+   (connect-only, no credential minted) and caches its advertised OAuth
+   authorization servers; `login <alias>` then runs a browser PKCE (or
+   device-code) flow and stores a per-realm session in `credentials.json`.
+   Subsequent management calls present that session's access token, silently
+   refreshing it as needed.
+2. **Non-interactive bootstrap** — for CI/automation, `I2SIG_BOOTSTRAP_TOKEN`
+   (or a configured `--token`/`--client-secret`/`--iat`) authorizes
+   `create key` / `create iat` directly.
 
 ```shell
-goSignals> add server go1 http://localhost:8888
+goSignals> add server gs1 https://goSignals1:8888
+goSignals> login gs1
 ```
-
-To start the process the gosignals command `add server` command is used with the optional parameter --iat which is used to specify a
-previously issued access token.  The command line utility will register the client with the goSignals server and in return
-will receive an administrative access token.  The command line utility will store the server and token information in 
-its local configuration file. If an alias is specified, that alias can be used to refer to the server in the future.  If
-an alias is not specified, an alias is automatically generated.
 
 ## Docker Compose Set Up
 
-In the demo scenario, there are 2 SCIM servers configured to run as replicas with synchronization being carried out via
-goSignals. In the scenario, both SCIM servers in the cluster use goSignals1:8888 as the common events server. 
-This is so that when one server issues an event, the replica SCIM server can receive it and synchronize.
+In the demo scenario, there are 2 SCIM servers configured to run as replicas with
+synchronization carried out via goSignals. Both SCIM servers in the cluster use
+goSignals1:8888 as the common events server, so an event issued by one is
+received by the replica for synchronization.
 
-In order for the SCIM servers to auto-register, they need an IAT token.  To do this, the service `scimSsfSetup` runs the
-goSignals command line utility and does the following goSignals commands:
+The SCIM servers need an issuer key and an IAT to auto-register. The
+`scimSsfSetup` service runs the goSignals CLI **unattended** using the bootstrap
+secret (`I2SIG_BOOTSTRAP_TOKEN`, injected by compose). The `key`-scope secret
+authorizes `create key` + `create iat` without any anonymous endpoint
+(`config/scim/scripts/auto-reg.gosignals`):
+
 ```shell
-add server gosignals1 http://goSignals1:8888
-add server gosignals2 http://goSignals2:8889
-create iat gosignals1 --output=/scim/iat1.txt
-create iat gosignals2 --output=/scim/iat2.txt
+add server gosignals1 https://goSignals1:8888
+add server gosignals2 https://goSignals2:8889
+create iat gosignals1 --output=/scim/iat-gosignals1.jwt
+create bundle --output=/scim/spire-bundle.pem
+create key gosignals1 cluster.scim.example.com --file=/scim/cluster-scim-issuer.pem
 exit
 ```
 
-When complete, the shell script takes iat1.txt and creates the file registration-iat.env which is picked up by services
-`scim_cluster1` and `scim_cluster2`.  When these services start they will auto-register with goSignals1.
+When complete, the setup script distributes the minted issuer key and IAT to the
+`scim_cluster1` / `scim_cluster2` data directories; on startup those services
+auto-register with goSignals1. The six compose variants (base / dev / cluster /
+cluster-dev / spiffe / spiffe-dev) all wire the bootstrap secret the same way;
+see the [CLI Login Guide](cli_login.md#3-docker-compose-variant-matrix) for the
+full matrix.
 
 ## Limitations
 

--- a/internal/authUtil/auth_token.go
+++ b/internal/authUtil/auth_token.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	mathRand "math/rand"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -175,11 +176,35 @@ func (a *AuthIssuer) loadOAuthJWKS() error {
 
 // IssueProjectIat issues a new registration token. If authCtx is nil, a new project is generated. If an authCtx is asserted,
 // then a new iat is issued for the identified project (AuthContext.ProjectId).
+// defaultIatLifetime is the fallback IAT validity when I2SIG_IAT_LIFETIME is
+// unset. IATs are short-lived bootstrap credentials, so the default is 24h
+// (previously a hard-coded 90 days).
+const defaultIatLifetime = 24 * time.Hour
+
+// iatLifetime resolves the IAT validity duration from I2SIG_IAT_LIFETIME
+// (a Go duration string such as "24h" or "30m"). An unset or unparseable value
+// falls back to defaultIatLifetime.
+func iatLifetime() time.Duration {
+	v := os.Getenv("I2SIG_IAT_LIFETIME")
+	if v == "" {
+		return defaultIatLifetime
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil || d <= 0 {
+		authLog.Warn("Invalid I2SIG_IAT_LIFETIME; using default", "value", v, "default", defaultIatLifetime)
+		return defaultIatLifetime
+	}
+	return d
+}
+
 func (a *AuthIssuer) IssueProjectIat(authCtx *AuthContext) (string, error) {
-	exp := time.Now().AddDate(0, 0, 90)
+	exp := time.Now().Add(iatLifetime())
 
 	projectId := generateAlias(4)
-	if authCtx != nil {
+	if authCtx != nil && authCtx.ProjectId != "" {
+		// Reuse the caller's project (e.g. an admin minting another IAT in the
+		// same project). A bootstrap (key-scope) caller carries no ProjectId, so
+		// a fresh project is generated above.
 		projectId = authCtx.ProjectId
 	}
 
@@ -360,6 +385,17 @@ func (a *AuthIssuer) ValidateAuthorizationAny(r *http.Request, scopes []string) 
 		return nil, http.StatusUnauthorized
 	}
 	tokenString := parts[1]
+
+	// Bootstrap-secret resolver: before any JWT/kid classification, a bearer that
+	// constant-time-equals I2SIG_BOOTSTRAP_TOKEN is synthesized into a key-scope
+	// AuthContext. When the secret is unset, no bootstrap bearer is ever accepted
+	// (the anonymous /iat door is gone — fail closed).
+	if bootCtx := a.resolveBootstrapBearer(tokenString); bootCtx != nil {
+		if bootCtx.Eat.IsAuthorized(streamRequested, scopes) {
+			return bootCtx, http.StatusOK
+		}
+		return nil, http.StatusForbidden
+	}
 
 	route := a.classifyToken(tokenString)
 	authLog.Debug("Authorization routing", "streamId", streamRequested, "route", route.name, "tokenKid", route.tokenKid, "localKids", route.localKids, "oauthConfigured", route.oauthConfigured)

--- a/internal/authUtil/bootstrap_resolver.go
+++ b/internal/authUtil/bootstrap_resolver.go
@@ -1,0 +1,40 @@
+package authUtil
+
+import (
+	"crypto/subtle"
+	"os"
+
+	"github.com/i2-open/i2goSignals/pkg/authSupport"
+)
+
+// bootstrapTokenEnv is the environment variable holding the shared bootstrap
+// secret. When set, a bearer equal to its value is granted the narrow "key"
+// scope so an unattended deployment can mint an issuer signing key and an IAT
+// without an anonymous endpoint. When unset, the bootstrap path is closed and
+// no bearer is ever accepted through it.
+const bootstrapTokenEnv = "I2SIG_BOOTSTRAP_TOKEN"
+
+// resolveBootstrapBearer returns a key-scope AuthContext when the presented
+// bearer constant-time-equals the configured bootstrap secret. It returns nil
+// when the secret is unset (fail closed) or the bearer does not match, in which
+// case the caller continues with normal JWT/kid classification.
+//
+// The comparison is constant-time to avoid leaking the secret length/prefix
+// via timing. An unset (empty) secret short-circuits before any comparison so
+// an empty presented bearer can never "match" an empty configured secret.
+func (a *AuthIssuer) resolveBootstrapBearer(tokenString string) *AuthContext {
+	secret := os.Getenv(bootstrapTokenEnv)
+	if secret == "" {
+		return nil
+	}
+	if subtle.ConstantTimeCompare([]byte(tokenString), []byte(secret)) != 1 {
+		return nil
+	}
+
+	authLog.Debug("Bootstrap bearer accepted; synthesizing key-scope context")
+	return &AuthContext{
+		Eat: &authSupport.EventAuthToken{
+			Roles: []string{authSupport.ScopeKey},
+		},
+	}
+}

--- a/internal/authUtil/bootstrap_resolver_test.go
+++ b/internal/authUtil/bootstrap_resolver_test.go
@@ -1,0 +1,74 @@
+package authUtil
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/i2-open/i2goSignals/pkg/authSupport"
+)
+
+// newBearerRequest builds a GET request carrying the supplied bearer token.
+func newBearerRequest(token string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/iat", nil)
+	if token != "" {
+		r.Header.Set("Authorization", "Bearer "+token)
+	}
+	return r
+}
+
+// TestBootstrapResolver_AcceptsMatchingSecret verifies that when
+// I2SIG_BOOTSTRAP_TOKEN is set, a bearer equal to it resolves to a
+// key-scope AuthContext.
+func TestBootstrapResolver_AcceptsMatchingSecret(t *testing.T) {
+	t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "s3cret-bootstrap")
+
+	ctx, status := auth.ValidateAuthorizationAny(newBearerRequest("s3cret-bootstrap"), []string{authSupport.ScopeKey})
+	if status != http.StatusOK {
+		t.Fatalf("expected 200 for matching bootstrap secret, got %d", status)
+	}
+	if ctx == nil || ctx.Eat == nil {
+		t.Fatalf("expected non-nil AuthContext with Eat")
+	}
+	if !ctx.Eat.IsScopeMatch([]string{authSupport.ScopeKey}) {
+		t.Errorf("bootstrap AuthContext must carry the key scope; roles=%v", ctx.Eat.Roles)
+	}
+	// The bootstrap identity must NOT carry broader capabilities.
+	if ctx.Eat.IsScopeMatch([]string{authSupport.ScopeStreamAdmin}) ||
+		ctx.Eat.IsScopeMatch([]string{authSupport.ScopeRoot}) {
+		t.Errorf("bootstrap AuthContext must not carry admin/root; roles=%v", ctx.Eat.Roles)
+	}
+}
+
+// TestBootstrapResolver_RejectsWrongSecret verifies a non-matching bearer is
+// not granted key scope via the bootstrap path.
+func TestBootstrapResolver_RejectsWrongSecret(t *testing.T) {
+	t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "s3cret-bootstrap")
+
+	ctx, status := auth.ValidateAuthorizationAny(newBearerRequest("not-the-secret"), []string{authSupport.ScopeKey})
+	if status == http.StatusOK && ctx != nil && ctx.Eat != nil && ctx.Eat.IsScopeMatch([]string{authSupport.ScopeKey}) {
+		t.Fatalf("wrong bootstrap secret must not resolve to a key-scope context")
+	}
+}
+
+// TestBootstrapResolver_UnsetFailsClosed verifies that when
+// I2SIG_BOOTSTRAP_TOKEN is unset, no bearer is ever accepted via the
+// bootstrap path (the anonymous door is gone).
+func TestBootstrapResolver_UnsetFailsClosed(t *testing.T) {
+	t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "")
+
+	// An empty presented bearer must never match an unset secret.
+	ctx, status := auth.ValidateAuthorizationAny(newBearerRequest(""), []string{authSupport.ScopeKey})
+	if status == http.StatusOK {
+		t.Fatalf("with bootstrap unset, an empty bearer must not be authorized; got 200")
+	}
+	if ctx != nil && ctx.Eat != nil && ctx.Eat.IsScopeMatch([]string{authSupport.ScopeKey}) {
+		t.Fatalf("with bootstrap unset, no key-scope context may be synthesized")
+	}
+
+	// A caller presenting the empty string as its bearer must likewise not match.
+	ctx2, status2 := auth.ValidateAuthorizationAny(newBearerRequest("anything"), []string{authSupport.ScopeKey})
+	if status2 == http.StatusOK && ctx2 != nil && ctx2.Eat != nil && ctx2.Eat.IsScopeMatch([]string{authSupport.ScopeKey}) {
+		t.Fatalf("with bootstrap unset, arbitrary bearer must not resolve to key scope")
+	}
+}

--- a/internal/authUtil/iat_lifetime_test.go
+++ b/internal/authUtil/iat_lifetime_test.go
@@ -1,0 +1,43 @@
+package authUtil
+
+import (
+	"testing"
+	"time"
+)
+
+// TestIatLifetimeDefault verifies that without I2SIG_IAT_LIFETIME the minted IAT
+// expires in ~24h (not the old hard-coded 90 days).
+func TestIatLifetimeDefault(t *testing.T) {
+	t.Setenv("I2SIG_IAT_LIFETIME", "")
+
+	token, err := auth.IssueProjectIat(nil)
+	if err != nil {
+		t.Fatalf("IssueProjectIat failed: %v", err)
+	}
+	eat, err := auth.ParseAuthToken(token)
+	if err != nil {
+		t.Fatalf("ParseAuthToken failed: %v", err)
+	}
+	ttl := time.Until(eat.ExpiresAt.Time)
+	if ttl < 23*time.Hour || ttl > 25*time.Hour {
+		t.Fatalf("expected default IAT lifetime ~24h, got %s", ttl)
+	}
+}
+
+// TestIatLifetimeConfigured verifies I2SIG_IAT_LIFETIME overrides the default.
+func TestIatLifetimeConfigured(t *testing.T) {
+	t.Setenv("I2SIG_IAT_LIFETIME", "1h")
+
+	token, err := auth.IssueProjectIat(nil)
+	if err != nil {
+		t.Fatalf("IssueProjectIat failed: %v", err)
+	}
+	eat, err := auth.ParseAuthToken(token)
+	if err != nil {
+		t.Fatalf("ParseAuthToken failed: %v", err)
+	}
+	ttl := time.Until(eat.ExpiresAt.Time)
+	if ttl < 50*time.Minute || ttl > 70*time.Minute {
+		t.Fatalf("expected configured IAT lifetime ~1h, got %s", ttl)
+	}
+}

--- a/internal/server/api_out_of_band.go
+++ b/internal/server/api_out_of_band.go
@@ -102,9 +102,19 @@ func (sa *SignalsApplication) CreateKey(w http.ResponseWriter, r *http.Request) 
 }
 
 func CreateKeyHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *http.Request) {
-	authCtx, stat := sa.GetAuth().ValidateAuthorizationAny(r, []string{authSupport.ScopeStreamAdmin, authSupport.ScopeRoot})
+	// Key creation accepts the narrow "key" scope in addition to stream_admin/root.
+	// The "key" scope is CREATE-ONLY: a key-scoped caller may mint a NEW issuer
+	// signing key but is denied takeover operations (force=replace/rotate). That
+	// guard is enforced below once the requested operation is known.
+	authCtx, stat := sa.GetAuth().ValidateAuthorizationAny(r, []string{authSupport.ScopeKey, authSupport.ScopeStreamAdmin, authSupport.ScopeRoot})
 	if stat != http.StatusOK || authCtx == nil {
 		http.Error(w, "Invalid permission", http.StatusForbidden)
+		return
+	}
+
+	// A key-scope-only caller (no admin/root) may not perform a takeover.
+	if keyScopeOnly(authCtx) && requestIsKeyTakeover(r) {
+		http.Error(w, "key scope is create-only; force=replace/rotate is not permitted", http.StatusForbidden)
 		return
 	}
 
@@ -120,6 +130,35 @@ func CreateKeyHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *http
 	} else {
 		createKeyByNameHandler(sa, w, r, authCtx)
 	}
+}
+
+// keyScopeOnly reports whether the AuthContext carries the narrow "key" scope
+// but NOT a broader stream_admin/root capability. Such a caller is a bootstrap
+// identity and is restricted to create-only key operations.
+func keyScopeOnly(authCtx *authUtil.AuthContext) bool {
+	if authCtx == nil || authCtx.Eat == nil {
+		return false
+	}
+	if authCtx.Eat.IsScopeMatch([]string{authSupport.ScopeStreamAdmin}) ||
+		authCtx.Eat.IsScopeMatch([]string{authSupport.ScopeRoot}) {
+		return false
+	}
+	return authCtx.Eat.IsScopeMatch([]string{authSupport.ScopeKey})
+}
+
+// requestIsKeyTakeover reports whether the key request asks to replace or rotate
+// an existing key (force=replace / force=rotate / ?rotate). These are denied for
+// key-scope-only callers to prevent key takeover and event forgery.
+func requestIsKeyTakeover(r *http.Request) bool {
+	q := r.URL.Query()
+	force := q.Get("force")
+	if force == "replace" || force == "rotate" {
+		return true
+	}
+	if _, rotate := q["rotate"]; rotate {
+		return true
+	}
+	return false
 }
 
 func createKeyByNameHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *http.Request, authCtx *authUtil.AuthContext) {
@@ -526,7 +565,15 @@ func (sa *SignalsApplication) IssuerProjectIat(w http.ResponseWriter, r *http.Re
 
 func IssuerProjectIatHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *http.Request) {
 	serverLog.Debug("IssuerProjectIatHandler called", "remoteAddr", r.RemoteAddr)
-	authCtx, _ := sa.GetAuth().ValidateAuthorizationAny(r, []string{authSupport.ScopeStreamAdmin})
+	// Honor the validation status. /iat accepts {key, stream_admin, root}. A
+	// missing/invalid bearer (including the now-removed anonymous path) is
+	// rejected, so an unset bootstrap secret fails closed. The minted IAT is
+	// always reg-only — the key/admin capability does not propagate.
+	authCtx, stat := sa.GetAuth().ValidateAuthorizationAny(r, []string{authSupport.ScopeKey, authSupport.ScopeStreamAdmin, authSupport.ScopeRoot})
+	if stat != http.StatusOK || authCtx == nil {
+		http.Error(w, "Invalid bootstrap or administrative token", stat)
+		return
+	}
 	projectIat, err := sa.GetAuth().IssueProjectIat(authCtx)
 	if err != nil {
 		serverLog.Error("Error generating IAT", "error", err.Error())
@@ -571,15 +618,20 @@ func RegisterClientHandler(sa SsfApplicationInterface, w http.ResponseWriter, r 
 		return
 	}
 
+	// Privilege ceiling: a reg (IAT) caller may not self-grant stream_admin at
+	// /register. A self-registration caps at stream_mgmt + event_delivery; an
+	// admin client is provisioned out of band, not via the registration door.
 	var scopes []string
 	if len(jsonRequest.Scopes) == 0 {
 		scopes = append(scopes, authSupport.ScopeStreamMgmt, authSupport.ScopeEventDelivery)
 	} else {
 		for _, v := range jsonRequest.Scopes {
 			switch v {
-			case authSupport.ScopeStreamMgmt, authSupport.ScopeStreamAdmin, authSupport.ScopeEventDelivery:
+			case authSupport.ScopeStreamMgmt, authSupport.ScopeEventDelivery:
 				scopes = append(scopes, v)
 			default:
+				// stream_admin and any unknown scope are silently dropped — a reg
+				// token cannot escalate its own privilege.
 			}
 		}
 	}

--- a/internal/server/api_out_of_band.go
+++ b/internal/server/api_out_of_band.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"slices"
 	"strings"
 
@@ -731,18 +732,40 @@ func ProtectedResourceMetadataHandler(sa SsfApplicationInterface, w http.Respons
 	if baseUrl != nil {
 		baseURl = baseUrl.String()
 	}
-	name := "GoSignals"
-	prMeta := model.ProtectedResourceMetadata{
-		Resource:               &baseURl,
-		AuthorizationServers:   sa.GetAuth().GetOAuthServers(),
-		ScopesSupported:        []string{authSupport.ScopeEventDelivery, authSupport.ScopeStreamMgmt, authSupport.ScopeStreamAdmin, authSupport.ScopeEventDelivery, authSupport.ScopeRegister},
-		BearerMethodsSupported: []string{"header"},
-		ResourceName:           &name,
-	}
+	prMeta := buildProtectedResourceMetadata(baseURl, sa.GetAuth().GetOAuthServers(), cliClientId())
 
 	resp, _ := json.MarshalIndent(prMeta, "", "  ")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(resp)
+}
+
+// cliClientId resolves the recommended public OAuth client_id advertised to
+// interactive clients (the goSignals CLI). Sourced from I2SIG_CLI_CLIENT_ID,
+// defaulting to "gosignals-cli".
+func cliClientId() string {
+	if v := os.Getenv("I2SIG_CLI_CLIENT_ID"); v != "" {
+		return v
+	}
+	return "gosignals-cli"
+}
+
+// buildProtectedResourceMetadata assembles RFC9728 metadata. It advertises the
+// configured authorization_servers, the recommended public CLI client_id, and
+// the scopes supported by the server (including the narrow "key" scope).
+func buildProtectedResourceMetadata(baseUrl string, authServers []string, cliClient string) model.ProtectedResourceMetadata {
+	name := "GoSignals"
+	res := baseUrl
+	meta := model.ProtectedResourceMetadata{
+		Resource:               &res,
+		AuthorizationServers:   authServers,
+		ScopesSupported:        []string{authSupport.ScopeEventDelivery, authSupport.ScopeStreamMgmt, authSupport.ScopeStreamAdmin, authSupport.ScopeRegister, authSupport.ScopeKey},
+		BearerMethodsSupported: []string{"header"},
+		ResourceName:           &name,
+	}
+	if cliClient != "" {
+		meta.ClientID = &cliClient
+	}
+	return meta
 }
 
 // ListStreamStates lists all stream states associated with the current project.

--- a/internal/server/api_stream_management.go
+++ b/internal/server/api_stream_management.go
@@ -434,7 +434,13 @@ func (sa *SignalsApplication) StreamCreate(w http.ResponseWriter, r *http.Reques
 }
 
 func StreamCreateHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *http.Request) {
-	authCtx, status := sa.GetAuth().ValidateAuthorizationAny(r, []string{authSupport.ScopeRegister, authSupport.ScopeStreamAdmin})
+	// Creating a stream is a stream-management operation: a self-registered
+	// receiver (capped at stream_mgmt by the /register privilege ceiling, never
+	// stream_admin) must be able to create its own stream. This mirrors the
+	// sibling stream operations (get/update/delete) which already accept
+	// stream_mgmt; stream_admin remains required only for elevated key/stream
+	// lifecycle actions. reg is retained for the legacy direct-IAT path.
+	authCtx, status := sa.GetAuth().ValidateAuthorizationAny(r, []string{authSupport.ScopeRegister, authSupport.ScopeStreamMgmt, authSupport.ScopeStreamAdmin})
 	if status != http.StatusOK {
 		w.WriteHeader(status)
 		return

--- a/internal/server/protected_resource_metadata_test.go
+++ b/internal/server/protected_resource_metadata_test.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+    "testing"
+
+    "github.com/i2-open/i2goSignals/pkg/authSupport"
+)
+
+// TestBuildProtectedResourceMetadata_AdvertisesCliClientIdAndKeyScope verifies
+// that the Protected Resource Metadata advertises the recommended public CLI
+// client_id and that the "key" scope is among scopes_supported (slice #122).
+func TestBuildProtectedResourceMetadata_AdvertisesCliClientIdAndKeyScope(t *testing.T) {
+    meta := buildProtectedResourceMetadata("https://gosignals.example.com", []string{"https://idp.example.com"}, "my-cli")
+
+    if meta.ClientID == nil || *meta.ClientID != "my-cli" {
+        t.Fatalf("expected client_id 'my-cli', got %v", meta.ClientID)
+    }
+
+    foundKey := false
+    for _, s := range meta.ScopesSupported {
+        if s == authSupport.ScopeKey {
+            foundKey = true
+        }
+    }
+    if !foundKey {
+        t.Errorf("expected scopes_supported to include %q, got %v", authSupport.ScopeKey, meta.ScopesSupported)
+    }
+
+    if meta.Resource == nil || *meta.Resource != "https://gosignals.example.com" {
+        t.Errorf("expected resource to be set to base url, got %v", meta.Resource)
+    }
+    if len(meta.AuthorizationServers) != 1 || meta.AuthorizationServers[0] != "https://idp.example.com" {
+        t.Errorf("expected authorization_servers to carry the configured AS, got %v", meta.AuthorizationServers)
+    }
+}
+
+// TestCliClientId_DefaultsToGosignalsCli verifies the I2SIG_CLI_CLIENT_ID
+// default value.
+func TestCliClientId_DefaultsToGosignalsCli(t *testing.T) {
+    t.Setenv("I2SIG_CLI_CLIENT_ID", "")
+    if got := cliClientId(); got != "gosignals-cli" {
+        t.Errorf("expected default client id 'gosignals-cli', got %q", got)
+    }
+    t.Setenv("I2SIG_CLI_CLIENT_ID", "custom")
+    if got := cliClientId(); got != "custom" {
+        t.Errorf("expected override 'custom', got %q", got)
+    }
+}

--- a/internal/server/test/bootstrap_iat_test.go
+++ b/internal/server/test/bootstrap_iat_test.go
@@ -1,0 +1,83 @@
+package test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/i2-open/i2goSignals/pkg/authSupport"
+	model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// getIat issues a GET /iat with the supplied bearer (empty => anonymous) and
+// returns the HTTP status and the minted token (if any).
+func getIat(t *testing.T, instance *ssfInstance, bearer string) (int, string) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, instance.ts.URL+"/iat", nil)
+	require.NoError(t, err)
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	resp, err := instance.client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return resp.StatusCode, ""
+	}
+	var reg model.RegisterResponse
+	_ = json.NewDecoder(resp.Body).Decode(&reg)
+	return resp.StatusCode, reg.Token
+}
+
+// TestIatFailsClosedWhenBootstrapUnset verifies the anonymous /iat door is gone:
+// with I2SIG_BOOTSTRAP_TOKEN unset, an unauthenticated caller is rejected.
+func TestIatFailsClosedWhenBootstrapUnset(t *testing.T) {
+	t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "")
+	instance, err := createServer(t, "iat_failclosed_test", true)
+	require.NoError(t, err)
+	defer instance.app.Shutdown()
+
+	status, _ := getIat(t, instance, "")
+	assert.NotEqual(t, http.StatusOK, status, "anonymous /iat must not succeed when bootstrap is unset")
+	assert.Contains(t, []int{http.StatusUnauthorized, http.StatusNotFound, http.StatusForbidden}, status)
+}
+
+// TestIatAcceptsBootstrapSecretAndMintsRegOnly verifies a key-scope bootstrap
+// caller can obtain an IAT, and that the minted IAT carries reg only — the key
+// capability does not propagate.
+func TestIatAcceptsBootstrapSecretAndMintsRegOnly(t *testing.T) {
+	t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "boot-secret-iat")
+	instance, err := createServer(t, "iat_bootstrap_test", true)
+	require.NoError(t, err)
+	defer instance.app.Shutdown()
+
+	status, token := getIat(t, instance, "boot-secret-iat")
+	require.Equal(t, http.StatusOK, status, "bootstrap secret should mint an IAT")
+	require.NotEmpty(t, token)
+
+	eat, err := instance.GetAuthIssuer().ParseAuthToken(token)
+	require.NoError(t, err)
+	assert.Contains(t, eat.Roles, authSupport.ScopeRegister, "minted IAT must carry reg")
+	assert.NotContains(t, eat.Roles, authSupport.ScopeKey, "key capability must NOT propagate into the IAT")
+	assert.NotContains(t, eat.Roles, authSupport.ScopeStreamAdmin)
+	assert.NotContains(t, eat.Roles, authSupport.ScopeRoot)
+}
+
+// TestIatAcceptsAdminToken verifies an existing stream_admin token can still
+// obtain an IAT (the /iat endpoint accepts {key, stream_admin, root}).
+func TestIatAcceptsAdminToken(t *testing.T) {
+	t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "")
+	instance, err := createServer(t, "iat_admin_test", true)
+	require.NoError(t, err)
+	defer instance.app.Shutdown()
+
+	status, token := getIat(t, instance, instance.streamMgmtToken)
+	require.Equal(t, http.StatusOK, status, "stream_admin token should obtain an IAT")
+	require.NotEmpty(t, token)
+
+	eat, err := instance.GetAuthIssuer().ParseAuthToken(token)
+	require.NoError(t, err)
+	assert.Contains(t, eat.Roles, authSupport.ScopeRegister)
+}

--- a/internal/server/test/bootstrap_key_test.go
+++ b/internal/server/test/bootstrap_key_test.go
@@ -1,0 +1,122 @@
+package test
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// postKey issues POST /key/{keyName} (optionally with a force query) carrying
+// the supplied bearer, and returns the HTTP status.
+func postKey(t *testing.T, instance *ssfInstance, bearer, keyName, force string, body []byte) int {
+	t.Helper()
+	u := instance.ts.URL + "/key/" + keyName
+	if force != "" {
+		u += "?force=" + force
+	}
+	req, err := http.NewRequest(http.MethodPost, u, bytes.NewReader(body))
+	require.NoError(t, err)
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	resp, err := instance.client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// deleteKey issues DELETE /key/{keyName} with the supplied bearer.
+func deleteKey(t *testing.T, instance *ssfInstance, bearer, keyName string) int {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodDelete, instance.ts.URL+"/key/"+keyName, nil)
+	require.NoError(t, err)
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	resp, err := instance.client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// TestKeyScopeCanCreateNewKey verifies a key-scoped (bootstrap) caller may
+// create a brand-new issuer signing key.
+func TestKeyScopeCanCreateNewKey(t *testing.T) {
+	t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "boot-secret-key")
+	instance, err := createServer(t, "key_create_test", true)
+	require.NoError(t, err)
+	defer instance.app.Shutdown()
+
+	status := postKey(t, instance, "boot-secret-key", "newissuer.example.com", "", nil)
+	assert.Contains(t, []int{http.StatusOK, http.StatusCreated}, status,
+		"key-scope caller must be able to create a new issuer key")
+}
+
+// TestKeyScopeDeniedReplace verifies a key-scoped caller cannot take over an
+// existing key via force=replace.
+func TestKeyScopeDeniedReplace(t *testing.T) {
+	t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "boot-secret-key")
+	instance, err := createServer(t, "key_replace_test", true)
+	require.NoError(t, err)
+	defer instance.app.Shutdown()
+
+	// First create the key as the bootstrap caller (allowed).
+	create := postKey(t, instance, "boot-secret-key", "victim.example.com", "", nil)
+	require.Contains(t, []int{http.StatusOK, http.StatusCreated}, create)
+
+	// Attempting force=replace must be denied for a key-scope caller.
+	status := postKey(t, instance, "boot-secret-key", "victim.example.com", "replace", nil)
+	assert.Equal(t, http.StatusForbidden, status, "key scope must NOT permit force=replace (key takeover)")
+}
+
+// TestKeyScopeDeniedRotate verifies a key-scoped caller cannot rotate an
+// existing key.
+func TestKeyScopeDeniedRotate(t *testing.T) {
+	t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "boot-secret-key")
+	instance, err := createServer(t, "key_rotate_test", true)
+	require.NoError(t, err)
+	defer instance.app.Shutdown()
+
+	create := postKey(t, instance, "boot-secret-key", "rot.example.com", "", nil)
+	require.Contains(t, []int{http.StatusOK, http.StatusCreated}, create)
+
+	status := postKey(t, instance, "boot-secret-key", "rot.example.com", "rotate", nil)
+	assert.Equal(t, http.StatusForbidden, status, "key scope must NOT permit force=rotate")
+}
+
+// TestKeyScopeDeniedDelete verifies a key-scoped caller cannot delete a key.
+func TestKeyScopeDeniedDelete(t *testing.T) {
+	t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "boot-secret-key")
+	instance, err := createServer(t, "key_delete_test", true)
+	require.NoError(t, err)
+	defer instance.app.Shutdown()
+
+	create := postKey(t, instance, "boot-secret-key", "del.example.com", "", nil)
+	require.Contains(t, []int{http.StatusOK, http.StatusCreated}, create)
+
+	status := deleteKey(t, instance, "boot-secret-key", "del.example.com")
+	assert.Equal(t, http.StatusForbidden, status, "key scope must NOT permit delete")
+}
+
+// TestAdminCanReplaceAndDelete confirms a full stream_admin token retains the
+// ability to replace/rotate/delete (the key-scope restriction is additive, not
+// a regression for admins).
+func TestAdminCanReplaceAndDelete(t *testing.T) {
+	t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "")
+	instance, err := createServer(t, "key_admin_test", true)
+	require.NoError(t, err)
+	defer instance.app.Shutdown()
+	admin := instance.streamMgmtToken
+
+	create := postKey(t, instance, admin, "adminkey.example.com", "", nil)
+	require.Contains(t, []int{http.StatusOK, http.StatusCreated}, create)
+
+	replace := postKey(t, instance, admin, "adminkey.example.com", "replace", nil)
+	assert.Contains(t, []int{http.StatusOK, http.StatusCreated}, replace, "admin may replace")
+
+	del := deleteKey(t, instance, admin, "adminkey.example.com")
+	assert.Contains(t, []int{http.StatusOK, http.StatusNoContent}, del, "admin may delete")
+}

--- a/internal/server/test/register_ceiling_test.go
+++ b/internal/server/test/register_ceiling_test.go
@@ -1,0 +1,58 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/i2-open/i2goSignals/pkg/authSupport"
+	model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// registerClient posts /register with the supplied IAT and requested scopes,
+// returning the granted client's AllowedScopes.
+func registerClient(t *testing.T, instance *ssfInstance, iat string, scopes []string) (int, []string) {
+	t.Helper()
+	body, _ := json.Marshal(model.RegisterParameters{
+		Email:       "ceiling@example.com",
+		Description: "ceiling test",
+		Scopes:      scopes,
+	})
+	req, err := http.NewRequest(http.MethodPost, instance.ts.URL+"/register", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+iat)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := instance.client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return resp.StatusCode, nil
+	}
+	var reg model.RegisterResponse
+	_ = json.NewDecoder(resp.Body).Decode(&reg)
+	// The granted scopes are carried as roles in the issued client token.
+	eat, err := instance.GetAuthIssuer().ParseAuthToken(reg.Token)
+	require.NoError(t, err)
+	return resp.StatusCode, eat.Roles
+}
+
+// TestRegisterCannotSelfGrantStreamAdmin verifies a reg (IAT) caller at
+// /register cannot escalate itself to stream_admin. The privilege ceiling caps
+// a self-registration at stream_mgmt + event_delivery.
+func TestRegisterCannotSelfGrantStreamAdmin(t *testing.T) {
+	t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "")
+	instance, err := createServer(t, "register_ceiling_test", true)
+	require.NoError(t, err)
+	defer instance.app.Shutdown()
+
+	status, granted := registerClient(t, instance, instance.iatToken,
+		[]string{authSupport.ScopeStreamAdmin, authSupport.ScopeStreamMgmt, authSupport.ScopeEventDelivery})
+	require.Equal(t, http.StatusOK, status)
+	assert.NotContains(t, granted, authSupport.ScopeStreamAdmin,
+		"a reg token must not be able to self-grant stream_admin")
+	// The permitted stream-management capability is still granted.
+	assert.Contains(t, granted, authSupport.ScopeStreamMgmt)
+}

--- a/internal/server/test/register_ceiling_test.go
+++ b/internal/server/test/register_ceiling_test.go
@@ -16,6 +16,14 @@ import (
 // returning the granted client's AllowedScopes.
 func registerClient(t *testing.T, instance *ssfInstance, iat string, scopes []string) (int, []string) {
 	t.Helper()
+	status, _, roles := registerClientToken(t, instance, iat, scopes)
+	return status, roles
+}
+
+// registerClientToken posts /register and returns the HTTP status, the issued
+// client token, and the granted scopes (carried as roles in the token).
+func registerClientToken(t *testing.T, instance *ssfInstance, iat string, scopes []string) (int, string, []string) {
+	t.Helper()
 	body, _ := json.Marshal(model.RegisterParameters{
 		Email:       "ceiling@example.com",
 		Description: "ceiling test",
@@ -29,14 +37,14 @@ func registerClient(t *testing.T, instance *ssfInstance, iat string, scopes []st
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return resp.StatusCode, nil
+		return resp.StatusCode, "", nil
 	}
 	var reg model.RegisterResponse
 	_ = json.NewDecoder(resp.Body).Decode(&reg)
 	// The granted scopes are carried as roles in the issued client token.
 	eat, err := instance.GetAuthIssuer().ParseAuthToken(reg.Token)
 	require.NoError(t, err)
-	return resp.StatusCode, eat.Roles
+	return resp.StatusCode, reg.Token, eat.Roles
 }
 
 // TestRegisterCannotSelfGrantStreamAdmin verifies a reg (IAT) caller at
@@ -55,4 +63,48 @@ func TestRegisterCannotSelfGrantStreamAdmin(t *testing.T) {
 		"a reg token must not be able to self-grant stream_admin")
 	// The permitted stream-management capability is still granted.
 	assert.Contains(t, granted, authSupport.ScopeStreamMgmt)
+}
+
+// TestStreamMgmtClientCanCreateStream verifies the end-to-end SCIM-receiver
+// bootstrap: a client self-registered through /register is capped at
+// stream_mgmt + event_delivery (never stream_admin), and must still be able to
+// create its own stream. This guards against the regression where StreamCreate
+// demanded stream_admin and a non-admin receiver got 403 Forbidden.
+func TestStreamMgmtClientCanCreateStream(t *testing.T) {
+	t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "")
+	instance, err := createServer(t, "stream_mgmt_create_test", true)
+	require.NoError(t, err)
+	defer instance.app.Shutdown()
+
+	// Register exactly as a SCIM receiver does: request stream + event, get
+	// capped below stream_admin by the privilege ceiling.
+	status, clientToken, granted := registerClientToken(t, instance, instance.iatToken,
+		[]string{authSupport.ScopeStreamMgmt, authSupport.ScopeEventDelivery})
+	require.Equal(t, http.StatusOK, status)
+	require.NotEmpty(t, clientToken)
+	require.NotContains(t, granted, authSupport.ScopeStreamAdmin,
+		"a self-registered receiver must not hold stream_admin")
+	require.Contains(t, granted, authSupport.ScopeStreamMgmt)
+
+	// A stream-mgmt (non-admin) client must be able to create its own stream.
+	streamConfig := model.StreamConfiguration{
+		Iss:             "DEFAULT",
+		Aud:             []string{"https://receiver.example.com"},
+		EventsSupported: []string{"https://schemas.openid.net/secevent/ssf/event-type/verification"},
+		Delivery: &model.OneOfStreamConfigurationDelivery{
+			PollTransmitMethod: &model.PollTransmitMethod{
+				Method: model.DeliveryPoll,
+			},
+		},
+	}
+	body, _ := json.Marshal(streamConfig)
+	req, err := http.NewRequest(http.MethodPost, instance.ts.URL+"/stream", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+clientToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := instance.client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusCreated, resp.StatusCode,
+		"a stream_mgmt client must be allowed to create its own stream (not 403)")
 }

--- a/internal/services/client_service.go
+++ b/internal/services/client_service.go
@@ -2,8 +2,10 @@ package services
 
 import (
 	"context"
+	"slices"
 
 	"github.com/i2-open/i2goSignals/internal/dao/interfaces"
+	"github.com/i2-open/i2goSignals/pkg/authSupport"
 	"github.com/i2-open/i2goSignals/pkg/logger"
 	"github.com/i2-open/i2goSignals/pkg/ssfModels"
 )
@@ -29,9 +31,14 @@ func (s *ClientService) RegisterClient(ctx context.Context, client model.SsfClie
 		return nil
 	}
 
-	token, err := s.keyService.GetAuthIssuer().IssueStreamClientToken(client, projectID, true)
+	// Issue a token reflecting only the scopes the client was actually granted.
+	// A self-registered client is capped below stream_admin by the registration
+	// handler's privilege ceiling, so admin is granted only when the client's
+	// AllowedScopes explicitly carry stream_admin (out-of-band provisioning).
+	admin := slices.Contains(client.AllowedScopes, authSupport.ScopeStreamAdmin)
+	token, err := s.keyService.GetAuthIssuer().IssueStreamClientToken(client, projectID, admin)
 	if err != nil {
-		csLog.Error("Error issuing stream admin token", "error", err)
+		csLog.Error("Error issuing stream client token", "error", err)
 		return nil
 	}
 

--- a/pkg/authSupport/auth_token.go
+++ b/pkg/authSupport/auth_token.go
@@ -18,8 +18,12 @@ const (
 	ScopeEventDelivery = "event"
 	ScopeStreamAdmin   = "admin"
 	ScopeRegister      = "reg"
-	ScopeRoot          = "root"
-	StreamAny          = "any"
+	// ScopeKey is a narrow capability sitting between reg and admin. A key-scoped
+	// caller may create a NEW issuer signing key (bootstrap) but is denied key
+	// takeover (force=replace/rotate/delete) and any stream/event capability.
+	ScopeKey  = "key"
+	ScopeRoot = "root"
+	StreamAny = "any"
 )
 
 // EventAuthToken is a token used for stream management and event delivery.

--- a/pkg/authSupport/auth_token_test.go
+++ b/pkg/authSupport/auth_token_test.go
@@ -1,0 +1,40 @@
+package authSupport
+
+import "testing"
+
+// TestScopeKeyExists asserts the narrow "key" scope is part of the scope
+// vocabulary alongside reg/stream/admin/event/root. The "key" scope sits
+// between reg and admin: it permits creating a new issuer signing key but
+// must not grant stream administration or event delivery.
+func TestScopeKeyExists(t *testing.T) {
+    if ScopeKey != "key" {
+        t.Fatalf("expected ScopeKey to be \"key\", got %q", ScopeKey)
+    }
+
+    // The key scope must be distinct from every other scope in the vocabulary.
+    others := []string{ScopeStreamMgmt, ScopeEventDelivery, ScopeStreamAdmin, ScopeRegister, ScopeRoot}
+    for _, s := range others {
+        if s == ScopeKey {
+            t.Fatalf("ScopeKey collides with existing scope %q", s)
+        }
+    }
+}
+
+// TestKeyScopeIsAuthorizedForKey verifies a token carrying only the key scope
+// satisfies a key-scoped requirement but nothing broader.
+func TestKeyScopeIsAuthorizedForKey(t *testing.T) {
+    tkn := &EventAuthToken{Roles: []string{ScopeKey}}
+
+    if !tkn.IsScopeMatch([]string{ScopeKey}) {
+        t.Errorf("key token should match a key-scope requirement")
+    }
+    if tkn.IsScopeMatch([]string{ScopeStreamAdmin}) {
+        t.Errorf("key token must NOT match a stream_admin requirement")
+    }
+    if tkn.IsScopeMatch([]string{ScopeEventDelivery}) {
+        t.Errorf("key token must NOT match an event_delivery requirement")
+    }
+    if tkn.IsScopeMatch([]string{ScopeStreamMgmt}) {
+        t.Errorf("key token must NOT match a stream_mgmt requirement")
+    }
+}

--- a/pkg/ssfModels/model_transmitter_configuration.go
+++ b/pkg/ssfModels/model_transmitter_configuration.go
@@ -19,6 +19,10 @@ type ProtectedResourceMetadata struct {
 	ScopesSupported        []string `json:"scopes_supported,omitempty"`
 	BearerMethodsSupported []string `json:"bearer_methods_supported,omitempty"`
 	ResourceName           *string  `json:"resource_name,omitempty"`
+	// ClientID is a recommended public OAuth client_id that interactive
+	// clients (e.g. the goSignals CLI) may use to authenticate against the
+	// advertised authorization_servers. Sourced from I2SIG_CLI_CLIENT_ID.
+	ClientID *string `json:"client_id,omitempty"`
 }
 
 type AuthScheme struct {

--- a/pkg/wellKnownSupport/well_known.go
+++ b/pkg/wellKnownSupport/well_known.go
@@ -68,6 +68,7 @@ type OIDCConfiguration struct {
 	Issuer                 string   `json:"issuer"`
 	AuthorizationEndpoint  string   `json:"authorization_endpoint,omitempty"`
 	TokenEndpoint          string   `json:"token_endpoint,omitempty"`
+	RevocationEndpoint     string   `json:"revocation_endpoint,omitempty"`
 	DeviceAuthEndpoint     string   `json:"device_authorization_endpoint,omitempty"`
 	JWKSURI                string   `json:"jwks_uri,omitempty"`
 	RegistrationEndpoint   string   `json:"registration_endpoint,omitempty"`

--- a/pkg/wellKnownSupport/well_known.go
+++ b/pkg/wellKnownSupport/well_known.go
@@ -68,6 +68,7 @@ type OIDCConfiguration struct {
 	Issuer                 string   `json:"issuer"`
 	AuthorizationEndpoint  string   `json:"authorization_endpoint,omitempty"`
 	TokenEndpoint          string   `json:"token_endpoint,omitempty"`
+	DeviceAuthEndpoint     string   `json:"device_authorization_endpoint,omitempty"`
 	JWKSURI                string   `json:"jwks_uri,omitempty"`
 	RegistrationEndpoint   string   `json:"registration_endpoint,omitempty"`
 	ScopesSupported        []string `json:"scopes_supported,omitempty"`


### PR DESCRIPTION
## Summary

Implements **PRD #120** — a `docker login`-style interactive OAuth flow for the goSignals CLI that delegates to whatever IdP a server advertises (RFC 9728), while keeping goSignals a pure resource server. Replaces the **anonymous `GET /iat`** bootstrap with an authenticated, least-privilege model so a docker-compose cluster can self-provision without a human. Net security win: **the anonymous privilege-escalation door is removed.**

Closes #120. Implements slices #121–#126 and closes #121, #122, #123, #124, #125, and #126

## What changed (by slice)

- **#121 — Authenticated bootstrap (server).** New `key` scope between `reg` and `admin`. A bearer equal to `I2SIG_BOOTSTRAP_TOKEN` (constant-time compare) resolves to a `key`-scope context; unset ⇒ anonymous `/iat` is closed (fails closed). `/iat` now honors validation status, accepts `{key, stream_admin, root}`, and mints a **reg-only** IAT. `key` callers can create a new issuer key but are denied `force=replace`/`rotate`/delete. `/register` privilege ceiling: a `reg` token cannot self-grant `stream_admin`. IAT lifetime configurable via `I2SIG_IAT_LIFETIME` (default ~24h).
- **#122 — CLI single-realm login.** PRM discovery (`/.well-known/oauth-protected-resource`) → OIDC discovery → PKCE loopback (ephemeral `127.0.0.1` listener + browser). `add server` is connect-only (no credential minting). `whoami`. Sessions in `credentials.json` (`0600`); non-secret metadata in `config.json`. Silent token refresh; clear re-login on dead refresh.
- **#123 — Bootstrap-secret wiring across all compose variants.** Every variant passes `I2SIG_BOOTSTRAP_TOKEN` to the nodes + `scimSsfSetup` and sets `I2SIG_CLI_CLIENT_ID`; scripts present the secret on `create key`/`create iat`. No variant depends on anonymous `/iat`.
- **#124 — Device-code login fallback (RFC 8628).** `--device` forces it; auto-fallback when no browser/loopback. Same stored session shape as PKCE.
- **#125 — Multi-realm CLI sessions.** Per-issuer session map; `whoami` lists all + which servers trust each realm; `logout --issuer/--all/<alias>` with best-effort RFC 7009 revocation; per-server active-issuer pointer (`use server --issuer`).
- **#126 — Docs + ADRs.** `docs/cli_login.md`, `docs/gosignals_tool.md`, `docs/configuration_properties.md`, `docs/security_model.md`, `CONTEXT.md` glossary, README cross-links; ADR 0005 (delegated CLI auth via RFC 9728) and ADR 0006 (key scope + closing anonymous `/iat`).

## Follow-up fixes in this branch

- **StreamCreate authorization (#121 regression).** The privilege ceiling caps a self-registered receiver at `stream` (never `admin`), but `StreamCreateHandler` still required `{reg, admin}` → SCIM receivers got `403` on `POST /stream`. Now accepts `{reg, stream, admin}`; added `TestStreamMgmtClientCanCreateStream`.
- **CLI `delete server <alias>`.** Remove local server definitions pointing at stale URLs.

## QA / verification

- `go test -race ./...` — **green** (full repo, 0 failures).
- `go vet ./...` / `gofmt` — clean.
- **Clean-room e2e:** `make dev-clean` → `make dev-up`. Fresh bootstrap with anonymous `/iat` closed: `scimSsfSetup` completes and **both SCIM receiver nodes register, create push streams, and poll with zero 403s**.
- Acceptance-criteria audit across all six slices: **39/40 PASS**, 1 PARTIAL (#126 getting-started guide — content verified accurate against the code, but not executed end-to-end on a clean checkout).

## HITL review notes

- Security-critical: this **changes the auth trust boundary** (#121) — please review the bootstrap-secret resolver and `key`-scope rules.
- The two ADRs (0005, 0006) are explicit architectural-decision checkpoints.
- Suggested manual step: walk the `docs/cli_login.md` getting-started flow on a clean checkout (the one PARTIAL criterion).