### PR TITLE
PRD #128: Token administration — list / introspect (RFC 7662) / revoke (RFC 7009) + redemption tracking & auto-expiry

### DIFF
--- a/cmd/goSignals/commands.go
+++ b/cmd/goSignals/commands.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/alecthomas/kong"
@@ -2020,9 +2021,71 @@ func parseMode(param string) string {
 	return mode
 }
 
+// applyServerBearer resolves the active-session bearer for server (with silent
+// refresh / fallback to a configured client token) and sets it on req. This is
+// the standard CLI auth path used by every management call.
+func applyServerBearer(cli *CLI, server *SsfServer, req *http.Request) error {
+	bearer, err := serverBearer(&cli.Globals, server)
+	if err != nil {
+		return err
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	return nil
+}
+
+// tokenState derives the human-readable lifecycle state of a token record:
+// revoked (RevokedAt set), expired (ExpiresAt past), else active.
+func tokenState(rec model.TokenRecord) string {
+	if !rec.RevokedAt.IsZero() {
+		return "revoked"
+	}
+	if !rec.ExpiresAt.IsZero() && rec.ExpiresAt.Before(time.Now()) {
+		return "expired"
+	}
+	return "active"
+}
+
+// tokenListEntry decodes the management /token list response. It embeds the
+// server's TokenRecord and additively decodes a usage_ip field that a later
+// slice (#132) will populate; until then the column renders blank. Keeping the
+// extra field local avoids touching the shared server model in this CLI slice.
+type tokenListEntry struct {
+	model.TokenRecord
+	UsageIP string `json:"usage_ip,omitempty"`
+}
+
+// renderTokenTable formats token records as a tab-aligned table an operator can
+// read. Columns: JTI, client, subject, type, scopes, issued, expires, state,
+// usage IP. The usage-IP column is rendered blank until the server populates it
+// (a later slice); the column always exists so scripts and humans see a stable
+// shape.
+func renderTokenTable(records []tokenListEntry) string {
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "JTI\tCLIENT\tSUBJECT\tTYPE\tSCOPES\tISSUED\tEXPIRES\tSTATE\tUSAGE IP")
+	for _, rec := range records {
+		issued := ""
+		if !rec.IssuedAt.IsZero() {
+			issued = rec.IssuedAt.UTC().Format(time.RFC3339)
+		}
+		expires := ""
+		if !rec.ExpiresAt.IsZero() {
+			expires = rec.ExpiresAt.UTC().Format(time.RFC3339)
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			rec.JTI, rec.ClientID, rec.Subject, rec.Type,
+			strings.Join(rec.Scopes, ","), issued, expires, tokenState(rec.TokenRecord), rec.UsageIP)
+	}
+	_ = w.Flush()
+	return buf.String()
+}
+
 type TokenListCmd struct {
 	Project string `help:"Filter by project ID"`
 	Client  string `help:"Filter by client ID"`
+	Json    bool   `help:"Emit the raw JSON response instead of a table"`
 }
 
 func (t *TokenListCmd) Run(cli *CLI) error {
@@ -2049,7 +2112,9 @@ func (t *TokenListCmd) Run(cli *CLI) error {
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Authorization", "Bearer "+server.ClientToken)
+	if err = applyServerBearer(cli, server, req); err != nil {
+		return err
+	}
 
 	client := getHttpClient(10 * time.Second)
 	resp, err := client.Do(req)
@@ -2063,12 +2128,22 @@ func (t *TokenListCmd) Run(cli *CLI) error {
 		return fmt.Errorf("error listing tokens: %s - %s", resp.Status, string(body))
 	}
 
-	fmt.Println(string(body))
+	if t.Json {
+		fmt.Println(string(body))
+		return nil
+	}
+
+	var records []tokenListEntry
+	if err = json.Unmarshal(body, &records); err != nil {
+		return fmt.Errorf("error parsing token list response: %w", err)
+	}
+	fmt.Print(renderTokenTable(records))
 	return nil
 }
 
 type TokenRevokeCmd struct {
-	Jti string `arg:"" help:"The JTI of the token to revoke"`
+	Jti  string `arg:"" help:"The JTI of the token to revoke"`
+	Json bool   `help:"Emit the raw JSON response instead of a confirmation message"`
 }
 
 func (t *TokenRevokeCmd) Run(cli *CLI) error {
@@ -2082,7 +2157,9 @@ func (t *TokenRevokeCmd) Run(cli *CLI) error {
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Authorization", "Bearer "+server.ClientToken)
+	if err = applyServerBearer(cli, server, req); err != nil {
+		return err
+	}
 
 	client := getHttpClient(10 * time.Second)
 	resp, err := client.Do(req)
@@ -2091,9 +2168,18 @@ func (t *TokenRevokeCmd) Run(cli *CLI) error {
 		return err
 	}
 
+	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("error revoking token: %s - %s", resp.Status, string(body))
+	}
+
+	if t.Json {
+		if len(bytes.TrimSpace(body)) > 0 {
+			fmt.Println(string(body))
+		} else {
+			fmt.Printf("{\"jti\":%q,\"revoked\":true}\n", t.Jti)
+		}
+		return nil
 	}
 
 	fmt.Printf("Token %s revoked.\n", t.Jti)
@@ -2102,6 +2188,7 @@ func (t *TokenRevokeCmd) Run(cli *CLI) error {
 
 type TokenIntrospectCmd struct {
 	Token string `arg:"" help:"The token string to introspect"`
+	Json  bool   `help:"Emit the raw JSON response instead of a table"`
 }
 
 func (t *TokenIntrospectCmd) Run(cli *CLI) error {
@@ -2119,7 +2206,9 @@ func (t *TokenIntrospectCmd) Run(cli *CLI) error {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("Authorization", "Bearer "+server.ClientToken)
+	if err = applyServerBearer(cli, server, req); err != nil {
+		return err
+	}
 
 	client := getHttpClient(10 * time.Second)
 	resp, err := client.Do(req)

--- a/cmd/goSignals/commands.go
+++ b/cmd/goSignals/commands.go
@@ -2035,25 +2035,23 @@ func applyServerBearer(cli *CLI, server *SsfServer, req *http.Request) error {
 	return nil
 }
 
-// tokenState derives the human-readable lifecycle state of a token record:
-// revoked (RevokedAt set), expired (ExpiresAt past), else active.
-func tokenState(rec model.TokenRecord) string {
-	if !rec.RevokedAt.IsZero() {
-		return "revoked"
-	}
-	if !rec.ExpiresAt.IsZero() && rec.ExpiresAt.Before(time.Now()) {
-		return "expired"
-	}
-	return "active"
-}
-
 // tokenListEntry decodes the management /token list response. It embeds the
-// server's TokenRecord and additively decodes a usage_ip field that a later
-// slice (#132) will populate; until then the column renders blank. Keeping the
-// extra field local avoids touching the shared server model in this CLI slice.
+// server's TokenRecord (which carries last_redemption_ip for IATs) and decodes
+// the live last_seen_ip the server joins onto STREAM-typed rows. These are the
+// field names the server's TokenListEntry actually emits.
 type tokenListEntry struct {
 	model.TokenRecord
-	UsageIP string `json:"usage_ip,omitempty"`
+	LastSeenIP string `json:"last_seen_ip,omitempty"`
+}
+
+// usageIP answers "where is this token being used?" (ADR 0007): a STREAM
+// token's live last-seen IP, or an IAT's last-redemption IP. Empty when the
+// token has never been redeemed/connected.
+func (e tokenListEntry) usageIP() string {
+	if e.LastSeenIP != "" {
+		return e.LastSeenIP
+	}
+	return e.LastRedemptionIP
 }
 
 // renderTokenTable formats token records as a tab-aligned table an operator can
@@ -2076,7 +2074,7 @@ func renderTokenTable(records []tokenListEntry) string {
 		}
 		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			rec.JTI, rec.ClientID, rec.Subject, rec.Type,
-			strings.Join(rec.Scopes, ","), issued, expires, tokenState(rec.TokenRecord), rec.UsageIP)
+			strings.Join(rec.Scopes, ","), issued, expires, rec.State(), rec.usageIP())
 	}
 	_ = w.Flush()
 	return buf.String()

--- a/cmd/goSignals/goSignals_test.go
+++ b/cmd/goSignals/goSignals_test.go
@@ -259,7 +259,7 @@ func (suite *toolSuite) Test0_MgmtTokens() {
 			AllowedScopes: []string{authSupport.ScopeStreamAdmin, authSupport.ScopeStreamMgmt},
 			Email:         "test@test.com",
 			Description:   "server test",
-		}, eat.ProjectId, true)
+		}, eat.ProjectId, true, eat.ID)
 		instance.streamMgmtToken = clientToken
 
 		testLog.Println("  Checking validation and project ids...")

--- a/cmd/goSignals/token_cmd_test.go
+++ b/cmd/goSignals/token_cmd_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+    "encoding/json"
+    "io"
+    "net/http"
+    "net/http/httptest"
+    "os"
+    "path/filepath"
+    "strings"
+    "testing"
+    "time"
+
+    model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// captureStdout redirects os.Stdout for the duration of fn and returns what was
+// written. Used to assert on the command's human/JSON output.
+func captureStdout(t *testing.T, fn func()) string {
+    t.Helper()
+    orig := os.Stdout
+    r, w, err := os.Pipe()
+    require.NoError(t, err)
+    os.Stdout = w
+    defer func() { os.Stdout = orig }()
+
+    fn()
+    _ = w.Close()
+    out, _ := io.ReadAll(r)
+    return string(out)
+}
+
+// fixedTokenRecords returns a deterministic set of token records spanning the
+// three lifecycle states (active, revoked, expired) for table-rendering tests.
+func fixedTokenRecords() []tokenListEntry {
+    iat := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+    return []tokenListEntry{
+        {TokenRecord: model.TokenRecord{
+            JTI:       "jti-active",
+            ClientID:  "client-a",
+            Subject:   "alice",
+            Type:      model.TokenTypeStream,
+            Scopes:    []string{"admin", "ssf"},
+            IssuedAt:  iat,
+            ExpiresAt: time.Now().Add(time.Hour),
+        }},
+        {TokenRecord: model.TokenRecord{
+            JTI:       "jti-revoked",
+            ClientID:  "client-b",
+            Type:      model.TokenTypeIAT,
+            IssuedAt:  iat,
+            ExpiresAt: time.Now().Add(time.Hour),
+            RevokedAt: iat.Add(time.Minute),
+        }},
+        {TokenRecord: model.TokenRecord{
+            JTI:       "jti-expired",
+            ClientID:  "client-c",
+            Type:      model.TokenTypeStream,
+            IssuedAt:  iat,
+            ExpiresAt: time.Now().Add(-time.Hour),
+        }},
+    }
+}
+
+// TestRenderTokenTable_ColumnsAndStates proves the table renderer emits a
+// header row with every operator-facing column and one row per token whose
+// derived state reflects revocation/expiry.
+func TestRenderTokenTable_ColumnsAndStates(t *testing.T) {
+    out := renderTokenTable(fixedTokenRecords())
+
+    for _, col := range []string{"JTI", "CLIENT", "SUBJECT", "TYPE", "SCOPES", "ISSUED", "EXPIRES", "STATE", "USAGE IP"} {
+        assert.Contains(t, out, col, "header column %s missing", col)
+    }
+
+    assert.Contains(t, out, "jti-active")
+    assert.Contains(t, out, "client-a")
+    assert.Contains(t, out, "alice")
+    assert.Contains(t, out, "admin,ssf")
+
+    lines := strings.Split(strings.TrimSpace(out), "\n")
+    assert.Equal(t, 4, len(lines), "expected header + 3 rows, got: %q", out)
+
+    assert.Contains(t, lineFor(t, lines, "jti-active"), "active")
+    assert.Contains(t, lineFor(t, lines, "jti-revoked"), "revoked")
+    assert.Contains(t, lineFor(t, lines, "jti-expired"), "expired")
+}
+
+func lineFor(t *testing.T, lines []string, needle string) string {
+    t.Helper()
+    for _, l := range lines {
+        if strings.Contains(l, needle) {
+            return l
+        }
+    }
+    t.Fatalf("no line containing %q", needle)
+    return ""
+}
+
+// configuredTokenCLI returns a CLI whose default server points at host and is
+// authenticated via a logged-in session (exercising the serverBearer path).
+func configuredTokenCLI(t *testing.T, host string) *CLI {
+    t.Helper()
+    dir := t.TempDir()
+    g := Globals{ConfigFile: filepath.Join(dir, "config.json")}
+    c := &CLI{Globals: g}
+    store := &CredentialStore{Path: credentialsPath(&c.Globals)}
+    store.Set("https://idp.example.com", &Session{
+        AccessToken: "session-token",
+        Expiry:      time.Now().Add(time.Hour),
+    })
+    require.NoError(t, store.Save())
+    c.Data.Servers = map[string]SsfServer{
+        "gs1": {
+            Alias:        "gs1",
+            Host:         host,
+            ProjectId:    "proj-1",
+            ActiveIssuer: "https://idp.example.com",
+            ClientToken:  "legacy-client-token",
+        },
+    }
+    c.Data.Selected = "gs1"
+    return c
+}
+
+// TestTokenListCmd_UsesSessionBearer proves token list authenticates with the
+// active session token (serverBearer), not the legacy ClientToken header.
+func TestTokenListCmd_UsesSessionBearer(t *testing.T) {
+    var gotAuth string
+    stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        gotAuth = r.Header.Get("Authorization")
+        w.Header().Set("Content-Type", "application/json")
+        _ = json.NewEncoder(w).Encode(fixedTokenRecords())
+    }))
+    defer stub.Close()
+
+    cli := configuredTokenCLI(t, stub.URL)
+    cmd := &TokenListCmd{}
+    require.NoError(t, cmd.Run(cli))
+    assert.Equal(t, "Bearer session-token", gotAuth)
+}
+
+// TestTokenListCmd_JSONFlag proves --json emits the raw JSON response array.
+func TestTokenListCmd_JSONFlag(t *testing.T) {
+    stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+        _ = json.NewEncoder(w).Encode(fixedTokenRecords())
+    }))
+    defer stub.Close()
+
+    cli := configuredTokenCLI(t, stub.URL)
+    out := captureStdout(t, func() {
+        require.NoError(t, (&TokenListCmd{Json: true}).Run(cli))
+    })
+    assert.Contains(t, out, `"jti":"jti-active"`)
+}
+
+// TestTokenListCmd_TableByDefault proves token list renders the table (not raw
+// JSON) when --json is absent.
+func TestTokenListCmd_TableByDefault(t *testing.T) {
+    stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+        _ = json.NewEncoder(w).Encode(fixedTokenRecords())
+    }))
+    defer stub.Close()
+
+    cli := configuredTokenCLI(t, stub.URL)
+    out := captureStdout(t, func() {
+        require.NoError(t, (&TokenListCmd{}).Run(cli))
+    })
+    assert.Contains(t, out, "JTI")
+    assert.Contains(t, out, "STATE")
+    assert.NotContains(t, out, `"jti":`, "default output should be a table, not JSON")
+}
+
+// TestTokenIntrospectCmd_UsesSessionBearer proves introspect authenticates via
+// the session bearer.
+func TestTokenIntrospectCmd_UsesSessionBearer(t *testing.T) {
+    var gotAuth string
+    stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        gotAuth = r.Header.Get("Authorization")
+        w.Header().Set("Content-Type", "application/json")
+        _, _ = w.Write([]byte(`{"active":true,"jti":"jti-active"}`))
+    }))
+    defer stub.Close()
+
+    cli := configuredTokenCLI(t, stub.URL)
+    require.NoError(t, (&TokenIntrospectCmd{Token: "jti-active"}).Run(cli))
+    assert.Equal(t, "Bearer session-token", gotAuth)
+}
+
+// TestTokenRevokeCmd_UsesSessionBearer proves revoke authenticates via the
+// session bearer.
+func TestTokenRevokeCmd_UsesSessionBearer(t *testing.T) {
+    var gotAuth string
+    stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        gotAuth = r.Header.Get("Authorization")
+        w.WriteHeader(http.StatusNoContent)
+    }))
+    defer stub.Close()
+
+    cli := configuredTokenCLI(t, stub.URL)
+    require.NoError(t, (&TokenRevokeCmd{Jti: "jti-active"}).Run(cli))
+    assert.Equal(t, "Bearer session-token", gotAuth)
+}

--- a/docs/adr/0007-track-token-redemption-not-issuance.md
+++ b/docs/adr/0007-track-token-redemption-not-issuance.md
@@ -1,0 +1,83 @@
+<!-- gosignals-brand-hero -->
+<picture><source media="(prefers-color-scheme: dark)" srcset="../../brand/logo/gosignals-hero-primary.svg"><img src="../../brand/logo/gosignals-hero-on-light.svg" alt="goSignals" height="77"></picture>
+
+# 7. Track token redemption, not issuance
+
+Date: 2026-05-31
+
+## Status
+
+Accepted
+
+## Context
+
+We are adding a management-plane view of issued tokens (IATs and stream
+tokens) so an administrator can list, introspect, and revoke them. The
+original request asked to show "the IP address each token was issued to."
+
+Taken literally, that means recording the remote address of the request that
+*minted* the token — the caller of `GET /iat`, or whoever registered a stream
+client. On reflection that signal is near-worthless:
+
+- An issued token is a **bearer credential**. The overwhelmingly common
+  workflow is that an administrator mints a token and then **copies and pastes
+  it** into some other system — a CI pipeline, a partner's configuration, a
+  receiver running elsewhere. The address the token was minted from is almost
+  always an admin's laptop or a CLI host, not where the token actually lives.
+- The audit question an operator actually asks during de-provisioning or
+  incident response is "**where is this token being used?**" — not "where was
+  it typed?"
+
+The codebase already has the right raw material for the "where is it used"
+question on the stream side: a stream's `RemoteIP` (`StreamStateRecord`) is
+refreshed every time the peer connects, and it is captured on the data plane
+at no extra cost. The gap was only on the IAT side, where "use" means a
+`/register` call — a **cold path**, cheap to instrument.
+
+## Decision
+
+We track **redemption**, not issuance.
+
+- **No issuance IP.** We do not record the address a token was minted from.
+- **IAT redemption** is captured at `/register`: `last_redemption_ip`,
+  `last_redemption_at`, and a `redemption_count` on the IAT's `TokenRecord`.
+  Last-only — not a full per-redemption trail (deep forensics live in the SET
+  event journal). The write is **best-effort** (logged at `WARN` on failure,
+  never blocking registration), matching the existing `TrackToken` posture.
+- **Stream-token "redemption"** is the ongoing push/poll connection. The
+  management view *joins* the stream's existing `RemoteIP` (last-seen IP) onto
+  stream-typed tokens rather than storing a second copy.
+- **Lineage** is recorded as `Parent` = the immediate parent JTI at each mint
+  site (IAT → stream-client token → delivery token), for trace/audit display.
+
+`redemption_count` is deliberately positioned as the data primitive a future
+**max-uses / redeem-once** policy would consume, and the redemption IP as the
+input a future **IAT-to-IP-mask restriction** would check. Neither policy is
+built today.
+
+## Consequences
+
+**Positive**
+
+- The IP shown to an operator answers the question they actually have ("where
+  is this used") instead of a misleading one ("where was it minted").
+- No new writes on the hot event-delivery path: stream last-seen IP reuses
+  existing capture; IAT redemption is on the cold `/register` path.
+- The data model seeds future use-count and IP-restriction policies without
+  committing to them now.
+
+**Negative**
+
+- A token minted but never redeemed shows no usage IP at all. That is correct
+  (it has not been used) but may surprise an operator expecting *some* address.
+- `redemption_count` may under-report if a best-effort write is lost. Acceptable
+  for an audit aid; a future max-uses policy that needs a reliable count would
+  have to revisit the best-effort posture.
+
+## Related
+
+- `CONTEXT.md` — "Token administration vocabulary": Redemption, Last-redemption
+  IP, Last-seen IP.
+- ADR 0006 — `key` scope and closing the anonymous IAT endpoint (the IAT
+  lifecycle this view administers).
+- `pkg/ssfModels/model_token.go` — `TokenRecord`.

--- a/docs/adr/0008-two-revocation-endpoints.md
+++ b/docs/adr/0008-two-revocation-endpoints.md
@@ -1,0 +1,72 @@
+<!-- gosignals-brand-hero -->
+<picture><source media="(prefers-color-scheme: dark)" srcset="../../brand/logo/gosignals-hero-primary.svg"><img src="../../brand/logo/gosignals-hero-on-light.svg" alt="goSignals" height="77"></picture>
+
+# 8. Two revocation endpoints: RFC 7009 `/revoke` and `DELETE /token/{jti}`
+
+Date: 2026-05-31
+
+## Status
+
+Accepted
+
+## Context
+
+Token revocation has two genuinely different callers, and they hold different
+things:
+
+1. **A token holder** — a transmitter, receiver, or tool that possesses the
+   token string and wants to kill it. This is the RFC 7009 model: present the
+   token in a form body and the server revokes it.
+2. **An administrator working from a list** — an operator looking at the
+   management-plane token table (or its GoSignalsAdmin console equivalent). By
+   design `TokenRecord` *does not store the token string* — only the JTI and
+   metadata. The admin has a JTI to act on, never the token itself.
+
+RFC 7009 cannot serve caller 2: the admin has no token string to present. And
+the pre-existing `DELETE /token/{jti}` is not RFC 7009 — it is a
+revoke-by-identifier operation. Collapsing to a single endpoint would force one
+caller into an unnatural shape (either admins reconstruct tokens they don't
+have, or holders look up a JTI they may not know).
+
+## Decision
+
+We keep **both** endpoints, each serving its natural caller.
+
+- **`POST /revoke` (RFC 7009)** — for holders. Accepts a `token` form field
+  (and an accepted-but-ignored `token_type_hint`); parses the JWT to extract
+  the JTI; revokes by JTI. Per RFC 7009 §2.2 it **always returns HTTP 200**,
+  even for an unknown, already-revoked, or expired token — never leaking
+  existence.
+- **`DELETE /token/{jti}`** — for admins acting from a table row, revoking by
+  identifier.
+
+Both share one authorization rule: a non-admin caller may revoke only tokens
+within their **own project** (`AuthContext.ProjectId` must match the target's
+project); `admin`/`root` may revoke anything. This blocks a low-scope
+delivery-token holder in one project from revoking another project's tokens.
+
+Revocation sets `revoked_at`; the record is retained (introspection still
+reports `active:false`, and lineage survives) until the Mongo TTL reaps it
+after `I2SIG_TOKEN_RETENTION`.
+
+## Consequences
+
+**Positive**
+
+- Each caller uses the shape that fits what it holds: a token string, or a JTI.
+- RFC 7009 conformance for holders (always-200, `token_type_hint` tolerated)
+  without distorting the admin path.
+- One consistent project-scoping rule across both endpoints and `/introspect`.
+
+**Negative**
+
+- Two endpoints and one more thing to keep aligned (both must apply the same
+  project guard and write the same `revoked_at`).
+- "Two ways to revoke" is surprising at first read; this ADR is the answer to
+  "why not just one?"
+
+## Related
+
+- `CONTEXT.md` — "Token administration vocabulary".
+- RFC 7009 (Token Revocation), RFC 7662 (Token Introspection).
+- ADR 0007 — track redemption, not issuance (same management-plane work).

--- a/docs/configuration_properties.md
+++ b/docs/configuration_properties.md
@@ -150,6 +150,7 @@ understands. They are documented in their natural section below.
 | `I2SIG_STORE_MONGO_FALLBACK_MEM`          | If `false`, the server fails to start when it cannot connect to MongoDB. If `true`, it falls back to the in-memory provider.                 | `true`                                                 |
 | `I2SIG_STORE_MONGO_BACKGROUND_RECONNECT`  | If `true`, the server starts even when MongoDB is unreachable and retries the connection in the background. Used with `_FALLBACK_MEM=true`.  | `false`                                                |
 | `I2SIG_STORE_MONGO_WATCH_ENABLED`         | If `true`, the server uses MongoDB Change Streams to watch for new events. Deprecated in favour of cluster wake-ups + backfill.              | `false`                                                |
+| `I2SIG_TOKEN_RETENTION`                   | How long (in seconds, measured from a token's `exp`) an expired token record is retained in the management-plane token collection before MongoDB's TTL reaper deletes it. A revoked-but-unexpired record stays visible (reporting `active:false`) until retention lapses, so revocations remain auditable. Applied via a TTL index on `exp`; changing the value on a live deployment updates the index in place via `collMod` (no data migration). Mongo-only. | `2592000` _(30 days)_ |
 
 ## Store_Mem
 

--- a/internal/authUtil/auth_token.go
+++ b/internal/authUtil/auth_token.go
@@ -485,6 +485,30 @@ func (a *AuthIssuer) classifyToken(tokenString string) tokenRoute {
 
 // peekKid parses only the JWT header to extract the kid. No signature check.
 // Returns "" when the token is malformed or has no kid.
+// PeekJti extracts the "jti" claim from a JWT payload WITHOUT verifying the
+// signature, expiry, or revocation state. It is used by the RFC 7009 /revoke
+// path, which must extract a JTI from a token that may already be expired or
+// revoked (and which RFC 7009 §2.2 must still answer with HTTP 200). Returns ""
+// when the token is not a parseable JWT.
+func PeekJti(tokenString string) string {
+	parts := strings.Split(strings.TrimSpace(tokenString), ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return ""
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		return ""
+	}
+	if jti, ok := payload["jti"].(string); ok {
+		return jti
+	}
+	return ""
+}
+
 func peekKid(tokenString string) string {
 	parts := strings.Split(strings.TrimSpace(tokenString), ".")
 	if len(parts) < 1 {

--- a/internal/authUtil/auth_token.go
+++ b/internal/authUtil/auth_token.go
@@ -249,12 +249,16 @@ func (a *AuthIssuer) IssueProjectIat(authCtx *AuthContext) (string, error) {
 	if err != nil {
 		authLog.Error("IssueProjectIat signing failed", "kid", kid, "error", err)
 	} else if a.TokenTracker != nil {
-		_ = a.TokenTracker.TrackToken(context.Background(), &eat, model.TokenTypeIAT)
+		// An IAT is the root of the token lineage — no parent.
+		_ = a.TokenTracker.TrackToken(context.Background(), &eat, "", model.TokenTypeIAT)
 	}
 	return signed, err
 }
 
-func (a *AuthIssuer) IssueStreamClientToken(client model.SsfClient, projectId string, admin bool) (string, error) {
+// IssueStreamClientToken mints a stream-client (management) token. parentJTI is
+// the JTI of the IAT redeemed to register the client, recorded as the token's
+// lineage parent.
+func (a *AuthIssuer) IssueStreamClientToken(client model.SsfClient, projectId string, admin bool, parentJTI string) (string, error) {
 	exp := time.Now().AddDate(0, 0, 90)
 
 	scopes := []string{authSupport.ScopeStreamMgmt}
@@ -290,7 +294,7 @@ func (a *AuthIssuer) IssueStreamClientToken(client model.SsfClient, projectId st
 
 	signed, err := token.SignedString(privateKey)
 	if err == nil && a.TokenTracker != nil {
-		_ = a.TokenTracker.TrackToken(context.Background(), &eat, model.TokenTypeStream)
+		_ = a.TokenTracker.TrackToken(context.Background(), &eat, parentJTI, model.TokenTypeStream)
 	}
 	return signed, err
 }
@@ -322,10 +326,14 @@ func (a *AuthIssuer) IssueStreamToken(streamId string, projectId string, session
 		eat.ProjectId = projectId
 	}
 	eat.Roles = []string{authSupport.ScopeEventDelivery}
+	// A delivery token's lineage parent is the stream-client token that
+	// authorized this mint (the issuing session's EAT).
+	parentJTI := ""
 	if session != nil {
 		if session.Eat != nil {
 			eat.ClientId = session.Eat.ClientId
 			eat.Subject, _ = session.Eat.GetSubject()
+			parentJTI = session.Eat.ID
 		}
 
 	}
@@ -336,7 +344,7 @@ func (a *AuthIssuer) IssueStreamToken(streamId string, projectId string, session
 
 	signed, err := token.SignedString(privateKey)
 	if err == nil && a.TokenTracker != nil {
-		_ = a.TokenTracker.TrackToken(context.Background(), &eat, model.TokenTypeStream)
+		_ = a.TokenTracker.TrackToken(context.Background(), &eat, parentJTI, model.TokenTypeStream)
 	}
 	return signed, err
 }

--- a/internal/authUtil/auth_token_test.go
+++ b/internal/authUtil/auth_token_test.go
@@ -72,7 +72,7 @@ func newTestTokens() testTokensSet {
 		AllowedScopes: []string{authSupport.ScopeStreamAdmin, authSupport.ScopeStreamMgmt, authSupport.ScopeEventDelivery},
 		Email:         "test@example.com",
 		Description:   "Test auth_token",
-	}, "abc", true)
+	}, "abc", true, "")
 	if err != nil {
 		fmt.Printf("Failed to issue stream client token: %s\n", err.Error())
 		os.Exit(-1)

--- a/internal/authUtil/token_lineage_test.go
+++ b/internal/authUtil/token_lineage_test.go
@@ -1,0 +1,71 @@
+package authUtil
+
+import (
+    "context"
+    "testing"
+
+    "github.com/i2-open/i2goSignals/pkg/authSupport"
+    "github.com/i2-open/i2goSignals/pkg/ssfModels"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// captureTracker records every TrackToken call so a test can inspect the
+// persisted JTI/parent lineage without reaching into a DAO.
+type captureTracker struct {
+    tracked []trackedCall
+}
+
+type trackedCall struct {
+    jti     string
+    parent  string
+    purpose string
+}
+
+func (c *captureTracker) TrackToken(_ context.Context, claims *authSupport.EventAuthToken, parent string, purpose string) error {
+    c.tracked = append(c.tracked, trackedCall{jti: claims.ID, parent: parent, purpose: purpose})
+    return nil
+}
+
+func (c *captureTracker) IsRevoked(context.Context, string) (bool, error) { return false, nil }
+
+// TestParentLineage proves Parent is the immediate parent JTI at each mint
+// site: IAT is the root (empty parent); a stream-client token's parent is the
+// IAT JTI; a delivery (stream) token's parent is the stream-client JTI.
+func TestParentLineage(t *testing.T) {
+    issuer := initMockIssuer()
+    tracker := &captureTracker{}
+    issuer.TokenTracker = tracker
+
+    // IAT — root, no parent.
+    _, err := issuer.IssueProjectIat(nil)
+    require.NoError(t, err)
+    require.Len(t, tracker.tracked, 1)
+    iat := tracker.tracked[0]
+    assert.Equal(t, model.TokenTypeIAT, iat.purpose)
+    assert.Empty(t, iat.parent, "IAT is the lineage root and has no parent")
+
+    // Stream-client token — parent is the IAT JTI.
+    iatCtx := &AuthContext{Eat: &authSupport.EventAuthToken{}}
+    iatCtx.Eat.ID = iat.jti
+    _, err = issuer.IssueStreamClientToken(model.SsfClient{
+        Id:         bson.NewObjectID(),
+        ProjectIds: []string{"abc"},
+    }, "abc", false, iat.jti)
+    require.NoError(t, err)
+    require.Len(t, tracker.tracked, 2)
+    streamClient := tracker.tracked[1]
+    assert.Equal(t, model.TokenTypeStream, streamClient.purpose)
+    assert.Equal(t, iat.jti, streamClient.parent)
+
+    // Delivery (stream) token — parent is the stream-client JTI, taken from
+    // the issuing session's EAT.
+    session := &AuthContext{Eat: &authSupport.EventAuthToken{}}
+    session.Eat.ID = streamClient.jti
+    _, err = issuer.IssueStreamToken("stream-1", "abc", session)
+    require.NoError(t, err)
+    require.Len(t, tracker.tracked, 3)
+    delivery := tracker.tracked[2]
+    assert.Equal(t, streamClient.jti, delivery.parent)
+}

--- a/internal/dao/interfaces/dao_interfaces.go
+++ b/internal/dao/interfaces/dao_interfaces.go
@@ -124,6 +124,10 @@ type TokenDAO interface {
     Insert(ctx context.Context, record *model.TokenRecord) error
     FindByJTI(ctx context.Context, jti string) (*model.TokenRecord, error)
     Revoke(ctx context.Context, jti string) error
+    // RecordRedemption captures a token redemption: it increments
+    // redemption_count and overwrites last_redemption_ip/last_redemption_at.
+    // Per ADR 0007 this is the "where is it used" signal (not issuance).
+    RecordRedemption(ctx context.Context, jti string, ip string, at time.Time) error
     DeleteExpired(ctx context.Context) error
     FindByProjectID(ctx context.Context, projectID string) ([]*model.TokenRecord, error)
     FindByClientID(ctx context.Context, clientID string) ([]*model.TokenRecord, error)

--- a/internal/dao/interfaces/dao_interfaces.go
+++ b/internal/dao/interfaces/dao_interfaces.go
@@ -131,6 +131,9 @@ type TokenDAO interface {
     DeleteExpired(ctx context.Context) error
     FindByProjectID(ctx context.Context, projectID string) ([]*model.TokenRecord, error)
     FindByClientID(ctx context.Context, clientID string) ([]*model.TokenRecord, error)
+    // FindAll returns every tracked token regardless of project. Used by the
+    // caller-scoped list for admin/root callers who see all projects.
+    FindAll(ctx context.Context) ([]*model.TokenRecord, error)
 }
 
 // ServerDAO handles server configuration data access

--- a/internal/dao/memory/token_dao.go
+++ b/internal/dao/memory/token_dao.go
@@ -97,3 +97,13 @@ func (d *TokenDAOMemory) FindByClientID(ctx context.Context, clientID string) ([
 	}
 	return results, nil
 }
+
+func (d *TokenDAOMemory) FindAll(ctx context.Context) ([]*model.TokenRecord, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	results := make([]*model.TokenRecord, 0, len(d.tokens))
+	for _, record := range d.tokens {
+		results = append(results, record)
+	}
+	return results, nil
+}

--- a/internal/dao/memory/token_dao.go
+++ b/internal/dao/memory/token_dao.go
@@ -49,6 +49,19 @@ func (d *TokenDAOMemory) Revoke(ctx context.Context, jti string) error {
 	return nil
 }
 
+func (d *TokenDAOMemory) RecordRedemption(ctx context.Context, jti string, ip string, at time.Time) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	record, ok := d.tokens[jti]
+	if !ok {
+		return errors.New("token not found")
+	}
+	record.RedemptionCount++
+	record.LastRedemptionIP = ip
+	record.LastRedemptionAt = at
+	return nil
+}
+
 func (d *TokenDAOMemory) DeleteExpired(ctx context.Context) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()

--- a/internal/dao/mongo/token_dao.go
+++ b/internal/dao/mongo/token_dao.go
@@ -25,6 +25,10 @@ type tokenRecordBson struct {
 	ExpiresAt time.Time `bson:"exp"`
 	RevokedAt time.Time `bson:"revoked_at,omitzero"`
 	Parent    any       `bson:"parent,omitzero"`
+
+	LastRedemptionIP string    `bson:"last_redemption_ip,omitzero"`
+	LastRedemptionAt time.Time `bson:"last_redemption_at,omitzero"`
+	RedemptionCount  int64     `bson:"redemption_count,omitzero"`
 }
 
 func toBson(record *model.TokenRecord) *tokenRecordBson {
@@ -39,6 +43,10 @@ func toBson(record *model.TokenRecord) *tokenRecordBson {
 		ExpiresAt: record.ExpiresAt,
 		RevokedAt: record.RevokedAt,
 		Parent:    ToFlexibleID(record.Parent),
+
+		LastRedemptionIP: record.LastRedemptionIP,
+		LastRedemptionAt: record.LastRedemptionAt,
+		RedemptionCount:  record.RedemptionCount,
 	}
 }
 
@@ -54,6 +62,10 @@ func fromBson(b *tokenRecordBson) *model.TokenRecord {
 		ExpiresAt: b.ExpiresAt,
 		RevokedAt: b.RevokedAt,
 		Parent:    IDToString(b.Parent),
+
+		LastRedemptionIP: b.LastRedemptionIP,
+		LastRedemptionAt: b.LastRedemptionAt,
+		RedemptionCount:  b.RedemptionCount,
 	}
 }
 
@@ -118,6 +130,23 @@ func (d *TokenDAOMongo) Revoke(ctx context.Context, jti string) error {
     _, err = c.UpdateOne(ctx, bson.M{"_id": ToFlexibleID(jti)}, bson.M{"$set": bson.M{"revoked_at": time.Now().UTC()}})
     if err != nil {
         tLog.Error("Error revoking token record", "jti", jti, "error", err)
+    }
+    return err
+}
+
+func (d *TokenDAOMongo) RecordRedemption(ctx context.Context, jti string, ip string, at time.Time) error {
+    c, err := d.col()
+    if err != nil {
+        return err
+    }
+    _, err = c.UpdateOne(ctx,
+        bson.M{"_id": ToFlexibleID(jti)},
+        bson.M{
+            "$inc": bson.M{"redemption_count": 1},
+            "$set": bson.M{"last_redemption_ip": ip, "last_redemption_at": at},
+        })
+    if err != nil {
+        tLog.Error("Error recording token redemption", "jti", jti, "error", err)
     }
     return err
 }

--- a/internal/dao/mongo/token_dao.go
+++ b/internal/dao/mongo/token_dao.go
@@ -25,6 +25,7 @@ type tokenRecordBson struct {
 	ExpiresAt time.Time `bson:"exp"`
 	RevokedAt time.Time `bson:"revoked_at,omitzero"`
 	Parent    any       `bson:"parent,omitzero"`
+	StreamID  string    `bson:"stream_id,omitzero"`
 
 	LastRedemptionIP string    `bson:"last_redemption_ip,omitzero"`
 	LastRedemptionAt time.Time `bson:"last_redemption_at,omitzero"`
@@ -43,6 +44,7 @@ func toBson(record *model.TokenRecord) *tokenRecordBson {
 		ExpiresAt: record.ExpiresAt,
 		RevokedAt: record.RevokedAt,
 		Parent:    ToFlexibleID(record.Parent),
+		StreamID:  record.StreamID,
 
 		LastRedemptionIP: record.LastRedemptionIP,
 		LastRedemptionAt: record.LastRedemptionAt,
@@ -62,6 +64,7 @@ func fromBson(b *tokenRecordBson) *model.TokenRecord {
 		ExpiresAt: b.ExpiresAt,
 		RevokedAt: b.RevokedAt,
 		Parent:    IDToString(b.Parent),
+		StreamID:  b.StreamID,
 
 		LastRedemptionIP: b.LastRedemptionIP,
 		LastRedemptionAt: b.LastRedemptionAt,
@@ -177,6 +180,29 @@ func (d *TokenDAOMongo) FindByProjectID(ctx context.Context, projectID string) (
     err = cursor.All(ctx, &bResults)
     if err != nil {
         tLog.Error("Error parsing tokens by project", "projectID", projectID, "error", err)
+        return nil, err
+    }
+    results := make([]*model.TokenRecord, len(bResults))
+    for i, b := range bResults {
+        results[i] = fromBson(b)
+    }
+    return results, nil
+}
+
+func (d *TokenDAOMongo) FindAll(ctx context.Context) ([]*model.TokenRecord, error) {
+    c, err := d.col()
+    if err != nil {
+        return nil, err
+    }
+    cursor, err := c.Find(ctx, bson.M{})
+    if err != nil {
+        tLog.Error("Error finding all tokens", "error", err)
+        return nil, err
+    }
+    var bResults []*tokenRecordBson
+    err = cursor.All(ctx, &bResults)
+    if err != nil {
+        tLog.Error("Error parsing all tokens", "error", err)
         return nil, err
     }
     results := make([]*model.TokenRecord, len(bResults))

--- a/internal/dao/token_parity_test.go
+++ b/internal/dao/token_parity_test.go
@@ -1,0 +1,96 @@
+package dao_test
+
+import (
+    "context"
+    "testing"
+    "time"
+
+    "github.com/i2-open/i2goSignals/internal/dao/interfaces"
+    "github.com/i2-open/i2goSignals/internal/dao/memory"
+    "github.com/i2-open/i2goSignals/internal/dao/mongo"
+    "github.com/i2-open/i2goSignals/pkg/ssfModels"
+    "github.com/stretchr/testify/require"
+    drivermongo "go.mongodb.org/mongo-driver/v2/mongo"
+    "go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+// TestDbUrl mirrors the connection string used by the per-adapter mongo
+// suites; the parity test skips the mongo arm when Mongo is unreachable.
+const TestDbUrl = "mongodb://root:dockTest@mongo1:30001,mongo2:30002,mongo3:30003/?retryWrites=true&replicaSet=dbrs&readPreference=primary&serverSelectionTimeoutMS=5000&connectTimeoutMS=10000&authSource=admin&authMechanism=SCRAM-SHA-256"
+
+// daoFactory builds a fresh, empty TokenDAO for one parity sub-test. The
+// returned cleanup releases any backing resources.
+type daoFactory struct {
+    name string
+    open func(t *testing.T) (dao interfaces.TokenDAO, cleanup func())
+}
+
+func tokenDAOFactories() []daoFactory {
+    return []daoFactory{
+        {
+            name: "memory",
+            open: func(t *testing.T) (interfaces.TokenDAO, func()) {
+                return memory.NewTokenDAO(), func() {}
+            },
+        },
+        {
+            name: "mongo",
+            open: func(t *testing.T) (interfaces.TokenDAO, func()) {
+                opts := options.Client().ApplyURI(TestDbUrl)
+                client, err := drivermongo.Connect(opts)
+                if err != nil {
+                    t.Skip("Mongo connection error: " + err.Error())
+                }
+                if err = client.Ping(context.Background(), nil); err != nil {
+                    t.Skip("Mongo ping error: " + err.Error())
+                }
+                col := client.Database("test_db").Collection("tokens_parity")
+                _ = col.Drop(context.Background())
+                return mongo.NewTokenDAO(col), func() {
+                    _ = col.Drop(context.Background())
+                    _ = client.Disconnect(context.Background())
+                }
+            },
+        },
+    }
+}
+
+// TestTokenDAO_RecordRedemption_Parity enforces that the Mongo and memory
+// TokenDAO adapters implement RecordRedemption identically: the first
+// redemption sets ip/time and a count of 1, and a second redemption
+// increments the count and overwrites the last-redemption ip/time.
+func TestTokenDAO_RecordRedemption_Parity(t *testing.T) {
+    for _, f := range tokenDAOFactories() {
+        t.Run(f.name, func(t *testing.T) {
+            dao, cleanup := f.open(t)
+            defer cleanup()
+            ctx := context.Background()
+
+            jti := "iat-parity-1"
+            require.NoError(t, dao.Insert(ctx, &model.TokenRecord{
+                JTI:       jti,
+                ProjectID: "p1",
+                Type:      model.TokenTypeIAT,
+                IssuedAt:  time.Now().UTC(),
+            }))
+
+            t1 := time.Now().UTC().Truncate(time.Millisecond)
+            require.NoError(t, dao.RecordRedemption(ctx, jti, "10.0.0.1", t1))
+
+            rec, err := dao.FindByJTI(ctx, jti)
+            require.NoError(t, err)
+            require.Equal(t, int64(1), rec.RedemptionCount)
+            require.Equal(t, "10.0.0.1", rec.LastRedemptionIP)
+            require.WithinDuration(t, t1, rec.LastRedemptionAt, time.Second)
+
+            t2 := t1.Add(time.Minute)
+            require.NoError(t, dao.RecordRedemption(ctx, jti, "10.0.0.2", t2))
+
+            rec, err = dao.FindByJTI(ctx, jti)
+            require.NoError(t, err)
+            require.Equal(t, int64(2), rec.RedemptionCount)
+            require.Equal(t, "10.0.0.2", rec.LastRedemptionIP)
+            require.WithinDuration(t, t2, rec.LastRedemptionAt, time.Second)
+        })
+    }
+}

--- a/internal/dao/token_parity_test.go
+++ b/internal/dao/token_parity_test.go
@@ -94,3 +94,43 @@ func TestTokenDAO_RecordRedemption_Parity(t *testing.T) {
         })
     }
 }
+
+// TestTokenDAO_FindAll_Parity enforces that the Mongo and memory TokenDAO
+// adapters implement FindAll identically: it returns every tracked token
+// across all projects (used by the admin/root caller-scoped list) and round
+// trips the StreamID join key.
+func TestTokenDAO_FindAll_Parity(t *testing.T) {
+    for _, f := range tokenDAOFactories() {
+        t.Run(f.name, func(t *testing.T) {
+            dao, cleanup := f.open(t)
+            defer cleanup()
+            ctx := context.Background()
+
+            require.NoError(t, dao.Insert(ctx, &model.TokenRecord{
+                JTI:       "all-iat",
+                ProjectID: "p1",
+                Type:      model.TokenTypeIAT,
+                IssuedAt:  time.Now().UTC(),
+            }))
+            require.NoError(t, dao.Insert(ctx, &model.TokenRecord{
+                JTI:       "all-stream",
+                ProjectID: "p2",
+                Type:      model.TokenTypeStream,
+                StreamID:  "stream-hex-1",
+                IssuedAt:  time.Now().UTC(),
+            }))
+
+            all, err := dao.FindAll(ctx)
+            require.NoError(t, err)
+            require.Len(t, all, 2)
+
+            byJTI := map[string]*model.TokenRecord{}
+            for _, r := range all {
+                byJTI[r.JTI] = r
+            }
+            require.Contains(t, byJTI, "all-iat")
+            require.Contains(t, byJTI, "all-stream")
+            require.Equal(t, "stream-hex-1", byJTI["all-stream"].StreamID)
+        })
+    }
+}

--- a/internal/providers/dbProviders/memory_provider/notifying_dao.go
+++ b/internal/providers/dbProviders/memory_provider/notifying_dao.go
@@ -347,3 +347,7 @@ func (d *notifyingTokenDAO) FindByProjectID(ctx context.Context, projectID strin
 func (d *notifyingTokenDAO) FindByClientID(ctx context.Context, clientID string) ([]*model.TokenRecord, error) {
     return d.inner.FindByClientID(ctx, clientID)
 }
+
+func (d *notifyingTokenDAO) FindAll(ctx context.Context) ([]*model.TokenRecord, error) {
+    return d.inner.FindAll(ctx)
+}

--- a/internal/providers/dbProviders/memory_provider/notifying_dao.go
+++ b/internal/providers/dbProviders/memory_provider/notifying_dao.go
@@ -324,6 +324,14 @@ func (d *notifyingTokenDAO) Revoke(ctx context.Context, jti string) error {
     return nil
 }
 
+func (d *notifyingTokenDAO) RecordRedemption(ctx context.Context, jti string, ip string, at time.Time) error {
+    if err := d.inner.RecordRedemption(ctx, jti, ip, at); err != nil {
+        return err
+    }
+    d.notify()
+    return nil
+}
+
 func (d *notifyingTokenDAO) DeleteExpired(ctx context.Context) error {
     if err := d.inner.DeleteExpired(ctx); err != nil {
         return err

--- a/internal/providers/dbProviders/memory_provider/provider.go
+++ b/internal/providers/dbProviders/memory_provider/provider.go
@@ -129,6 +129,7 @@ func (m *MemoryProvider) buildServices() {
     tokenDAO := newNotifyingTokenDAO(m.rawTokenDAO, m.markDirty)
 
     m.tokenService = services.NewTokenService(tokenDAO)
+    m.tokenService.SetStreamDAO(streamDAO)
     m.keyService = services.NewKeyService(keyDAO, m.TokenIssuer, m.tokenService)
     m.streamService = services.NewStreamService(streamDAO, m.keyService, m.DefaultIssuer)
     m.eventService = services.NewEventService(eventDAO)

--- a/internal/providers/dbProviders/mongo_provider/provider.go
+++ b/internal/providers/dbProviders/mongo_provider/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -47,6 +48,20 @@ const CEnvClusterInternalPort = "I2SIG_CLUSTER_INTERNAL_PORT"
 const CEnvTransmitterBackfillInterval = "I2SIG_TRANSMITTER_BACKFILL_INTERVAL"
 const CEnvTransmitterBackfillBatch = "I2SIG_TRANSMITTER_BACKFILL_BATCH"
 const CEnvMongoWatchEnabled = "I2SIG_STORE_MONGO_WATCH_ENABLED"
+
+// CEnvTokenRetention sets how long (in seconds, measured from a token's `exp`
+// timestamp) an expired token record is retained in the management-plane token
+// collection before MongoDB's TTL reaper deletes it. Slice #131 / PRD #128.
+const CEnvTokenRetention = "I2SIG_TOKEN_RETENTION"
+
+// CDefTokenRetentionSeconds is the default token retention: 30 days.
+const CDefTokenRetentionSeconds = 30 * 24 * 60 * 60 // 2592000
+
+// tokenTTLIndexName is the stable name of the TTL index on the token
+// collection's `exp` field. A fixed name lets startup recognise the existing
+// index and adjust expireAfterSeconds in place via collMod.
+const tokenTTLIndexName = "exp_ttl"
+
 const CDefTokenIssuer = "DEFAULT"
 const ErrorInvalidProject = "invalid project_id - invalid token"
 
@@ -244,6 +259,13 @@ func (m *MongoProvider) initialize(dbName string, ctx context.Context) error {
 		}
 	}
 
+	// The token TTL index is ensured on every (re)connect — not just on a
+	// fresh DB — so a changed I2SIG_TOKEN_RETENTION is applied to an existing
+	// collection in place via collMod (no data migration). Slice #131.
+	if err = m.ensureTokenTTLIndex(ctx, tokenRetentionSeconds()); err != nil {
+		return err
+	}
+
     // Rebind the existing DAOs in place. The DAOs are created once by
     // initServices with nil collections; here we point them at the
     // collections from the freshly-(re)connected database. Services hold
@@ -302,6 +324,93 @@ func (m *MongoProvider) createIndexes(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+// tokenRetentionSeconds reads I2SIG_TOKEN_RETENTION (seconds). It falls back to
+// CDefTokenRetentionSeconds (30 days) when unset, non-numeric, or negative.
+func tokenRetentionSeconds() int32 {
+    val := os.Getenv(CEnvTokenRetention)
+    if val == "" {
+        return CDefTokenRetentionSeconds
+    }
+    parsed, err := strconv.Atoi(val)
+    if err != nil {
+        pLog.Warn("Invalid integer; falling back to default token retention",
+            "env", CEnvTokenRetention, "value", val, "default", CDefTokenRetentionSeconds)
+        return CDefTokenRetentionSeconds
+    }
+    if parsed < 0 {
+        pLog.Warn("Negative value not permitted; falling back to default token retention",
+            "env", CEnvTokenRetention, "value", parsed, "default", CDefTokenRetentionSeconds)
+        return CDefTokenRetentionSeconds
+    }
+    return int32(parsed)
+}
+
+// ensureTokenTTLIndex makes the token collection's TTL index match the desired
+// expireAfterSeconds. Mongo deletes a token record expireAfterSeconds AFTER its
+// `exp` timestamp, so a revoked-but-unexpired record stays present (and reports
+// active:false) until retention lapses. Runs on every (re)connect:
+//   - no TTL index yet  -> create one named tokenTTLIndexName on {exp:1}
+//   - exists, same value -> no-op
+//   - exists, different  -> collMod the index in place (no drop/recreate, so no
+//     collection migration is needed to change retention on a live deployment)
+//
+// TTL is Mongo-only; the memory provider intentionally has no equivalent.
+func (m *MongoProvider) ensureTokenTTLIndex(ctx context.Context, expireAfter int32) error {
+    if m.tokenCol == nil {
+        return errors.New("token collection not initialized")
+    }
+
+    specs, err := m.tokenCol.Indexes().ListSpecifications(ctx, nil)
+    if err != nil {
+        pLog.Error("Error listing token collection indexes", "error", err)
+        return err
+    }
+
+    var existing *int32
+    for _, s := range specs {
+        if s.Name == tokenTTLIndexName {
+            existing = s.ExpireAfterSeconds
+            break
+        }
+    }
+
+    if existing == nil {
+        ttlIndex := mongo.IndexModel{
+            Keys: bson.D{{Key: "exp", Value: 1}},
+            Options: options.Index().
+                SetName(tokenTTLIndexName).
+                SetExpireAfterSeconds(expireAfter),
+        }
+        if _, err = m.tokenCol.Indexes().CreateOne(ctx, ttlIndex); err != nil {
+            pLog.Error("Error creating token TTL index", "error", err)
+            return err
+        }
+        pLog.Info("Created token TTL index", "index", tokenTTLIndexName, "expireAfterSeconds", expireAfter)
+        return nil
+    }
+
+    if *existing == expireAfter {
+        return nil
+    }
+
+    // Adjust in place via collMod rather than drop+recreate.
+    cmd := bson.D{
+        {Key: "collMod", Value: CDbTokens},
+        {Key: "index", Value: bson.D{
+            {Key: "name", Value: tokenTTLIndexName},
+            {Key: "expireAfterSeconds", Value: expireAfter},
+        }},
+    }
+    if err = m.ssefDb.RunCommand(ctx, cmd).Err(); err != nil {
+        pLog.Error("Error adjusting token TTL index via collMod",
+            "from", *existing, "to", expireAfter, "error", err)
+        return err
+    }
+    pLog.Info("Adjusted token TTL index expireAfterSeconds",
+        "index", tokenTTLIndexName, "from", *existing, "to", expireAfter)
+    return nil
 }
 
 func (m *MongoProvider) Check() error {

--- a/internal/providers/dbProviders/mongo_provider/provider.go
+++ b/internal/providers/dbProviders/mongo_provider/provider.go
@@ -3,6 +3,7 @@ package mongo_provider
 import (
 	"context"
 	"errors"
+	"math"
 	"os"
 	"strconv"
 	"sync"
@@ -89,6 +90,14 @@ type MongoProvider struct {
 	serverDAO        *mongodao.ServerDAOMongo
 	tokenDAO         *mongodao.TokenDAOMongo
 	subjectFilterDAO *mongodao.SubjectFilterDAOMongo
+
+	// tokenTTLEnsured records whether the token TTL index has been reconciled in
+	// THIS process. The desired expireAfterSeconds comes from I2SIG_TOKEN_RETENTION
+	// which is fixed for the process lifetime, so once reconciled, reconnects can
+	// skip the per-(re)connect ListSpecifications round-trip. Accessed under m.mu
+	// (initialize() runs while the lock is held). A changed env requires a restart,
+	// which resets this to false.
+	tokenTTLEnsured bool
 
 	// Services — long-lived, never swapped after Open returns. Reconnects
 	// only rebind DAO collections in place (rebindable-collection pattern).
@@ -257,11 +266,17 @@ func (m *MongoProvider) initialize(dbName string, ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		// A fresh database (first connect, or after a ResetDb that dropped it)
+		// has no TTL index; force the reconcile below to run even if a prior
+		// connect in this process had already ensured it.
+		m.tokenTTLEnsured = false
 	}
 
-	// The token TTL index is ensured on every (re)connect — not just on a
-	// fresh DB — so a changed I2SIG_TOKEN_RETENTION is applied to an existing
-	// collection in place via collMod (no data migration). Slice #131.
+	// Ensure the token TTL index. After the first successful reconcile in this
+	// process this is a cheap no-op (the desired retention is fixed for the
+	// process lifetime), so reconnects skip the ListSpecifications round-trip.
+	// On a pre-existing collection the first reconcile applies a changed
+	// I2SIG_TOKEN_RETENTION in place via collMod (no data migration). Slice #131.
 	if err = m.ensureTokenTTLIndex(ctx, tokenRetentionSeconds()); err != nil {
 		return err
 	}
@@ -327,7 +342,9 @@ func (m *MongoProvider) createIndexes(ctx context.Context) error {
 }
 
 // tokenRetentionSeconds reads I2SIG_TOKEN_RETENTION (seconds). It falls back to
-// CDefTokenRetentionSeconds (30 days) when unset, non-numeric, or negative.
+// CDefTokenRetentionSeconds (30 days) when unset, non-numeric, negative, or out
+// of range for Mongo's int32 expireAfterSeconds. The bounds are checked BEFORE
+// narrowing to int32 so a value above math.MaxInt32 cannot wrap to a negative.
 func tokenRetentionSeconds() int32 {
     val := os.Getenv(CEnvTokenRetention)
     if val == "" {
@@ -339,25 +356,42 @@ func tokenRetentionSeconds() int32 {
             "env", CEnvTokenRetention, "value", val, "default", CDefTokenRetentionSeconds)
         return CDefTokenRetentionSeconds
     }
-    if parsed < 0 {
-        pLog.Warn("Negative value not permitted; falling back to default token retention",
-            "env", CEnvTokenRetention, "value", parsed, "default", CDefTokenRetentionSeconds)
+    if parsed < 0 || parsed > math.MaxInt32 {
+        pLog.Warn("Value out of range (0..MaxInt32); falling back to default token retention",
+            "env", CEnvTokenRetention, "value", parsed, "max", int(math.MaxInt32), "default", CDefTokenRetentionSeconds)
         return CDefTokenRetentionSeconds
     }
     return int32(parsed)
 }
 
-// ensureTokenTTLIndex makes the token collection's TTL index match the desired
-// expireAfterSeconds. Mongo deletes a token record expireAfterSeconds AFTER its
-// `exp` timestamp, so a revoked-but-unexpired record stays present (and reports
-// active:false) until retention lapses. Runs on every (re)connect:
+// ensureTokenTTLIndex reconciles the token collection's TTL index to the
+// desired expireAfterSeconds, at most once per process. The desired value comes
+// from I2SIG_TOKEN_RETENTION (fixed for the process lifetime), so after the
+// first successful reconcile, later reconnects skip the work entirely — avoiding
+// a ListSpecifications round-trip on every reconnect. A changed retention takes
+// effect on restart (which clears tokenTTLEnsured).
+//
+// TTL is Mongo-only; the memory provider intentionally has no equivalent.
+func (m *MongoProvider) ensureTokenTTLIndex(ctx context.Context, expireAfter int32) error {
+    if m.tokenTTLEnsured {
+        return nil
+    }
+    if err := m.reconcileTokenTTLIndex(ctx, expireAfter); err != nil {
+        return err
+    }
+    m.tokenTTLEnsured = true
+    return nil
+}
+
+// reconcileTokenTTLIndex makes the token collection's TTL index match the
+// desired expireAfterSeconds. Mongo deletes a token record expireAfterSeconds
+// AFTER its `exp` timestamp, so a revoked-but-unexpired record stays present
+// (and reports active:false) until retention lapses:
 //   - no TTL index yet  -> create one named tokenTTLIndexName on {exp:1}
 //   - exists, same value -> no-op
 //   - exists, different  -> collMod the index in place (no drop/recreate, so no
 //     collection migration is needed to change retention on a live deployment)
-//
-// TTL is Mongo-only; the memory provider intentionally has no equivalent.
-func (m *MongoProvider) ensureTokenTTLIndex(ctx context.Context, expireAfter int32) error {
+func (m *MongoProvider) reconcileTokenTTLIndex(ctx context.Context, expireAfter int32) error {
     if m.tokenCol == nil {
         return errors.New("token collection not initialized")
     }

--- a/internal/providers/dbProviders/mongo_provider/provider.go
+++ b/internal/providers/dbProviders/mongo_provider/provider.go
@@ -139,6 +139,7 @@ func (m *MongoProvider) initServices() {
 	m.subjectFilterDAO = mongodao.NewSubjectFilterDAO(nil).(*mongodao.SubjectFilterDAOMongo)
 
 	m.tokenService = services.NewTokenService(m.tokenDAO)
+	m.tokenService.SetStreamDAO(m.streamDAO)
 	m.keyService = services.NewKeyService(m.keyDAO, m.TokenIssuer, m.tokenService)
 	m.streamService = services.NewStreamService(m.streamDAO, m.keyService, m.DefaultIssuer)
 	m.eventService = services.NewEventService(m.eventDAO)

--- a/internal/providers/dbProviders/mongo_provider/test/provider_test.go
+++ b/internal/providers/dbProviders/mongo_provider/test/provider_test.go
@@ -111,7 +111,7 @@ func (s *MongoProviderSuite) TestA_ClientReg() {
 		AllowedScopes: []string{authSupport.ScopeStreamMgmt, authSupport.ScopeEventDelivery},
 	}
 
-	resp := s.provider.GetClientService().RegisterClient(context.Background(), client, s.project)
+	resp := s.provider.GetClientService().RegisterClient(context.Background(), client, s.project, "")
 	s.NotNil(resp, "Client registration response return check")
 	s.mgmtToken = resp.Token
 	tkn, err := s.auth.ParseAuthToken(s.mgmtToken)

--- a/internal/providers/dbProviders/mongo_provider/token_ttl_test.go
+++ b/internal/providers/dbProviders/mongo_provider/token_ttl_test.go
@@ -105,6 +105,9 @@ func TestTokenTTLIndex_CreatedWithConfiguredRetention(t *testing.T) {
 }
 
 // AC: Retention can be changed via collMod without re-creating the collection.
+// The reconcile mechanism (invoked once per connect by ensureTokenTTLIndex) is
+// exercised directly here: on a restart with a changed I2SIG_TOKEN_RETENTION it
+// collMods the existing index in place.
 func TestTokenTTLIndex_AdjustViaCollMod(t *testing.T) {
     t.Setenv(CEnvTokenRetention, "300")
     p := openTTLProvider(t)
@@ -113,20 +116,38 @@ func TestTokenTTLIndex_AdjustViaCollMod(t *testing.T) {
         t.Fatalf("precondition: expireAfterSeconds=%d found=%v, want 300/true", got, found)
     }
 
-    // Re-run with a different retention; must collMod the existing index.
-    if err := p.ensureTokenTTLIndex(context.Background(), 600); err != nil {
-        t.Fatalf("ensureTokenTTLIndex adjust: %v", err)
+    // Reconcile with a different retention; must collMod the existing index.
+    if err := p.reconcileTokenTTLIndex(context.Background(), 600); err != nil {
+        t.Fatalf("reconcileTokenTTLIndex adjust: %v", err)
     }
     if got, found := findTokenTTLIndex(t, p); !found || got != 600 {
         t.Errorf("after collMod expireAfterSeconds=%d found=%v, want 600/true", got, found)
     }
 
     // Same value again must be a no-op (no error).
-    if err := p.ensureTokenTTLIndex(context.Background(), 600); err != nil {
-        t.Fatalf("ensureTokenTTLIndex no-op: %v", err)
+    if err := p.reconcileTokenTTLIndex(context.Background(), 600); err != nil {
+        t.Fatalf("reconcileTokenTTLIndex no-op: %v", err)
     }
     if got, _ := findTokenTTLIndex(t, p); got != 600 {
         t.Errorf("after no-op expireAfterSeconds=%d, want 600", got)
+    }
+}
+
+// ensureTokenTTLIndex reconciles at most once per process: after the first
+// reconcile, a subsequent call with a different value is a no-op (the desired
+// retention is fixed for the process lifetime; a change takes effect on
+// restart). This avoids the per-reconnect ListSpecifications round-trip.
+func TestTokenTTLIndex_EnsureOncePerProcess(t *testing.T) {
+    t.Setenv(CEnvTokenRetention, "300")
+    p := openTTLProvider(t)
+
+    // Startup already ensured at 300; a further ensure with a new value must
+    // NOT touch the index (guarded by tokenTTLEnsured).
+    if err := p.ensureTokenTTLIndex(context.Background(), 600); err != nil {
+        t.Fatalf("ensureTokenTTLIndex: %v", err)
+    }
+    if got, found := findTokenTTLIndex(t, p); !found || got != 300 {
+        t.Errorf("expireAfterSeconds=%d found=%v, want 300/true (guard should skip)", got, found)
     }
 }
 

--- a/internal/providers/dbProviders/mongo_provider/token_ttl_test.go
+++ b/internal/providers/dbProviders/mongo_provider/token_ttl_test.go
@@ -1,0 +1,175 @@
+package mongo_provider
+
+import (
+    "context"
+    "os"
+    "path/filepath"
+    "testing"
+    "time"
+
+    mongodao "github.com/i2-open/i2goSignals/internal/dao/mongo"
+    model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+)
+
+// Slice #131 (PRD #128): Mongo TTL auto-expiry for token records driven by
+// I2SIG_TOKEN_RETENTION. The TTL index is created on the token collection's
+// expiry field (`exp`) at provider startup and adjusted in place via collMod
+// when the configured retention changes.
+
+const testMongoURL = "mongodb://root:dockTest@mongo1:30001,mongo2:30002,mongo3:30003/?retryWrites=true&replicaSet=dbrs&readPreference=primary&serverSelectionTimeoutMS=5000&connectTimeoutMS=10000&authSource=admin&authMechanism=SCRAM-SHA-256"
+
+func ttlMongoURL() string {
+    if u := os.Getenv("MONGO_URL"); u != "" {
+        return u
+    }
+    return testMongoURL
+}
+
+// openTTLProvider opens a fresh provider against the live Mongo and resets the
+// database so index assertions start from a clean collection. Skips when Mongo
+// is unreachable.
+func openTTLProvider(t *testing.T) *MongoProvider {
+    t.Helper()
+    t.Setenv("I2SIG_STORE_MONGO_RESUME_FILE", filepath.Join(t.TempDir(), "mongo_token.json"))
+    p, err := Open(ttlMongoURL(), "ttltest")
+    if err != nil {
+        t.Skip("Mongo client error: " + err.Error())
+    }
+    if err := p.Check(); err != nil {
+        t.Skip("Mongo Server not available: " + err.Error())
+    }
+    if err := p.ResetDb(true); err != nil {
+        t.Fatalf("ResetDb: %v", err)
+    }
+    t.Cleanup(func() { _ = p.Close() })
+    return p
+}
+
+// findTokenTTLIndex returns the expireAfterSeconds for the TTL index on the
+// token collection's `exp` field, or (nil, true=found?) info.
+func findTokenTTLIndex(t *testing.T, p *MongoProvider) (expireAfter int32, found bool) {
+    t.Helper()
+    specs, err := p.tokenCol.Indexes().ListSpecifications(context.Background(), nil)
+    if err != nil {
+        t.Fatalf("ListSpecifications: %v", err)
+    }
+    for _, s := range specs {
+        if s.ExpireAfterSeconds != nil && string(s.KeysDocument) != "" {
+            // The TTL index must be keyed on the exp field.
+            if s.Name == tokenTTLIndexName {
+                return *s.ExpireAfterSeconds, true
+            }
+        }
+    }
+    return 0, false
+}
+
+func TestTokenRetentionSeconds_Default(t *testing.T) {
+    t.Setenv(CEnvTokenRetention, "")
+    if got := tokenRetentionSeconds(); got != CDefTokenRetentionSeconds {
+        t.Errorf("tokenRetentionSeconds() = %d, want default %d", got, CDefTokenRetentionSeconds)
+    }
+    if CDefTokenRetentionSeconds != 30*24*60*60 {
+        t.Errorf("CDefTokenRetentionSeconds = %d, want 2592000 (30 days)", CDefTokenRetentionSeconds)
+    }
+}
+
+func TestTokenRetentionSeconds_Override(t *testing.T) {
+    t.Setenv(CEnvTokenRetention, "120")
+    if got := tokenRetentionSeconds(); got != 120 {
+        t.Errorf("tokenRetentionSeconds() = %d, want 120", got)
+    }
+}
+
+func TestTokenRetentionSeconds_InvalidFallsBackToDefault(t *testing.T) {
+    t.Setenv(CEnvTokenRetention, "not-a-number")
+    if got := tokenRetentionSeconds(); got != CDefTokenRetentionSeconds {
+        t.Errorf("tokenRetentionSeconds() = %d, want default %d on invalid input", got, CDefTokenRetentionSeconds)
+    }
+}
+
+// AC: A TTL index exists on the token expiry field with expireAfterSeconds
+// driven by I2SIG_TOKEN_RETENTION. Asserted by reading index metadata, not by
+// waiting on Mongo's reaper.
+func TestTokenTTLIndex_CreatedWithConfiguredRetention(t *testing.T) {
+    t.Setenv(CEnvTokenRetention, "300")
+    p := openTTLProvider(t)
+
+    got, found := findTokenTTLIndex(t, p)
+    if !found {
+        t.Fatalf("TTL index %q not found on token collection", tokenTTLIndexName)
+    }
+    if got != 300 {
+        t.Errorf("TTL expireAfterSeconds = %d, want 300", got)
+    }
+}
+
+// AC: Retention can be changed via collMod without re-creating the collection.
+func TestTokenTTLIndex_AdjustViaCollMod(t *testing.T) {
+    t.Setenv(CEnvTokenRetention, "300")
+    p := openTTLProvider(t)
+
+    if got, found := findTokenTTLIndex(t, p); !found || got != 300 {
+        t.Fatalf("precondition: expireAfterSeconds=%d found=%v, want 300/true", got, found)
+    }
+
+    // Re-run with a different retention; must collMod the existing index.
+    if err := p.ensureTokenTTLIndex(context.Background(), 600); err != nil {
+        t.Fatalf("ensureTokenTTLIndex adjust: %v", err)
+    }
+    if got, found := findTokenTTLIndex(t, p); !found || got != 600 {
+        t.Errorf("after collMod expireAfterSeconds=%d found=%v, want 600/true", got, found)
+    }
+
+    // Same value again must be a no-op (no error).
+    if err := p.ensureTokenTTLIndex(context.Background(), 600); err != nil {
+        t.Fatalf("ensureTokenTTLIndex no-op: %v", err)
+    }
+    if got, _ := findTokenTTLIndex(t, p); got != 600 {
+        t.Errorf("after no-op expireAfterSeconds=%d, want 600", got)
+    }
+}
+
+// AC: Revoked-but-unexpired records remain present and report active:false.
+// Because the TTL is measured from `exp` (which is in the future here), the
+// reaper cannot have removed the record yet, so revocations stay auditable.
+func TestTokenTTLIndex_RevokedUnexpiredStaysPresentAndInactive(t *testing.T) {
+    t.Setenv(CEnvTokenRetention, "300")
+    p := openTTLProvider(t)
+
+    dao := mongodao.NewTokenDAO(p.tokenCol)
+    ctx := context.Background()
+
+    rec := &model.TokenRecord{
+        JTI:       "ttl-revoked-unexpired",
+        ProjectID: "proj-1",
+        Type:      model.TokenTypeIAT,
+        Scopes:    []string{"go.signals.register"},
+        IssuedAt:  time.Now().UTC(),
+        ExpiresAt: time.Now().UTC().Add(1 * time.Hour), // not yet expired
+    }
+    if err := dao.Insert(ctx, rec); err != nil {
+        t.Fatalf("Insert: %v", err)
+    }
+    if err := dao.Revoke(ctx, rec.JTI); err != nil {
+        t.Fatalf("Revoke: %v", err)
+    }
+
+    // Still present: FindByJTI returns the record.
+    got, err := dao.FindByJTI(ctx, rec.JTI)
+    if err != nil {
+        t.Fatalf("FindByJTI after revoke: %v", err)
+    }
+    if got == nil || got.RevokedAt.IsZero() {
+        t.Fatalf("revoked-but-unexpired record missing or not marked revoked: %+v", got)
+    }
+
+    // Reports active:false via introspection (same active rule the service uses).
+    resp, err := p.GetTokenService().IntrospectToken(ctx, rec.JTI)
+    if err != nil {
+        t.Fatalf("IntrospectToken: %v", err)
+    }
+    if resp.Active {
+        t.Errorf("revoked-but-unexpired token reported active:true, want active:false")
+    }
+}

--- a/internal/server/api_out_of_band.go
+++ b/internal/server/api_out_of_band.go
@@ -1231,6 +1231,25 @@ func (sa *SignalsApplication) GetSummaries(w http.ResponseWriter, r *http.Reques
 	_, _ = w.Write(resp)
 }
 
+// callerMayActOnProject implements the shared single-token project guard
+// (ADR 0008). It reuses the ProjectScope derivation from the token service: an
+// admin/root caller is unrestricted; every other caller may act only on tokens
+// whose project matches its own AuthContext.ProjectId. A target with no tracked
+// project (unknown JTI) is treated as out-of-scope for a confined caller, which
+// the callers turn into a no-op (revoke) or active:false (introspect) without
+// leaking existence.
+func callerMayActOnProject(authCtx *authUtil.AuthContext, targetProjectID string) bool {
+	var eat *authSupport.EventAuthToken
+	if authCtx != nil {
+		eat = authCtx.Eat
+	}
+	unrestricted, projectID := services.ProjectScope(eat)
+	if unrestricted {
+		return true
+	}
+	return targetProjectID != "" && targetProjectID == projectID
+}
+
 // IntrospectHandler implements RFC7662 token introspection.
 func (sa *SignalsApplication) IntrospectHandler(w http.ResponseWriter, r *http.Request) {
 	// 1. Validate authorization (Relatively open) - should this be anyone?
@@ -1251,9 +1270,30 @@ func (sa *SignalsApplication) IntrospectHandler(w http.ResponseWriter, r *http.R
 	jti := token
 	if claims, err := sa.GetAuth().ParseAuthTokenVerbose(token, false); err == nil && claims != nil {
 		jti = claims.ID
+	} else if peeked := authUtil.PeekJti(token); peeked != "" {
+		jti = peeked
 	}
 
-	// 4. Introspect
+	// 4. Project guard (ADR 0008): a non-admin caller may only introspect tokens
+	// in its own project. A cross-project (or unknown) target is reported as
+	// active:false rather than 403, so existence is not leaked.
+	record, err := sa.GetTokenService().FindByJTI(r.Context(), jti)
+	if err != nil {
+		serverLog.Error("Introspection lookup error", "error", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	targetProject := ""
+	if record != nil {
+		targetProject = record.ProjectID
+	}
+	if !callerMayActOnProject(authCtx, targetProject) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.IntrospectionResponse{Active: false})
+		return
+	}
+
+	// 5. Introspect
 	resp, err := sa.GetTokenService().IntrospectToken(r.Context(), jti)
 	if err != nil {
 		serverLog.Error("Introspection error", "error", err)
@@ -1265,7 +1305,68 @@ func (sa *SignalsApplication) IntrospectHandler(w http.ResponseWriter, r *http.R
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
-// TokenRevokeHandler revokes a token by its JTI.
+// RevokeHandler implements RFC 7009 token revocation for a token holder. The
+// holder presents the token string in a `token` form field (with an
+// accepted-but-ignored `token_type_hint`); the JTI is parsed from the JWT and
+// revoked. Per RFC 7009 §2.2 the response is ALWAYS HTTP 200 — for an unknown,
+// already-revoked, expired, unparseable, or cross-project-denied token — so the
+// existence of a token is never leaked. Only a malformed request (no `token`
+// parameter) is a 400.
+func (sa *SignalsApplication) RevokeHandler(w http.ResponseWriter, r *http.Request) {
+	authCtx, status := sa.GetAuth().ValidateAuthorizationAny(r, []string{authSupport.ScopeRoot, authSupport.ScopeStreamAdmin, authSupport.ScopeStreamMgmt, authSupport.ScopeEventDelivery})
+	if status != http.StatusOK || authCtx == nil {
+		http.Error(w, "Unauthorized", status)
+		return
+	}
+
+	token := r.FormValue("token")
+	if token == "" {
+		http.Error(w, "Missing token", http.StatusBadRequest)
+		return
+	}
+	// token_type_hint is accepted but ignored (RFC 7009 §2.1).
+
+	// Parse the JTI from the JWT. An unverified peek is used so that an expired
+	// or already-revoked token still yields its JTI; an unparseable token leaves
+	// jti empty and the handler simply returns 200 without revoking.
+	jti := ""
+	if claims, err := sa.GetAuth().ParseAuthTokenVerbose(token, false); err == nil && claims != nil {
+		jti = claims.ID
+	} else if peeked := authUtil.PeekJti(token); peeked != "" {
+		jti = peeked
+	}
+
+	if jti != "" {
+		sa.revokeIfPermitted(r, authCtx, jti)
+	}
+
+	// RFC 7009 §2.2: always 200, regardless of outcome.
+	w.WriteHeader(http.StatusOK)
+}
+
+// revokeIfPermitted applies the project guard then revokes by JTI. A
+// cross-project (or unknown) target is a silent no-op so /revoke never leaks
+// existence. Revocation failures are logged but never change the HTTP outcome.
+func (sa *SignalsApplication) revokeIfPermitted(r *http.Request, authCtx *authUtil.AuthContext, jti string) {
+	record, err := sa.GetTokenService().FindByJTI(r.Context(), jti)
+	if err != nil {
+		serverLog.Warn("Revoke lookup error", "jti", jti, "error", err)
+		return
+	}
+	targetProject := ""
+	if record != nil {
+		targetProject = record.ProjectID
+	}
+	if !callerMayActOnProject(authCtx, targetProject) {
+		// Cross-project or unknown: no-op, but still 200 (no leak).
+		return
+	}
+	if err := sa.GetTokenService().RevokeToken(r.Context(), jti); err != nil {
+		serverLog.Warn("Revocation error", "jti", jti, "error", err)
+	}
+}
+
+// TokenRevokeHandler revokes a token by its JTI (admin path, DELETE /token/{jti}).
 func (sa *SignalsApplication) TokenRevokeHandler(w http.ResponseWriter, r *http.Request) {
 	authCtx, status := sa.GetAuth().ValidateAuthorizationAny(r, []string{authSupport.ScopeRoot, authSupport.ScopeStreamAdmin, authSupport.ScopeStreamMgmt})
 	if status != http.StatusOK || authCtx == nil {
@@ -1280,8 +1381,26 @@ func (sa *SignalsApplication) TokenRevokeHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
-	err := sa.GetTokenService().RevokeToken(r.Context(), jti)
+	// Project guard (ADR 0008): a non-admin caller may only revoke tokens in its
+	// own project. Unlike RFC 7009 /revoke, the admin-by-identifier path returns
+	// 403 on a cross-project target (the admin acts from a table row and is
+	// entitled to a clear authorization error).
+	record, err := sa.GetTokenService().FindByJTI(r.Context(), jti)
 	if err != nil {
+		serverLog.Error("Revoke lookup error", "jti", jti, "error", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	targetProject := ""
+	if record != nil {
+		targetProject = record.ProjectID
+	}
+	if !callerMayActOnProject(authCtx, targetProject) {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
+	if err := sa.GetTokenService().RevokeToken(r.Context(), jti); err != nil {
 		serverLog.Error("Revocation error", "jti", jti, "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/server/api_out_of_band.go
+++ b/internal/server/api_out_of_band.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1289,32 +1290,43 @@ func (sa *SignalsApplication) TokenRevokeHandler(w http.ResponseWriter, r *http.
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// TokenListHandler lists tokens by project or client.
+// TokenListHandler returns a caller-scoped, enriched token inventory.
+//
+// Project scope is derived from the AuthContext, never from a query parameter:
+// admin/root callers see all projects; every other authorized caller sees only
+// its own project. Optional filters: type=IAT|STREAM and active=true|false
+// (composable). STREAM-typed rows include the stream's last-seen IP, joined
+// live from the stream's RemoteAddress.
 func (sa *SignalsApplication) TokenListHandler(w http.ResponseWriter, r *http.Request) {
-	authCtx, status := sa.GetAuth().ValidateAuthorizationAny(r, []string{authSupport.ScopeRoot, authSupport.ScopeStreamAdmin})
+	authCtx, status := sa.GetAuth().ValidateAuthorizationAny(r, []string{authSupport.ScopeRoot, authSupport.ScopeStreamAdmin, authSupport.ScopeStreamMgmt})
 	if status != http.StatusOK || authCtx == nil {
 		http.Error(w, "Unauthorized", status)
 		return
 	}
 
 	queryParams := r.URL.Query()
-	projectId := queryParams.Get("project_id")
-	clientId := queryParams.Get("client_id")
 
-	var tokens []*model.TokenRecord
-	var err error
-
-	if clientId != "" {
-		tokens, err = sa.GetTokenService().ListByClient(r.Context(), clientId)
-	} else if projectId != "" {
-		tokens, err = sa.GetTokenService().ListByProject(r.Context(), projectId)
-	} else {
-		// List all? DAO doesn't have list all yet. I'll use projectId if provided, else return error for now
-		// or I can add ListAll to DAO.
-		http.Error(w, "Missing project_id or client_id", http.StatusBadRequest)
+	filters := services.TokenListFilters{}
+	switch typeParam := queryParams.Get("type"); typeParam {
+	case "":
+		// no type filter
+	case model.TokenTypeIAT, model.TokenTypeStream:
+		filters.Type = typeParam
+	default:
+		http.Error(w, "invalid type filter (expected IAT or STREAM)", http.StatusBadRequest)
 		return
 	}
 
+	if activeParam := queryParams.Get("active"); activeParam != "" {
+		active, err := strconv.ParseBool(activeParam)
+		if err != nil {
+			http.Error(w, "invalid active filter (expected true or false)", http.StatusBadRequest)
+			return
+		}
+		filters.Active = &active
+	}
+
+	tokens, err := sa.GetTokenService().ListForAuthority(r.Context(), authCtx.Eat, filters)
 	if err != nil {
 		serverLog.Error("Token list error", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/server/api_out_of_band.go
+++ b/internal/server/api_out_of_band.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/MicahParks/keyfunc/v2"
 	"github.com/gorilla/mux"
@@ -645,10 +646,26 @@ func RegisterClientHandler(sa SsfApplicationInterface, w http.ResponseWriter, r 
 		Id:            bson.NewObjectID(),
 	}
 
-	response := sa.GetClientService().RegisterClient(r.Context(), client, authCtx.ProjectId)
+	// The redeemed IAT's JTI is this client token's lineage parent (ADR 0007).
+	parentJTI := ""
+	if authCtx.Eat != nil {
+		parentJTI = authCtx.Eat.ID
+	}
+
+	response := sa.GetClientService().RegisterClient(r.Context(), client, authCtx.ProjectId, parentJTI)
 	if response == nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
+	}
+
+	// Best-effort IAT redemption capture: a /register call is a redemption of
+	// the IAT (ADR 0007). A write failure logs at WARN and never blocks
+	// registration, matching the TrackToken posture.
+	if parentJTI != "" {
+		remoteIP := model.BuildRemoteIPFromRequest(r).String()
+		if err := sa.GetTokenService().RecordRedemption(r.Context(), parentJTI, remoteIP, time.Now().UTC()); err != nil {
+			serverLog.Warn("RegisterClient: failed to record IAT redemption", "jti", parentJTI, "error", err)
+		}
 	}
 
 	regBytes, _ := json.MarshalIndent(response, "", " ")

--- a/internal/server/api_out_of_band.go
+++ b/internal/server/api_out_of_band.go
@@ -1247,7 +1247,13 @@ func callerMayActOnProject(authCtx *authUtil.AuthContext, targetProjectID string
 	if unrestricted {
 		return true
 	}
-	return targetProjectID != "" && targetProjectID == projectID
+	// Fail closed: a confined caller with no resolved project (OAuth client or
+	// token with no ProjectId) may act on nothing; never match the empty-project
+	// bucket. A confined caller may act only on a target in its own project.
+	if projectID == "" {
+		return false
+	}
+	return targetProjectID == projectID
 }
 
 // IntrospectHandler implements RFC7662 token introspection.
@@ -1293,13 +1299,9 @@ func (sa *SignalsApplication) IntrospectHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	// 5. Introspect
-	resp, err := sa.GetTokenService().IntrospectToken(r.Context(), jti)
-	if err != nil {
-		serverLog.Error("Introspection error", "error", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	// 5. Introspect — build the response from the record already fetched for the
+	// project guard (a nil record yields active:false), avoiding a second read.
+	resp := services.IntrospectionFromRecord(record)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)

--- a/internal/server/routers.go
+++ b/internal/server/routers.go
@@ -376,6 +376,13 @@ func (h *HttpRouter) getRoutes() Routes {
 			false,
 		},
 		Route{
+			"Revoke",
+			http.MethodPost,
+			"/revoke",
+			h.sa.RevokeHandler,
+			false,
+		},
+		Route{
 			"TokenRevoke",
 			http.MethodDelete,
 			"/token/{jti}",

--- a/internal/server/test/jwks_summaries_test.go
+++ b/internal/server/test/jwks_summaries_test.go
@@ -32,7 +32,7 @@ func (suite *ServerSuite) TestF_JwksSummaries() {
 		AllowedScopes: []string{authSupport.ScopeEventDelivery},
 		Email:         "lowscope@test.com",
 		Description:   "low scope test client",
-	}, suite.servers[0].projectId, false)
+	}, suite.servers[0].projectId, false, "")
 	suite.NoError(err)
 
 	req, _ = http.NewRequest(http.MethodGet, baseUrl, nil)

--- a/internal/server/test/register_provenance_test.go
+++ b/internal/server/test/register_provenance_test.go
@@ -1,0 +1,78 @@
+package test
+
+import (
+    "context"
+    "errors"
+    "net/http"
+    "testing"
+    "time"
+
+    "github.com/i2-open/i2goSignals/internal/dao/interfaces"
+    "github.com/i2-open/i2goSignals/internal/dao/memory"
+    "github.com/i2-open/i2goSignals/internal/services"
+    "github.com/i2-open/i2goSignals/pkg/authSupport"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// redemptionFailDAO wraps the memory TokenDAO but always fails
+// RecordRedemption, to exercise the best-effort posture at /register.
+type redemptionFailDAO struct {
+    interfaces.TokenDAO
+}
+
+func (d redemptionFailDAO) RecordRedemption(context.Context, string, string, time.Time) error {
+    return errors.New("simulated redemption write failure")
+}
+
+// TestRegisterRecordsProvenance is the demoable end-to-end of issue #130: a
+// /register call redeems the IAT (count + last-redemption IP/time on the IAT's
+// record) and the minted stream-client token's lineage Parent is the IAT JTI.
+// Provenance is read back through introspection.
+func TestRegisterRecordsProvenance(t *testing.T) {
+    t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "")
+    instance, err := createServer(t, "register_provenance_test", true)
+    require.NoError(t, err)
+    defer instance.app.Shutdown()
+
+    ctx := context.Background()
+    iatEat, err := instance.GetAuthIssuer().ParseAuthToken(instance.iatToken)
+    require.NoError(t, err)
+    iatJTI := iatEat.ID
+
+    status, clientToken, _ := registerClientToken(t, instance, instance.iatToken,
+        []string{authSupport.ScopeStreamMgmt, authSupport.ScopeEventDelivery})
+    require.Equal(t, http.StatusOK, status)
+
+    // The IAT's record now shows one redemption with a last-redemption IP/time.
+    iatIntro, err := instance.tokenSvc().IntrospectToken(ctx, iatJTI)
+    require.NoError(t, err)
+    assert.Equal(t, int64(1), iatIntro.RedemptionCount, "register must redeem the IAT once")
+    assert.NotEmpty(t, iatIntro.LastRedemptionIP, "register must capture a last-redemption IP")
+    assert.NotZero(t, iatIntro.LastRedemptionAt, "register must capture a last-redemption time")
+
+    // The minted stream-client token's lineage parent is the IAT JTI.
+    clientEat, err := instance.GetAuthIssuer().ParseAuthToken(clientToken)
+    require.NoError(t, err)
+    clientIntro, err := instance.tokenSvc().IntrospectToken(ctx, clientEat.ID)
+    require.NoError(t, err)
+    assert.Equal(t, iatJTI, clientIntro.Parent, "stream-client token parent must be the IAT JTI")
+}
+
+// TestRegisterRedemptionIsBestEffort proves a redemption write failure logs at
+// WARN and never blocks registration (the TrackToken posture, ADR 0007).
+func TestRegisterRedemptionIsBestEffort(t *testing.T) {
+    t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "")
+    instance, err := createServer(t, "register_best_effort_test", true)
+    require.NoError(t, err)
+    defer instance.app.Shutdown()
+
+    // Swap in a TokenService whose RecordRedemption always fails.
+    failing := services.NewTokenService(redemptionFailDAO{TokenDAO: memory.NewTokenDAO()})
+    instance.app.TokenService = failing
+
+    status, _ := registerClient(t, instance, instance.iatToken,
+        []string{authSupport.ScopeStreamMgmt, authSupport.ScopeEventDelivery})
+    require.Equal(t, http.StatusOK, status,
+        "a failed redemption write must not fail registration")
+}

--- a/internal/server/test/test_helpers.go
+++ b/internal/server/test/test_helpers.go
@@ -56,6 +56,7 @@ func (instance *ssfInstance) keySvc() *services.KeyService       { return instan
 func (instance *ssfInstance) eventSvc() *services.EventService   { return instance.persistence.EventService }
 func (instance *ssfInstance) serverSvc() *services.ServerService { return instance.persistence.ServerService }
 func (instance *ssfInstance) clientSvc() *services.ClientService { return instance.persistence.ClientService }
+func (instance *ssfInstance) tokenSvc() *services.TokenService   { return instance.persistence.TokenService }
 
 // The methods below preserve the call shape that test files used to reach
 // through `instance.provider.X` so the per-test diff is mechanical. Each
@@ -220,7 +221,7 @@ func createServer(t *testing.T, dbName string, resetDb bool) (*ssfInstance, erro
 		AllowedScopes: []string{authSupport.ScopeStreamAdmin, authSupport.ScopeStreamMgmt},
 		Email:         "test@test.com",
 		Description:   "server test",
-	}, eat.ProjectId, true)
+	}, eat.ProjectId, true, eat.ID)
 	instance.streamMgmtToken = clientToken
 
 	instance.projectId = eat.ProjectId

--- a/internal/server/token_revoke_introspect_test.go
+++ b/internal/server/token_revoke_introspect_test.go
@@ -1,0 +1,263 @@
+package server
+
+import (
+    "context"
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "net/url"
+    "strings"
+    "testing"
+
+    "github.com/gorilla/mux"
+    "github.com/i2-open/i2goSignals/internal/providers/dbProviders"
+    "github.com/i2-open/i2goSignals/pkg/ssfModels"
+    "github.com/stretchr/testify/suite"
+    "go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// TokenAdminSuite drives the single-token management endpoints (/revoke,
+// /introspect, DELETE /token/{jti}) end-to-end against a memory-backed
+// persistence with a real AuthIssuer, exercising RFC 7009 / RFC 7662
+// conformance and the shared project guard.
+type TokenAdminSuite struct {
+    suite.Suite
+    app *SignalsApplication
+}
+
+func (s *TokenAdminSuite) SetupTest() {
+    persistence, err := dbProviders.OpenPersistence("memorydb:", "tokenadmin-test")
+    s.Require().NoError(err)
+    // Wire the token signing key so the AuthIssuer can mint + validate tokens.
+    err = persistence.KeyService.InitializeTokenKey(context.Background(), "DEFAULT")
+    s.Require().NoError(err)
+
+    s.app = newTestApplication(persistence)
+    s.app.DefIssuer = "DEFAULT"
+}
+
+// issueStreamTokenForProject mints an event-delivery (non-admin) token bound to
+// the given project, returning the token string and its JTI.
+func (s *TokenAdminSuite) issueDeliveryToken(projectId string) (string, string) {
+    tok, err := s.app.GetAuth().IssueStreamToken("stream-"+projectId, projectId, nil)
+    s.Require().NoError(err)
+    jti := s.jtiOf(tok)
+    return tok, jti
+}
+
+// issueAdminToken mints a stream-admin token bound to the given project.
+func (s *TokenAdminSuite) issueAdminToken(projectId string) string {
+    client := model.SsfClient{Id: bson.NewObjectID(), ProjectIds: []string{projectId}}
+    tok, err := s.app.GetAuth().IssueStreamClientToken(client, projectId, true, "")
+    s.Require().NoError(err)
+    return tok
+}
+
+func (s *TokenAdminSuite) jtiOf(token string) string {
+    claims, err := s.app.GetAuth().ParseAuthTokenVerbose(token, false)
+    s.Require().NoError(err)
+    s.Require().NotNil(claims)
+    return claims.ID
+}
+
+func (s *TokenAdminSuite) postForm(handler http.HandlerFunc, path string, bearer string, form url.Values) *httptest.ResponseRecorder {
+    req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(form.Encode()))
+    req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+    if bearer != "" {
+        req.Header.Set("Authorization", "Bearer "+bearer)
+    }
+    rr := httptest.NewRecorder()
+    handler(rr, req)
+    return rr
+}
+
+// --- Tracer bullet: RFC 7662 field names ---
+
+func (s *TokenAdminSuite) TestIntrospectUsesRFC7662FieldNames() {
+    adminTok := s.issueAdminToken("proj-A")
+    _, jti := s.issueDeliveryToken("proj-A")
+
+    rr := s.postForm(s.app.IntrospectHandler, "/introspect", adminTok, url.Values{"token": {jti}})
+    s.Equal(http.StatusOK, rr.Code)
+
+    var raw map[string]any
+    s.Require().NoError(json.Unmarshal(rr.Body.Bytes(), &raw))
+
+    // RFC 7662 field names.
+    s.Contains(raw, "active")
+    s.Contains(raw, "token_type", "RFC 7662 uses token_type, not the non-standard 'type'")
+    s.NotContains(raw, "type", "non-standard 'type' must be renamed to token_type")
+    s.Equal(model.TokenTypeStream, raw["token_type"])
+}
+
+// --- RFC 7009 /revoke always-200 semantics ---
+
+func (s *TokenAdminSuite) TestRevokeUnknownTokenReturns200() {
+    adminTok := s.issueAdminToken("proj-A")
+    // An opaque/unknown JTI that was never issued.
+    rr := s.postForm(s.app.RevokeHandler, "/revoke", adminTok, url.Values{"token": {"never-issued-jti"}})
+    s.Equal(http.StatusOK, rr.Code, "RFC 7009 §2.2: unknown token still returns 200")
+}
+
+func (s *TokenAdminSuite) TestRevokeUnparseableTokenReturns200() {
+    adminTok := s.issueAdminToken("proj-A")
+    rr := s.postForm(s.app.RevokeHandler, "/revoke", adminTok, url.Values{"token": {"not-a-jwt.garbage"}})
+    s.Equal(http.StatusOK, rr.Code, "an unparseable token still returns 200 without erroring")
+}
+
+func (s *TokenAdminSuite) TestRevokeToleratesTokenTypeHint() {
+    adminTok := s.issueAdminToken("proj-A")
+    deliveryTok, _ := s.issueDeliveryToken("proj-A")
+    rr := s.postForm(s.app.RevokeHandler, "/revoke", adminTok, url.Values{
+        "token":           {deliveryTok},
+        "token_type_hint": {"access_token"},
+    })
+    s.Equal(http.StatusOK, rr.Code, "token_type_hint is accepted but ignored")
+}
+
+func (s *TokenAdminSuite) TestRevokeSetsRevokedAtAndIntrospectReportsInactive() {
+    adminTok := s.issueAdminToken("proj-A")
+    deliveryTok, jti := s.issueDeliveryToken("proj-A")
+
+    // Before revoke: active.
+    pre, err := s.app.GetTokenService().IntrospectToken(context.Background(), jti)
+    s.Require().NoError(err)
+    s.True(pre.Active)
+
+    // Revoke by presenting the full JWT (RFC 7009).
+    rr := s.postForm(s.app.RevokeHandler, "/revoke", adminTok, url.Values{"token": {deliveryTok}})
+    s.Equal(http.StatusOK, rr.Code)
+
+    // revoked_at is set on the record (IsRevoked reads revoked_at).
+    revoked, err := s.app.GetTokenService().IsRevoked(context.Background(), jti)
+    s.Require().NoError(err)
+    s.True(revoked, "revoke must set revoked_at")
+
+    // A later introspect reports active:false (record retained).
+    post, err := s.app.GetTokenService().IntrospectToken(context.Background(), jti)
+    s.Require().NoError(err)
+    s.False(post.Active, "introspect reports active:false after revoke")
+}
+
+func (s *TokenAdminSuite) TestRevokeAlreadyRevokedReturns200() {
+    adminTok := s.issueAdminToken("proj-A")
+    deliveryTok, _ := s.issueDeliveryToken("proj-A")
+
+    rr := s.postForm(s.app.RevokeHandler, "/revoke", adminTok, url.Values{"token": {deliveryTok}})
+    s.Equal(http.StatusOK, rr.Code)
+    // Second revoke of the same token.
+    rr = s.postForm(s.app.RevokeHandler, "/revoke", adminTok, url.Values{"token": {deliveryTok}})
+    s.Equal(http.StatusOK, rr.Code, "already-revoked token still returns 200")
+}
+
+func (s *TokenAdminSuite) TestRevokeMissingTokenReturns400() {
+    adminTok := s.issueAdminToken("proj-A")
+    rr := s.postForm(s.app.RevokeHandler, "/revoke", adminTok, url.Values{})
+    s.Equal(http.StatusBadRequest, rr.Code, "absent token param is a malformed request")
+}
+
+// --- Project guard across /revoke, /introspect, DELETE /token/{jti} ---
+
+func (s *TokenAdminSuite) deleteToken(bearer, jti string) *httptest.ResponseRecorder {
+    req := httptest.NewRequest(http.MethodDelete, "/token/"+jti, nil)
+    if bearer != "" {
+        req.Header.Set("Authorization", "Bearer "+bearer)
+    }
+    req = muxSetVar(req, "jti", jti)
+    rr := httptest.NewRecorder()
+    s.app.TokenRevokeHandler(rr, req)
+    return rr
+}
+
+func (s *TokenAdminSuite) TestIntrospectCrossProjectDeniedForNonAdmin() {
+    // Target token lives in proj-A.
+    _, targetJti := s.issueDeliveryToken("proj-A")
+    // Caller is a non-admin (delivery) token in proj-B.
+    callerTok, _ := s.issueDeliveryToken("proj-B")
+
+    rr := s.postForm(s.app.IntrospectHandler, "/introspect", callerTok, url.Values{"token": {targetJti}})
+    s.Equal(http.StatusOK, rr.Code)
+    var raw map[string]any
+    s.Require().NoError(json.Unmarshal(rr.Body.Bytes(), &raw))
+    s.Equal(false, raw["active"], "cross-project introspect reports active:false (no leak)")
+    s.NotContains(raw, "project_id", "cross-project introspect must not leak the target's project")
+}
+
+func (s *TokenAdminSuite) TestIntrospectSameProjectAllowedForNonAdmin() {
+    _, targetJti := s.issueDeliveryToken("proj-A")
+    callerTok, _ := s.issueDeliveryToken("proj-A")
+
+    rr := s.postForm(s.app.IntrospectHandler, "/introspect", callerTok, url.Values{"token": {targetJti}})
+    s.Equal(http.StatusOK, rr.Code)
+    var raw map[string]any
+    s.Require().NoError(json.Unmarshal(rr.Body.Bytes(), &raw))
+    s.Equal(true, raw["active"], "same-project non-admin introspect is allowed and reports the live token")
+}
+
+func (s *TokenAdminSuite) TestIntrospectAdminUnrestricted() {
+    _, targetJti := s.issueDeliveryToken("proj-A")
+    adminTok := s.issueAdminToken("proj-B") // admin in a DIFFERENT project
+
+    rr := s.postForm(s.app.IntrospectHandler, "/introspect", adminTok, url.Values{"token": {targetJti}})
+    s.Equal(http.StatusOK, rr.Code)
+    var raw map[string]any
+    s.Require().NoError(json.Unmarshal(rr.Body.Bytes(), &raw))
+    s.Equal(true, raw["active"], "admin/root is unrestricted across projects")
+    s.Equal("proj-A", raw["project_id"])
+}
+
+func (s *TokenAdminSuite) TestRevokeCrossProjectStill200ButDoesNotRevoke() {
+    targetTok, targetJti := s.issueDeliveryToken("proj-A")
+    callerTok, _ := s.issueDeliveryToken("proj-B") // non-admin in another project
+
+    rr := s.postForm(s.app.RevokeHandler, "/revoke", callerTok, url.Values{"token": {targetTok}})
+    s.Equal(http.StatusOK, rr.Code, "RFC 7009 always-200, even when the project guard denies")
+
+    // The target was NOT revoked.
+    revoked, err := s.app.GetTokenService().IsRevoked(context.Background(), targetJti)
+    s.Require().NoError(err)
+    s.False(revoked, "cross-project /revoke must be a no-op")
+}
+
+func (s *TokenAdminSuite) TestRevokeSameProjectByNonAdminRevokes() {
+    targetTok, targetJti := s.issueDeliveryToken("proj-A")
+    callerTok, _ := s.issueDeliveryToken("proj-A")
+
+    rr := s.postForm(s.app.RevokeHandler, "/revoke", callerTok, url.Values{"token": {targetTok}})
+    s.Equal(http.StatusOK, rr.Code)
+    revoked, err := s.app.GetTokenService().IsRevoked(context.Background(), targetJti)
+    s.Require().NoError(err)
+    s.True(revoked, "same-project non-admin revoke takes effect")
+}
+
+func (s *TokenAdminSuite) TestDeleteTokenCrossProjectDeniedForNonAdmin() {
+    _, targetJti := s.issueDeliveryToken("proj-A")
+    callerTok, _ := s.issueDeliveryToken("proj-B")
+
+    rr := s.deleteToken(callerTok, targetJti)
+    s.Equal(http.StatusForbidden, rr.Code, "admin-by-identifier path returns 403 on cross-project")
+    revoked, err := s.app.GetTokenService().IsRevoked(context.Background(), targetJti)
+    s.Require().NoError(err)
+    s.False(revoked)
+}
+
+func (s *TokenAdminSuite) TestDeleteTokenAdminUnrestricted() {
+    _, targetJti := s.issueDeliveryToken("proj-A")
+    adminTok := s.issueAdminToken("proj-B")
+
+    rr := s.deleteToken(adminTok, targetJti)
+    s.Equal(http.StatusNoContent, rr.Code, "admin/root may revoke any project by identifier")
+    revoked, err := s.app.GetTokenService().IsRevoked(context.Background(), targetJti)
+    s.Require().NoError(err)
+    s.True(revoked)
+}
+
+func TestTokenAdminSuite(t *testing.T) {
+    suite.Run(t, new(TokenAdminSuite))
+}
+
+// muxSetVar attaches a mux route variable to a request, so handlers that read
+// mux.Vars(r) (e.g. DELETE /token/{jti}) can be driven directly in tests.
+func muxSetVar(r *http.Request, key, value string) *http.Request {
+    return mux.SetURLVars(r, map[string]string{key: value})
+}

--- a/internal/services/client_service.go
+++ b/internal/services/client_service.go
@@ -24,7 +24,10 @@ func NewClientService(clientDAO interfaces.ClientDAO, keyService *KeyService) *C
 	}
 }
 
-func (s *ClientService) RegisterClient(ctx context.Context, client model.SsfClient, projectID string) *model.RegisterResponse {
+// RegisterClient persists the client and mints its stream-client token. parentJTI
+// is the JTI of the IAT redeemed to register the client; it is threaded onto the
+// minted token as its lineage parent (ADR 0007). It may be empty.
+func (s *ClientService) RegisterClient(ctx context.Context, client model.SsfClient, projectID string, parentJTI string) *model.RegisterResponse {
 	err := s.clientDAO.Insert(ctx, &client)
 	if err != nil {
 		csLog.Error("Error registering client", "error", err)
@@ -36,7 +39,7 @@ func (s *ClientService) RegisterClient(ctx context.Context, client model.SsfClie
 	// handler's privilege ceiling, so admin is granted only when the client's
 	// AllowedScopes explicitly carry stream_admin (out-of-band provisioning).
 	admin := slices.Contains(client.AllowedScopes, authSupport.ScopeStreamAdmin)
-	token, err := s.keyService.GetAuthIssuer().IssueStreamClientToken(client, projectID, admin)
+	token, err := s.keyService.GetAuthIssuer().IssueStreamClientToken(client, projectID, admin, parentJTI)
 	if err != nil {
 		csLog.Error("Error issuing stream client token", "error", err)
 		return nil

--- a/internal/services/stream_service.go
+++ b/internal/services/stream_service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/i2-open/i2goSignals/internal/authUtil"
 	"github.com/i2-open/i2goSignals/internal/dao/interfaces"
 	"github.com/i2-open/i2goSignals/internal/envcompat"
+	"github.com/i2-open/i2goSignals/pkg/authSupport"
 	"github.com/i2-open/i2goSignals/pkg/goSet"
 	"github.com/i2-open/i2goSignals/pkg/httpSupport"
 	"github.com/i2-open/i2goSignals/pkg/logger"
@@ -297,9 +298,18 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamSt
 	}
 
 	isOAuth := false
+	// deliveryParent carries the lineage parent for any delivery (stream) token
+	// minted below: the stream-client token that authorized this CreateStream
+	// (ADR 0007). Passing it as the issuing session sets Parent without altering
+	// the delivery token's other claims (an empty-ID session leaves Parent empty).
+	var deliveryParent *authUtil.AuthContext
 	if ctx.Value("authCtx") != nil {
 		authCtx := ctx.Value("authCtx").(*authUtil.AuthContext)
 		isOAuth = authCtx.IsOAuthClient
+		if authCtx.Eat != nil {
+			deliveryParent = &authUtil.AuthContext{Eat: &authSupport.EventAuthToken{}}
+			deliveryParent.Eat.ID = authCtx.Eat.ID
+		}
 	}
 
 	config.Id = mid.Hex()
@@ -357,7 +367,7 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamSt
 	case model.DeliveryPoll, "DEFAULT":
 		authToken := ""
 		if !isOAuth {
-			authToken, err = authIssuer.IssueStreamToken(mid.Hex(), projectID, nil)
+			authToken, err = authIssuer.IssueStreamToken(mid.Hex(), projectID, deliveryParent)
 		}
 		if err != nil {
 			return model.StreamConfiguration{}, fmt.Errorf("failed to issue stream token: %v", err)
@@ -385,7 +395,7 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamSt
 		method := config.Delivery.PushReceiveMethod
 		method.EndpointUrl = s.getFullUrl(fmt.Sprintf("/events/%s", mid.Hex()))
 		if !isOAuth {
-			authToken, err := authIssuer.IssueStreamToken(mid.Hex(), projectID, nil)
+			authToken, err := authIssuer.IssueStreamToken(mid.Hex(), projectID, deliveryParent)
 			if err != nil {
 				return model.StreamConfiguration{}, fmt.Errorf("failed to issue stream token: %v", err)
 			}

--- a/internal/services/token_list_authority_test.go
+++ b/internal/services/token_list_authority_test.go
@@ -1,0 +1,165 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/i2-open/i2goSignals/internal/dao/interfaces"
+	"github.com/i2-open/i2goSignals/internal/dao/memory"
+	"github.com/i2-open/i2goSignals/pkg/authSupport"
+	"github.com/i2-open/i2goSignals/pkg/ssfModels"
+	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+type TokenListAuthorityTestSuite struct {
+	suite.Suite
+	service   *TokenService
+	streamDAO interfaces.StreamDAO
+}
+
+func (s *TokenListAuthorityTestSuite) SetupTest() {
+	tokenDAO := memory.NewTokenDAO()
+	streamDAO := memory.NewStreamDAO()
+	s.service = NewTokenService(tokenDAO)
+	s.service.SetStreamDAO(streamDAO)
+	s.streamDAO = streamDAO
+}
+
+func (s *TokenListAuthorityTestSuite) track(jti, projectID, clientID, tokenType, streamID string) {
+	claims := &authSupport.EventAuthToken{
+		ProjectId: projectID,
+		ClientId:  clientID,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        jti,
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	}
+	if streamID != "" {
+		claims.StreamIds = []string{streamID}
+	}
+	s.NoError(s.service.TrackToken(context.Background(), claims, "", tokenType))
+}
+
+func (s *TokenListAuthorityTestSuite) seedStream(hexID, projectID, ip string) {
+	oid, err := bson.ObjectIDFromHex(hexID)
+	s.NoError(err)
+	rec := &model.StreamStateRecord{
+		Id:        oid,
+		ProjectId: projectID,
+		RemoteAddress: &model.RemoteIP{
+			IP:       ip,
+			Protocol: "https",
+		},
+	}
+	rec.StreamConfiguration.Id = hexID
+	s.NoError(s.streamDAO.Create(context.Background(), rec))
+}
+
+func nonAdmin(projectID string) *authSupport.EventAuthToken {
+	return &authSupport.EventAuthToken{ProjectId: projectID, Roles: []string{authSupport.ScopeStreamMgmt}}
+}
+
+func (s *TokenListAuthorityTestSuite) TestNonAdminSeesOnlyOwnProject() {
+	ctx := context.Background()
+	s.track("j1", "p1", "c1", model.TokenTypeIAT, "")
+	s.track("j2", "p2", "c2", model.TokenTypeIAT, "")
+
+	rows, err := s.service.ListForAuthority(ctx, nonAdmin("p1"), TokenListFilters{})
+	s.NoError(err)
+	s.Len(rows, 1)
+	s.Equal("p1", rows[0].ProjectID)
+}
+
+func (s *TokenListAuthorityTestSuite) TestAdminSeesAllProjects() {
+	ctx := context.Background()
+	s.track("j1", "p1", "c1", model.TokenTypeIAT, "")
+	s.track("j2", "p2", "c2", model.TokenTypeIAT, "")
+
+	admin := &authSupport.EventAuthToken{ProjectId: "p1", Roles: []string{authSupport.ScopeStreamAdmin}}
+	rows, err := s.service.ListForAuthority(ctx, admin, TokenListFilters{})
+	s.NoError(err)
+	s.Len(rows, 2)
+}
+
+func (s *TokenListAuthorityTestSuite) TestRootSeesAllProjects() {
+	ctx := context.Background()
+	s.track("j1", "p1", "c1", model.TokenTypeIAT, "")
+	s.track("j2", "p2", "c2", model.TokenTypeIAT, "")
+
+	root := &authSupport.EventAuthToken{ProjectId: "", Roles: []string{authSupport.ScopeRoot}}
+	rows, err := s.service.ListForAuthority(ctx, root, TokenListFilters{})
+	s.NoError(err)
+	s.Len(rows, 2)
+}
+
+func (s *TokenListAuthorityTestSuite) TestTypeFilter() {
+	ctx := context.Background()
+	s.track("j1", "p1", "c1", model.TokenTypeIAT, "")
+	s.track("j2", "p1", "c1", model.TokenTypeStream, "")
+
+	iat := model.TokenTypeIAT
+	rows, err := s.service.ListForAuthority(ctx, nonAdmin("p1"), TokenListFilters{Type: iat})
+	s.NoError(err)
+	s.Len(rows, 1)
+	s.Equal("j1", rows[0].JTI)
+}
+
+func (s *TokenListAuthorityTestSuite) TestActiveFilter() {
+	ctx := context.Background()
+	s.track("active", "p1", "c1", model.TokenTypeIAT, "")
+	s.track("revoked", "p1", "c1", model.TokenTypeIAT, "")
+	s.NoError(s.service.RevokeToken(ctx, "revoked"))
+
+	yes := true
+	rows, err := s.service.ListForAuthority(ctx, nonAdmin("p1"), TokenListFilters{Active: &yes})
+	s.NoError(err)
+	s.Len(rows, 1)
+	s.Equal("active", rows[0].JTI)
+
+	no := false
+	rows, err = s.service.ListForAuthority(ctx, nonAdmin("p1"), TokenListFilters{Active: &no})
+	s.NoError(err)
+	s.Len(rows, 1)
+	s.Equal("revoked", rows[0].JTI)
+}
+
+func (s *TokenListAuthorityTestSuite) TestFiltersCompose() {
+	ctx := context.Background()
+	s.track("iat-active", "p1", "c1", model.TokenTypeIAT, "")
+	s.track("stream-active", "p1", "c1", model.TokenTypeStream, "")
+	s.track("iat-revoked", "p1", "c1", model.TokenTypeIAT, "")
+	s.NoError(s.service.RevokeToken(ctx, "iat-revoked"))
+
+	yes := true
+	rows, err := s.service.ListForAuthority(ctx, nonAdmin("p1"), TokenListFilters{Type: model.TokenTypeIAT, Active: &yes})
+	s.NoError(err)
+	s.Len(rows, 1)
+	s.Equal("iat-active", rows[0].JTI)
+}
+
+func (s *TokenListAuthorityTestSuite) TestStreamRowJoinsLastSeenIP() {
+	ctx := context.Background()
+	hexID := bson.NewObjectID().Hex()
+	s.seedStream(hexID, "p1", "203.0.113.7")
+	s.track("stream-tok", "p1", "c1", model.TokenTypeStream, hexID)
+	s.track("iat-tok", "p1", "c1", model.TokenTypeIAT, "")
+
+	rows, err := s.service.ListForAuthority(ctx, nonAdmin("p1"), TokenListFilters{})
+	s.NoError(err)
+	s.Len(rows, 2)
+
+	byJTI := map[string]*model.TokenListEntry{}
+	for _, r := range rows {
+		byJTI[r.JTI] = r
+	}
+	s.Equal("203.0.113.7", byJTI["stream-tok"].LastSeenIP, "stream row should join the stream's last-seen IP")
+	s.Equal("", byJTI["iat-tok"].LastSeenIP, "IAT row should have no joined IP")
+}
+
+func TestTokenListAuthoritySuite(t *testing.T) {
+	suite.Run(t, new(TokenListAuthorityTestSuite))
+}

--- a/internal/services/token_service.go
+++ b/internal/services/token_service.go
@@ -18,7 +18,7 @@ func NewTokenService(dao interfaces.TokenDAO) *TokenService {
 	return &TokenService{dao: dao}
 }
 
-func (s *TokenService) TrackToken(ctx context.Context, claims *authSupport.EventAuthToken, tokenPurpose string) error {
+func (s *TokenService) TrackToken(ctx context.Context, claims *authSupport.EventAuthToken, parent string, tokenPurpose string) error {
 	iat := time.Now()
 	if claims.IssuedAt != nil {
 		iat = claims.IssuedAt.Time
@@ -37,8 +37,15 @@ func (s *TokenService) TrackToken(ctx context.Context, claims *authSupport.Event
 		Scopes:    claims.Roles,
 		IssuedAt:  iat,
 		ExpiresAt: exp,
+		Parent:    parent,
 	}
 	return s.dao.Insert(ctx, record)
+}
+
+// RecordRedemption captures a token redemption (ADR 0007): it bumps the
+// redemption count and records the last-redemption IP and time.
+func (s *TokenService) RecordRedemption(ctx context.Context, jti string, ip string, at time.Time) error {
+	return s.dao.RecordRedemption(ctx, jti, ip, at)
 }
 
 func (s *TokenService) IsRevoked(ctx context.Context, jti string) (bool, error) {
@@ -81,7 +88,22 @@ func (s *TokenService) IntrospectToken(ctx context.Context, jti string) (*model.
 		Exp:       record.ExpiresAt.Unix(),
 		Iat:       record.IssuedAt.Unix(),
 		Jti:       record.JTI,
+
+		Parent:           record.Parent,
+		LastRedemptionIP: record.LastRedemptionIP,
+		RedemptionCount:  record.RedemptionCount,
+		LastRedemptionAt: redemptionUnix(record.LastRedemptionAt),
 	}, nil
+}
+
+// redemptionUnix returns the Unix timestamp for t, or 0 when t is the zero
+// time, so a never-redeemed token reports 0 (and is omitted) rather than a
+// large negative epoch.
+func redemptionUnix(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.Unix()
 }
 
 func (s *TokenService) ListByProject(ctx context.Context, projectID string) ([]*model.TokenRecord, error) {

--- a/internal/services/token_service.go
+++ b/internal/services/token_service.go
@@ -139,15 +139,24 @@ func (s *TokenService) IntrospectToken(ctx context.Context, jti string) (*model.
 		}
 		return nil, err
 	}
+	return IntrospectionFromRecord(record), nil
+}
+
+// IntrospectionFromRecord builds an RFC 7662 introspection response from an
+// already-fetched token record, avoiding a second store read on the introspect
+// path. A nil record (untracked/unknown JTI) yields active:false without
+// leaking existence.
+func IntrospectionFromRecord(record *model.TokenRecord) *model.IntrospectionResponse {
+	if record == nil {
+		return &model.IntrospectionResponse{Active: false}
+	}
 	scope := ""
 	if record.Scopes != nil {
 		scope = strings.Join(record.Scopes, ",")
 	}
 
-	active := record.RevokedAt.IsZero() && (record.ExpiresAt.IsZero() || record.ExpiresAt.After(time.Now()))
-
 	return &model.IntrospectionResponse{
-		Active:    active,
+		Active:    record.IsActive(),
 		ClientID:  record.ClientID,
 		Subject:   record.Subject,
 		Type:      record.Type,
@@ -161,7 +170,7 @@ func (s *TokenService) IntrospectToken(ctx context.Context, jti string) (*model.
 		LastRedemptionIP: record.LastRedemptionIP,
 		RedemptionCount:  record.RedemptionCount,
 		LastRedemptionAt: redemptionUnix(record.LastRedemptionAt),
-	}, nil
+	}
 }
 
 // redemptionUnix returns the Unix timestamp for t, or 0 when t is the zero
@@ -190,6 +199,13 @@ func (s *TokenService) ListByClient(ctx context.Context, clientID string) ([]*mo
 // token. The result is capped (cap-and-log) since there is no pagination here.
 func (s *TokenService) ListForAuthority(ctx context.Context, authCtx *authSupport.EventAuthToken, filters TokenListFilters) ([]*model.TokenListEntry, error) {
 	unrestricted, projectID := ProjectScope(authCtx)
+
+	// Fail closed: a confined caller with no resolved project (e.g. an OAuth
+	// client or a token carrying no ProjectId) must see nothing, rather than
+	// being scoped to the empty-project bucket via FindByProjectID("").
+	if !unrestricted && projectID == "" {
+		return []*model.TokenListEntry{}, nil
+	}
 
 	var records []*model.TokenRecord
 	var err error
@@ -260,8 +276,7 @@ func matchesFilters(rec *model.TokenRecord, filters TokenListFilters) bool {
 		return false
 	}
 	if filters.Active != nil {
-		active := rec.RevokedAt.IsZero() && (rec.ExpiresAt.IsZero() || rec.ExpiresAt.After(time.Now()))
-		if active != *filters.Active {
+		if rec.IsActive() != *filters.Active {
 			return false
 		}
 	}

--- a/internal/services/token_service.go
+++ b/internal/services/token_service.go
@@ -115,6 +115,22 @@ func (s *TokenService) RevokeToken(ctx context.Context, jti string) error {
 	return s.dao.Revoke(ctx, jti)
 }
 
+// FindByJTI returns the tracked token record for a JTI, or (nil, nil) when no
+// record is tracked. It is used by the single-token project guard to read the
+// target token's project before authorizing a revoke/introspect. A
+// not-found-by-JTI is a non-error (nil record) so callers can apply RFC 7009
+// always-200 semantics without leaking existence.
+func (s *TokenService) FindByJTI(ctx context.Context, jti string) (*model.TokenRecord, error) {
+	record, err := s.dao.FindByJTI(ctx, jti)
+	if err != nil {
+		if err.Error() == "token not found" {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return record, nil
+}
+
 func (s *TokenService) IntrospectToken(ctx context.Context, jti string) (*model.IntrospectionResponse, error) {
 	record, err := s.dao.FindByJTI(ctx, jti)
 	if err != nil {

--- a/internal/services/token_service.go
+++ b/internal/services/token_service.go
@@ -7,15 +7,58 @@ import (
 
 	"github.com/i2-open/i2goSignals/internal/dao/interfaces"
 	"github.com/i2-open/i2goSignals/pkg/authSupport"
+	"github.com/i2-open/i2goSignals/pkg/logger"
 	"github.com/i2-open/i2goSignals/pkg/ssfModels"
 )
 
+var tokenLog = logger.Sub("TOKEN_SVC")
+
+// tokenListCap bounds the caller-scoped list to avoid unbounded responses.
+// There is no pagination in this slice; if the cap is hit, the overflow is
+// dropped and logged (cap-and-log, never a silent truncation).
+const tokenListCap = 1000
+
 type TokenService struct {
-	dao interfaces.TokenDAO
+	dao       interfaces.TokenDAO
+	streamDAO interfaces.StreamDAO
 }
 
 func NewTokenService(dao interfaces.TokenDAO) *TokenService {
 	return &TokenService{dao: dao}
+}
+
+// SetStreamDAO supplies the stream store used to join the last-seen IP onto
+// STREAM-typed token rows. When unset, stream rows simply omit LastSeenIP.
+func (s *TokenService) SetStreamDAO(dao interfaces.StreamDAO) {
+	s.streamDAO = dao
+}
+
+// TokenListFilters are the optional, composable filters for the caller-scoped
+// token list. An empty filter matches everything in scope.
+type TokenListFilters struct {
+	// Type filters by token purpose (model.TokenTypeIAT or TokenTypeStream).
+	// Empty means all types.
+	Type string
+	// Active, when set, filters by liveness: true keeps non-revoked,
+	// non-expired tokens; false keeps revoked-or-expired tokens.
+	Active *bool
+}
+
+// ProjectScope derives the project visibility for a caller from its
+// AuthContext, never from a client-supplied query parameter. admin/root
+// callers are unrestricted (see all projects); every other caller is confined
+// to its own AuthContext.ProjectId. This is the shared scoping derivation that
+// the single-token endpoints (revoke/introspect) reuse.
+//
+// Returns (unrestricted, confinedProjectID).
+func ProjectScope(authCtx *authSupport.EventAuthToken) (bool, string) {
+	if authCtx == nil {
+		return false, ""
+	}
+	if authCtx.IsScopeMatch([]string{authSupport.ScopeRoot, authSupport.ScopeStreamAdmin}) {
+		return true, ""
+	}
+	return false, authCtx.ProjectId
 }
 
 func (s *TokenService) TrackToken(ctx context.Context, claims *authSupport.EventAuthToken, parent string, tokenPurpose string) error {
@@ -28,6 +71,14 @@ func (s *TokenService) TrackToken(ctx context.Context, claims *authSupport.Event
 		exp = claims.ExpiresAt.Time
 	}
 
+	// For STREAM-typed tokens, capture the stream id (join key) so the list
+	// endpoint can later read the stream's live RemoteAddress. The IP itself is
+	// never copied onto the token record.
+	streamID := ""
+	if tokenPurpose == model.TokenTypeStream && len(claims.StreamIds) > 0 {
+		streamID = claims.StreamIds[0]
+	}
+
 	record := &model.TokenRecord{
 		JTI:       claims.ID,
 		ClientID:  claims.ClientId,
@@ -38,6 +89,7 @@ func (s *TokenService) TrackToken(ctx context.Context, claims *authSupport.Event
 		IssuedAt:  iat,
 		ExpiresAt: exp,
 		Parent:    parent,
+		StreamID:  streamID,
 	}
 	return s.dao.Insert(ctx, record)
 }
@@ -112,4 +164,90 @@ func (s *TokenService) ListByProject(ctx context.Context, projectID string) ([]*
 
 func (s *TokenService) ListByClient(ctx context.Context, clientID string) ([]*model.TokenRecord, error) {
 	return s.dao.FindByClientID(ctx, clientID)
+}
+
+// ListForAuthority returns an enriched, caller-scoped token inventory. Project
+// scope is derived from the AuthContext (admin/root see all; others see only
+// their own project) via ProjectScope — never from a client-supplied query
+// param. The type and active filters compose. STREAM-typed rows are joined to
+// the stream's live RemoteAddress (last-seen IP); the IP is not stored on the
+// token. The result is capped (cap-and-log) since there is no pagination here.
+func (s *TokenService) ListForAuthority(ctx context.Context, authCtx *authSupport.EventAuthToken, filters TokenListFilters) ([]*model.TokenListEntry, error) {
+	unrestricted, projectID := ProjectScope(authCtx)
+
+	var records []*model.TokenRecord
+	var err error
+	if unrestricted {
+		records, err = s.dao.FindAll(ctx)
+	} else {
+		records, err = s.dao.FindByProjectID(ctx, projectID)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	ipByStream := s.streamIPIndex(ctx, unrestricted, projectID)
+
+	entries := make([]*model.TokenListEntry, 0, len(records))
+	for _, rec := range records {
+		if !matchesFilters(rec, filters) {
+			continue
+		}
+		entry := &model.TokenListEntry{TokenRecord: rec}
+		if rec.Type == model.TokenTypeStream && rec.StreamID != "" {
+			entry.LastSeenIP = ipByStream[rec.StreamID]
+		}
+		entries = append(entries, entry)
+		if len(entries) >= tokenListCap {
+			break
+		}
+	}
+
+	if len(records) > len(entries) && len(entries) >= tokenListCap {
+		tokenLog.Warn("Token list capped; results truncated (no pagination)",
+			"cap", tokenListCap, "matched_or_more", len(records), "returned", len(entries))
+	}
+
+	return entries, nil
+}
+
+// streamIPIndex builds a stream-id -> last-seen-IP lookup for the streams in
+// scope. Returns an empty map when no stream store is wired.
+func (s *TokenService) streamIPIndex(ctx context.Context, unrestricted bool, projectID string) map[string]string {
+	index := map[string]string{}
+	if s.streamDAO == nil {
+		return index
+	}
+	var streams []model.StreamStateRecord
+	var err error
+	if unrestricted {
+		streams, err = s.streamDAO.List(ctx)
+	} else {
+		streams, err = s.streamDAO.FindByProjectID(ctx, projectID)
+	}
+	if err != nil {
+		tokenLog.Warn("Could not load streams for last-seen IP join", "error", err)
+		return index
+	}
+	for i := range streams {
+		st := streams[i]
+		if st.RemoteAddress != nil && st.RemoteAddress.IP != "" {
+			index[st.StreamConfiguration.Id] = st.RemoteAddress.IP
+		}
+	}
+	return index
+}
+
+// matchesFilters reports whether a record satisfies the (composed) filters.
+func matchesFilters(rec *model.TokenRecord, filters TokenListFilters) bool {
+	if filters.Type != "" && rec.Type != filters.Type {
+		return false
+	}
+	if filters.Active != nil {
+		active := rec.RevokedAt.IsZero() && (rec.ExpiresAt.IsZero() || rec.ExpiresAt.After(time.Now()))
+		if active != *filters.Active {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/services/token_service_test.go
+++ b/internal/services/token_service_test.go
@@ -36,7 +36,7 @@ func (s *TokenServiceTestSuite) TestTokenLifecycle() {
 	}
 
 	// 1. Track
-	err := s.service.TrackToken(ctx, claims, model.TokenTypeStream)
+	err := s.service.TrackToken(ctx, claims, "", model.TokenTypeStream)
 	s.NoError(err)
 
 	// 2. IsRevoked (should be false)
@@ -74,17 +74,17 @@ func (s *TokenServiceTestSuite) TestListByProjectAndClient() {
 		ProjectId:        "p1",
 		ClientId:         "c1",
 		RegisteredClaims: jwt.RegisteredClaims{ID: "j1"},
-	}, model.TokenTypeStream)
+	}, "", model.TokenTypeStream)
 	_ = s.service.TrackToken(ctx, &authSupport.EventAuthToken{
 		ProjectId:        "p1",
 		ClientId:         "c2",
 		RegisteredClaims: jwt.RegisteredClaims{ID: "j2"},
-	}, model.TokenTypeStream)
+	}, "", model.TokenTypeStream)
 	_ = s.service.TrackToken(ctx, &authSupport.EventAuthToken{
 		ProjectId:        "p2",
 		ClientId:         "c1",
 		RegisteredClaims: jwt.RegisteredClaims{ID: "j3"},
-	}, model.TokenTypeStream)
+	}, "", model.TokenTypeStream)
 
 	// List by Project p1
 	tokens, err := s.service.ListByProject(ctx, "p1")
@@ -95,6 +95,26 @@ func (s *TokenServiceTestSuite) TestListByProjectAndClient() {
 	tokens, err = s.service.ListByClient(ctx, "c1")
 	s.NoError(err)
 	s.Len(tokens, 2)
+}
+
+func (s *TokenServiceTestSuite) TestRecordRedemption() {
+	ctx := context.Background()
+	jti := "iat-redeem"
+	err := s.service.TrackToken(ctx, &authSupport.EventAuthToken{
+		ProjectId:        "p1",
+		RegisteredClaims: jwt.RegisteredClaims{ID: jti},
+	}, "", model.TokenTypeIAT)
+	s.NoError(err)
+
+	at := time.Now().UTC()
+	err = s.service.RecordRedemption(ctx, jti, "192.0.2.10", at)
+	s.NoError(err)
+
+	rec, err := s.service.dao.FindByJTI(ctx, jti)
+	s.NoError(err)
+	s.Equal(int64(1), rec.RedemptionCount)
+	s.Equal("192.0.2.10", rec.LastRedemptionIP)
+	s.WithinDuration(at, rec.LastRedemptionAt, time.Second)
 }
 
 func TestTokenServiceSuite(t *testing.T) {

--- a/pkg/authSupport/auth_token.go
+++ b/pkg/authSupport/auth_token.go
@@ -9,7 +9,7 @@ import (
 
 // TokenTracker is an interface for tracking and checking token revocation.
 type TokenTracker interface {
-	TrackToken(ctx context.Context, claims *EventAuthToken, tokenPurpose string) error
+	TrackToken(ctx context.Context, claims *EventAuthToken, parent string, tokenPurpose string) error
 	IsRevoked(ctx context.Context, jti string) (bool, error)
 }
 

--- a/pkg/ssfModels/model_token.go
+++ b/pkg/ssfModels/model_token.go
@@ -16,6 +16,13 @@ type TokenRecord struct {
 	ExpiresAt time.Time `bson:"exp" json:"exp"`
 	RevokedAt time.Time `bson:"revoked_at,omitzero" json:"revoked_at,omitzero"`
 	Parent    string    `bson:"parent" json:"parent,omitempty"`
+
+	// Provenance: redemption tracking (ADR 0007 — track redemption, not
+	// issuance). LastRedemptionIP/At record where and when the token was last
+	// used (a /register call for an IAT); RedemptionCount is the running tally.
+	LastRedemptionIP string    `bson:"last_redemption_ip,omitzero" json:"last_redemption_ip,omitempty"`
+	LastRedemptionAt time.Time `bson:"last_redemption_at,omitzero" json:"last_redemption_at,omitzero"`
+	RedemptionCount  int64     `bson:"redemption_count,omitzero" json:"redemption_count,omitempty"`
 }
 
 // IntrospectionResponse implements RFC7662 response format.
@@ -29,6 +36,12 @@ type IntrospectionResponse struct {
 	Exp       int64  `json:"exp,omitzero"`
 	Iat       int64  `json:"iat,omitzero"`
 	Jti       string `json:"jti"`
+
+	// Provenance (ADR 0007) surfaced for audit display.
+	Parent           string `json:"parent,omitempty"`
+	LastRedemptionIP string `json:"last_redemption_ip,omitempty"`
+	LastRedemptionAt int64  `json:"last_redemption_at,omitzero"`
+	RedemptionCount  int64  `json:"redemption_count,omitzero"`
 }
 
 const (

--- a/pkg/ssfModels/model_token.go
+++ b/pkg/ssfModels/model_token.go
@@ -61,6 +61,26 @@ type TokenListEntry struct {
 	LastSeenIP string `json:"last_seen_ip,omitempty"`
 }
 
+// IsActive reports whether the token is currently live: neither revoked nor
+// expired. This is the single source of truth for token liveness, shared by
+// introspection, the list filter, and the CLI, so the three cannot diverge.
+func (r TokenRecord) IsActive() bool {
+	return r.RevokedAt.IsZero() && (r.ExpiresAt.IsZero() || r.ExpiresAt.After(time.Now()))
+}
+
+// State returns the human-readable lifecycle state of the token: "revoked"
+// (RevokedAt set, taking precedence), "expired" (ExpiresAt in the past), else
+// "active". Consistent with IsActive.
+func (r TokenRecord) State() string {
+	if !r.RevokedAt.IsZero() {
+		return "revoked"
+	}
+	if !r.ExpiresAt.IsZero() && r.ExpiresAt.Before(time.Now()) {
+		return "expired"
+	}
+	return "active"
+}
+
 const (
 	TokenTypeIAT    = "IAT"
 	TokenTypeStream = "STREAM"

--- a/pkg/ssfModels/model_token.go
+++ b/pkg/ssfModels/model_token.go
@@ -33,7 +33,7 @@ type TokenRecord struct {
 // IntrospectionResponse implements RFC7662 response format.
 type IntrospectionResponse struct {
 	Active    bool   `json:"active"`
-	Type      string `json:"type"` // one of TokenTypeIAT or TokenTypeStream
+	Type      string `json:"token_type,omitzero"` // RFC 7662 token_type; one of TokenTypeIAT or TokenTypeStream
 	ProjectID string `json:"project_id,omitzero"`
 	ClientID  string `json:"client_id,omitzero"`
 	Subject   string `json:"subject,omitzero"`

--- a/pkg/ssfModels/model_token.go
+++ b/pkg/ssfModels/model_token.go
@@ -17,6 +17,11 @@ type TokenRecord struct {
 	RevokedAt time.Time `bson:"revoked_at,omitzero" json:"revoked_at,omitzero"`
 	Parent    string    `bson:"parent" json:"parent,omitempty"`
 
+	// StreamID links a STREAM-typed token to the stream it authorizes (the
+	// stream's hex id). It is a join key only — the last-seen IP is NOT copied
+	// here; it is read live from the stream's RemoteAddress when listing.
+	StreamID string `bson:"stream_id,omitzero" json:"stream_id,omitempty"`
+
 	// Provenance: redemption tracking (ADR 0007 — track redemption, not
 	// issuance). LastRedemptionIP/At record where and when the token was last
 	// used (a /register call for an IAT); RedemptionCount is the running tally.
@@ -42,6 +47,18 @@ type IntrospectionResponse struct {
 	LastRedemptionIP string `json:"last_redemption_ip,omitempty"`
 	LastRedemptionAt int64  `json:"last_redemption_at,omitzero"`
 	RedemptionCount  int64  `json:"redemption_count,omitzero"`
+}
+
+// TokenListEntry is an enriched, caller-scoped row returned by GET /token. It
+// embeds the stored TokenRecord (provenance + lineage included) and adds the
+// live last-seen IP joined from the stream's RemoteAddress for STREAM-typed
+// tokens (never stored a second time on the token).
+type TokenListEntry struct {
+	*TokenRecord `bson:",inline"`
+
+	// LastSeenIP is the stream's most recent RemoteAddress, joined at list time
+	// for STREAM-typed rows. Empty for IAT tokens or when no address is known.
+	LastSeenIP string `json:"last_seen_ip,omitempty"`
 }
 
 const (


### PR DESCRIPTION
## Summary

Completes and hardens the management-plane token APIs (PRD #128) so the CLI and
the GoSignalsAdmin console can **list**, **introspect** (RFC 7662), and
**revoke** (RFC 7009) the tokens a goSignals server issues — Initial Access
Tokens (IATs) and stream tokens — while expired records age out automatically.

Largely a complete-and-harden effort over the existing endpoints, model,
service, DAOs, and CLI. Decisions recorded in **ADR 0007** (track redemption,
not issuance) and **ADR 0008** (two revocation endpoints).

Closes #128. Implements #129, #130, #131, #132, #133.

## What changed (by slice)

| Slice | Issue | Change |
|-------|-------|--------|
| 1 | #129 | CLI `token list/introspect/revoke` authenticate via `serverBearer` (was a direct `ClientToken` header); `token list` renders a human table by default; all three accept `--json`. |
| 2 | #130 | `TokenRecord` gains `last_redemption_ip`/`last_redemption_at`/`redemption_count` (no issuance-IP, per ADR 0007); `RecordRedemption` DAO write in both Mongo + memory adapters with `factory_test` parity; `Parent` lineage populated at the IAT → stream-client → delivery-token mint sites; best-effort IAT redemption capture at `/register` (WARN on failure, never blocks registration). |
| 3 | #132 | `GET /token` becomes caller-scoped and enriched via `ListForAuthority` — project scope derived from `AuthContext` (never a query param), `admin`/`root` see all, others see only their own; `type=IAT\|STREAM` and `active=true\|false` filters compose; stream rows join the last-seen IP from the stream's existing `RemoteIP`; rows carry redemption fields + `Parent`. Introduces the reusable `ProjectScope` guard. |
| 4 | #133 | RFC 7009 `POST /revoke` (form `token` + tolerated `token_type_hint`, revokes by JTI parsed from the JWT, **always HTTP 200** so existence is never leaked); RFC 7662 field-name conformance on `/introspect` (`type` → `token_type`); the shared project guard applied across `/revoke`, `/introspect`, and `DELETE /token/{jti}`. |
| 5 | #131 | MongoDB TTL index on the token `exp` field with `expireAfterSeconds = I2SIG_TOKEN_RETENTION` (default 30 days), created at startup and adjusted in place via `collMod` (no migration). Mongo-only; documented in `docs/configuration_properties.md`. |

## Authorization rule

One consistent rule across `/revoke`, `DELETE /token/{jti}`, `/introspect`, and
`GET /token`: a non-admin caller is confined to `AuthContext.ProjectId`;
`admin`/`root` are unrestricted.

## Post-review fixes

A high-effort `/code-review` pass over the integrated diff surfaced six findings,
all addressed in follow-up commits on this branch:

| # | Severity | Fix |
|---|----------|-----|
| 1 | correctness | CLI `token list` decoded a `usage_ip` field the server never emits, so the **USAGE IP column was always blank**. The CLI now decodes `last_seen_ip` and derives the usage IP (stream last-seen IP, falling back to the IAT's last-redemption IP). |
| 2 | security | A confined caller with **no resolved project** (e.g. an OAuth client, or a token carrying no `ProjectId`) was scoped to the empty-project bucket via `FindByProjectID("")`/`callerMayActOnProject(…, "")` — listing/introspecting/revoking every project-less token. Both paths now **fail closed**: an empty project grants access to nothing. |
| 3 | efficiency | `/introspect` read the token record **twice** (project guard, then re-query). The handler now builds the response from the record already fetched via `IntrospectionFromRecord` — one DAO read. |
| 4 | maintainability | Token liveness/state was derived **three independent ways** (CLI, introspection, list filter). Consolidated into `TokenRecord.IsActive()` / `State()` as the single source of truth. |
| 5 | efficiency | The token TTL index was re-reconciled (a `ListSpecifications` round-trip) on **every Mongo reconnect**. Now reconciled at most **once per process** (the desired retention is fixed for the process lifetime), with the guard reset on a fresh DB so `ResetDb`/first-connect still create the index. |
| 6 | robustness | `tokenRetentionSeconds` cast `I2SIG_TOKEN_RETENTION` toward Mongo's int32 `expireAfterSeconds` before its range check, so an oversized value could **wrap to a negative TTL**. The bounds (`0..math.MaxInt32`) are now checked before narrowing. |

Remaining review candidates were verified and refuted during the review (e.g. the
introspect-unknown-token path already returns `active:false`, not a 500).

## Testing

- `go build ./...` — clean.
- `go vet ./...` — no new warnings (only the pre-existing ones documented in `CLAUDE.md`).
- `go test ./...` — **green** (35 packages, 0 failures). Mongo-dependent DAO-parity and TTL-index tests ran against a live replica set, not skipped.
- New behavioral coverage: CLI table/JSON rendering + session auth; `RecordRedemption` + lineage + provider parity; `ListForAuthority` scoping/filters/last-seen-IP join; `/revoke` always-200 semantics + RFC 7662 field names + cross-project guard; TTL index `expireAfterSeconds` asserted via index metadata (the `collMod` adjust path **and** the once-per-process guard), not by waiting on Mongo's reaper.

## Out of scope (per PRD)

Max-uses/redeem-once policy, IAT-to-IP-mask restriction, full per-redemption
audit trail, TTL for the memory provider, list pagination, the GoSignalsAdmin
console UI (tracked as i2goSignalsAdmin#129), and storing the token string.

## Review notes

Each slice was implemented TDD-first in an isolated worktree and fast-forward
merged in dependency order (#129 → #130 → #132 → #133 → #131). Per-slice issues
are labeled `ready-for-review`. The post-review fixes above were committed
directly to the branch after slice integration.
