### PR TITLE
Token lifecycle, authz, CLI & SSF fixes (batch incl. #140)

### DIFF
--- a/DECISIONS_LOG.md
+++ b/DECISIONS_LOG.md
@@ -1242,6 +1242,10 @@ plannedChange, add, graceSeconds)`, returns one of three decisions:
     elapsed), matching the slice #99 `entryDelivers` boundary, so the local
     delivery decision and the sweep both flip on the same tick.
 
+## [2026-05-31] Foreign-server provisioning requires admin scope (#139)
+
+`/server` CRUD is admin-only (drop `reg`); `POST /stream` with `tx_alias` requires `admin` (`root` free) while a plain create stays at `stream`; the CLI fails fast offline and translates 401/403 into actionable admin-scope guidance. `/server` stays separate from `/stream`. See ADR 0009.
+
 ---
 
 <!-- gosignals-brand-footer -->

--- a/cmd/goSignals/bearer_test.go
+++ b/cmd/goSignals/bearer_test.go
@@ -93,3 +93,79 @@ func TestResolveBearer_NoSessionInstructsLogin(t *testing.T) {
         t.Errorf("expected errReloginRequired when no session, got %v", err)
     }
 }
+
+// TestSession_ZeroExpiryIsExpired guards GH #142: an IdP that omits expires_in
+// yields a zero Expiry. A zero Expiry means "expiry unknown", which must be
+// treated as needing a refresh (Expired() == true), not as never-expiring.
+func TestSession_ZeroExpiryIsExpired(t *testing.T) {
+    sess := &Session{AccessToken: "at", RefreshToken: "rt"}
+    if !sess.Expiry.IsZero() {
+        t.Fatalf("test precondition: expected a zero Expiry")
+    }
+    if !sess.Expired() {
+        t.Errorf("a session with a zero (unknown) Expiry should report Expired()==true so it refreshes")
+    }
+}
+
+// TestResolveBearer_ZeroExpiryRefreshesWhenRefreshTokenPresent guards GH #142:
+// when the session lacks a known expiry but has a refresh token, resolve() must
+// attempt a refresh_token grant rather than presenting the stale access token.
+func TestResolveBearer_ZeroExpiryRefreshesWhenRefreshTokenPresent(t *testing.T) {
+    refreshed := false
+    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        _ = r.ParseForm()
+        if r.Form.Get("grant_type") != "refresh_token" || r.Form.Get("refresh_token") != "rt-live" {
+            w.WriteHeader(http.StatusBadRequest)
+            return
+        }
+        refreshed = true
+        w.Header().Set("Content-Type", "application/json")
+        _, _ = w.Write([]byte(`{"access_token":"fresh-token","refresh_token":"rt-new","expires_in":3600,"token_type":"Bearer"}`))
+    }))
+    defer ts.Close()
+
+    store := &CredentialStore{Path: filepath.Join(t.TempDir(), "credentials.json")}
+    store.Set("https://idp.example.com", &Session{
+        AccessToken:  "stale-no-expiry",
+        RefreshToken: "rt-live",
+        // No Expiry set -> zero value -> expiry unknown.
+        ClientId: "gosignals-cli",
+    })
+
+    br := &bearerResolver{store: store, tokenEndpoint: func(string) (string, error) { return ts.URL, nil }}
+    tok, err := br.resolve("https://idp.example.com")
+    if err != nil {
+        t.Fatalf("resolve with zero-expiry + refresh token should refresh, got error: %v", err)
+    }
+    if !refreshed {
+        t.Errorf("expected a refresh_token grant to be attempted for a zero-expiry session")
+    }
+    if tok != "fresh-token" {
+        t.Errorf("expected refreshed access token, got %q", tok)
+    }
+}
+
+// TestResolveBearer_ZeroExpiryNoRefreshTokenInstructsRelogin guards GH #142
+// against a refresh storm: a session with no known expiry AND no refresh token
+// must surface the relogin-required path rather than loop or silently present a
+// stale token forever.
+func TestResolveBearer_ZeroExpiryNoRefreshTokenInstructsRelogin(t *testing.T) {
+    store := &CredentialStore{Path: filepath.Join(t.TempDir(), "credentials.json")}
+    store.Set("https://idp.example.com", &Session{
+        AccessToken: "stale-no-expiry",
+        // No RefreshToken, no Expiry.
+    })
+
+    endpointCalled := false
+    br := &bearerResolver{store: store, tokenEndpoint: func(string) (string, error) {
+        endpointCalled = true
+        return "", nil
+    }}
+    _, err := br.resolve("https://idp.example.com")
+    if !errors.Is(err, errReloginRequired) {
+        t.Errorf("expected errReloginRequired for a zero-expiry session with no refresh token, got %v", err)
+    }
+    if endpointCalled {
+        t.Errorf("must not attempt a refresh (no refresh token); should fall through to relogin")
+    }
+}

--- a/cmd/goSignals/commands.go
+++ b/cmd/goSignals/commands.go
@@ -1464,7 +1464,13 @@ func (d *DeleteStreamCmd) Run(cli *CLI) error {
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Authorization", "Bearer "+server.ClientToken)
+	bearer, err := serverBearer(&cli.Globals, server)
+	if err != nil {
+		return err
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
 	resp, err := client.Do(req)
 	defer httpSupport.HandleRespClose(resp)
 	if err != nil {
@@ -1556,7 +1562,13 @@ func (s *SetStreamConfigCmd) Run(cli *CLI) error {
 		if err != nil {
 			return err
 		}
-		req.Header.Set("Authorization", "Bearer "+server.ClientToken)
+		bearer, err := serverBearer(&cli.Globals, server)
+		if err != nil {
+			return err
+		}
+		if bearer != "" {
+			req.Header.Set("Authorization", "Bearer "+bearer)
+		}
 		client := http.Client{}
 		resp, err := client.Do(req)
 		defer httpSupport.HandleRespClose(resp)
@@ -1623,8 +1635,12 @@ func (s *SetStreamStatusCmd) Run(cli *CLI) error {
 	if err != nil {
 		return err
 	}
-	if server.ClientToken != "" {
-		req.Header.Set("Authorization", "Bearer "+server.ClientToken)
+	bearer, err := serverBearer(&cli.Globals, server)
+	if err != nil {
+		return err
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
 	} else {
 		fmt.Println(fmt.Sprintf("No client admin token for %s, attempting anonymous request.", server.Alias))
 	}
@@ -2249,7 +2265,7 @@ var errSubjectFilteringDisabled = errors.New("subject filtering is disabled on t
 
 // fetchSubjectFilterSettings issues a settings-only POST to the admin review
 // endpoint (no subject body field) and decodes the policy bits.
-func fetchSubjectFilterSettings(server *SsfServer, streamId string) (*subjectFilterReviewWire, error) {
+func fetchSubjectFilterSettings(g *Globals, server *SsfServer, streamId string) (*subjectFilterReviewWire, error) {
 	reqBody, err := json.Marshal(map[string]any{"stream_id": streamId})
 	if err != nil {
 		return nil, err
@@ -2262,7 +2278,13 @@ func fetchSubjectFilterSettings(server *SsfServer, streamId string) (*subjectFil
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+server.ClientToken)
+	bearer, err := serverBearer(g, server)
+	if err != nil {
+		return nil, err
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
 	req.Header.Set("Content-Type", "application/json")
 	client := getHttpClient(0)
 	defer client.CloseIdleConnections()
@@ -2350,7 +2372,7 @@ type subjectFilterStatusLookup struct {
 // decodes the filter-table state. When subject is non-nil it rides in the body
 // so the response carries a point-lookup result; otherwise the request is
 // summary-only (counts + pending list).
-func fetchSubjectFilterStatus(server *SsfServer, streamId string, subject *goSet.SubjectIdentifier) (*subjectFilterStatusWire, error) {
+func fetchSubjectFilterStatus(g *Globals, server *SsfServer, streamId string, subject *goSet.SubjectIdentifier) (*subjectFilterStatusWire, error) {
 	body := map[string]any{"stream_id": streamId}
 	if subject != nil {
 		body["subject"] = subject
@@ -2367,7 +2389,13 @@ func fetchSubjectFilterStatus(server *SsfServer, streamId string, subject *goSet
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+server.ClientToken)
+	bearer, err := serverBearer(g, server)
+	if err != nil {
+		return nil, err
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
 	req.Header.Set("Content-Type", "application/json")
 	client := getHttpClient(0)
 	defer client.CloseIdleConnections()
@@ -2460,7 +2488,7 @@ func (g *GetSubjectFilterConfigCmd) Run(cli *CLI) error {
 	if stream == nil {
 		return errors.New("Could not locate locally defined stream alias: " + alias)
 	}
-	wire, err := fetchSubjectFilterSettings(server, stream.Id)
+	wire, err := fetchSubjectFilterSettings(&cli.Globals, server, stream.Id)
 	if err != nil {
 		// A 404 means subject filtering is switched off server-wide; surface a
 		// plain operator message rather than a raw HTTP status.
@@ -2540,7 +2568,7 @@ func (g *GetSubjectFilterStatusCmd) Run(cli *CLI) error {
 		return err
 	}
 
-	review, err := fetchSubjectFilterStatus(server, stream.Id, subject)
+	review, err := fetchSubjectFilterStatus(&cli.Globals, server, stream.Id, subject)
 	if err != nil {
 		// A 404 means subject filtering is switched off server-wide; surface a
 		// plain operator message rather than a raw HTTP status.
@@ -2652,7 +2680,13 @@ func (s *SetSubjectFilterConfigCmd) Run(cli *CLI) error {
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Authorization", "Bearer "+server.ClientToken)
+	bearer, err := serverBearer(&cli.Globals, server)
+	if err != nil {
+		return err
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
 	req.Header.Set("Content-Type", "application/json")
 	client := getHttpClient(0)
 	defer client.CloseIdleConnections()
@@ -2673,7 +2707,7 @@ func (s *SetSubjectFilterConfigCmd) Run(cli *CLI) error {
 	// Read back the post-update settings so the operator sees what actually
 	// landed. This surfaces the server's WARN/ignore behavior for a grace
 	// override set on a receiver stream — the persisted value comes back as 0.
-	wire, err := fetchSubjectFilterSettings(server, stream.Id)
+	wire, err := fetchSubjectFilterSettings(&cli.Globals, server, stream.Id)
 	if err != nil {
 		// A 404 means subject filtering is switched off server-wide; surface a
 		// plain operator message rather than a raw HTTP status.
@@ -2737,7 +2771,13 @@ func changeSubjectFilter(cli *CLI, alias, jsonArg string, flags subjectArgFlags,
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Authorization", "Bearer "+server.ClientToken)
+	bearer, err := serverBearer(&cli.Globals, server)
+	if err != nil {
+		return err
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
 	req.Header.Set("Content-Type", "application/json")
 
 	client := getHttpClient(0)

--- a/cmd/goSignals/commands.go
+++ b/cmd/goSignals/commands.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 
 	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/i2-open/i2goSignals/pkg/authSupport"
 	"github.com/i2-open/i2goSignals/pkg/goScim/resource"
 	"github.com/i2-open/i2goSignals/pkg/httpSupport"
 	"github.com/i2-open/i2goSignals/pkg/ssfModels"
@@ -328,7 +329,7 @@ type CreatePollReceiverCmd struct {
 	EventUrl string `short:"e" group:"man" help:"The event publishers polling endpoint URL. Required unless Connect specified."`
 	Auth     string `group:"man" help:"An authorization header used to poll for events. Required unless Connect specified"`
 	Connect  string `short:"c" group:"auto" xor:"man,auto" help:"The Alias of a stream which is publishing events using polling"`
-	TxAlias  string `help:"Alias of a configured foreign SSF transmitter (e.g. 'add server --client-id'). The transmitter is registered on the node and the server-side TxAlias auto-registration path discovers and wires its poll endpoint."`
+	TxAlias  string `help:"Alias of a configured foreign SSF transmitter (e.g. 'add server --client-id'). Requires an ADMIN credential (not the IAT): the transmitter is registered on the node and the server-side TxAlias auto-registration path discovers and wires its poll endpoint."`
 	Secret   string `help:"OAuth client secret for the tx-alias transmitter (non-interactive); resolved as staged->flag->env"`
 	Mode     string `optional:"" default:"IMPORT" enum:"IMPORT,FORWARD,PUBLISH,I,F,P" help:"What should the receiver to with received events"`
 }
@@ -825,6 +826,14 @@ func (cli *CLI) registerTxAliasServer(node *SsfServer, alias, flagSecret, envVar
     if err != nil {
         return err
     }
+    // Proactive fail-fast (#139): registering a foreign transmitter requires
+    // admin scope. When the resolved credential decodes to a goSignals
+    // ClientToken whose scopes lack admin/root, short-circuit BEFORE the network
+    // call with an actionable message. If the credential cannot be classified
+    // locally (opaque/IdP token), degrade gracefully and fall through.
+    if known, hasAdmin := clientTokenHasAdminScope(bearer); known && !hasAdmin {
+        return errTxAliasAdminRequired
+    }
     if bearer != "" {
         req.Header.Set("Authorization", "Bearer "+bearer)
     }
@@ -843,10 +852,41 @@ func (cli *CLI) registerTxAliasServer(node *SsfServer, alias, flagSecret, envVar
         // Transmitter already registered on this node — proceed.
         fmt.Printf("Transmitter '%s' already registered on %s (409); proceeding.\n", alias, node.Alias)
         return nil
+    case http.StatusUnauthorized, http.StatusForbidden:
+        // Reactive translation (#139): surface the SAME actionable admin-scope
+        // guidance instead of leaking a raw status/body.
+        return errTxAliasAdminRequired
     default:
         body, _ := io.ReadAll(resp.Body)
         return fmt.Errorf("unexpected status registering tx-alias '%s' on %s: %s (body: %s)", alias, node.Alias, resp.Status, string(body))
     }
+}
+
+// errTxAliasAdminRequired is the actionable guidance returned both proactively
+// (offline precheck) and reactively (401/403 translation) when a tx-alias
+// registration is attempted without an admin-scoped credential (#139).
+var errTxAliasAdminRequired = errors.New("registering tx-alias requires admin scope; log in with an admin session or configure an admin client token")
+
+// clientTokenHasAdminScope decodes a bearer as a goSignals ClientToken JWT
+// WITHOUT verifying its signature and reports whether the scope could be
+// determined (known) and, if so, whether it grants admin (root rides free). An
+// opaque or non-goSignals token returns known=false so callers degrade
+// gracefully and proceed to the network.
+func clientTokenHasAdminScope(bearer string) (known bool, hasAdmin bool) {
+    if bearer == "" {
+        return false, false
+    }
+    var eat authSupport.EventAuthToken
+    parser := jwt.NewParser()
+    if _, _, err := parser.ParseUnverified(bearer, &eat); err != nil {
+        return false, false
+    }
+    // A goSignals ClientToken carries roles and/or a scope claim. Absent both,
+    // this is an IdP/opaque token we cannot classify here.
+    if len(eat.Roles) == 0 && eat.Scope == "" {
+        return false, false
+    }
+    return true, eat.IsScopeMatch([]string{authSupport.ScopeStreamAdmin})
 }
 
 func (cli *CLI) executeCreateRequest(streamAlias string, reg model.StreamConfiguration, server *SsfServer, typeDescription string, connectAlias string) (*model.StreamConfiguration, error) {

--- a/cmd/goSignals/config.go
+++ b/cmd/goSignals/config.go
@@ -298,6 +298,14 @@ func (c *ConfigData) checkConfigPath(g *Globals) error {
 			}
 		} else {
 			fmt.Printf("Using GOSIGNALS_HOME path: %s\n", configPath)
+			// When GOSIGNALS_HOME points at a directory (existing dir, or a
+			// path with no file extension), it names the home dir — append the
+			// config filename so g.ConfigFile is the config FILE and
+			// filepath.Dir(g.ConfigFile) is the true home dir. Otherwise treat
+			// it as an explicit config file path (GH #143).
+			if info, statErr := os.Stat(configPath); (statErr == nil && info.IsDir()) || filepath.Ext(configPath) == "" {
+				configPath = filepath.Join(configPath, ConfigFile)
+			}
 			g.ConfigFile = configPath
 			return nil
 		}

--- a/cmd/goSignals/config_test.go
+++ b/cmd/goSignals/config_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+    "path/filepath"
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// TestCheckConfigPath_GosignalsHomeDir verifies that when GOSIGNALS_HOME points
+// at a directory, config.json and credentials.json co-locate in that same
+// directory (GH #143 — credentials.json must not land one level above
+// config.json).
+func TestCheckConfigPath_GosignalsHomeDir(t *testing.T) {
+    home := t.TempDir()
+    t.Setenv("GOSIGNALS_HOME", home)
+
+    g := &Globals{} // g.Config empty -> resolve from env
+    c := &ConfigData{}
+    require.NoError(t, c.checkConfigPath(g))
+
+    // config.json should live directly inside the GOSIGNALS_HOME directory.
+    assert.Equal(t, filepath.Join(home, ConfigFile), g.ConfigFile,
+        "config.json should resolve inside GOSIGNALS_HOME directory")
+
+    // credentials.json must co-locate in the same directory as config.json.
+    assert.Equal(t, filepath.Dir(g.ConfigFile), filepath.Dir(credentialsPath(g)),
+        "config.json and credentials.json must resolve to the same directory")
+    assert.Equal(t, home, filepath.Dir(credentialsPath(g)),
+        "credentials.json should live inside GOSIGNALS_HOME directory")
+}
+
+// TestCheckConfigPath_GosignalsHomeFile verifies the regression guard: when
+// GOSIGNALS_HOME is a file path, credentials.json co-locates in that file's
+// directory (existing behavior preserved).
+func TestCheckConfigPath_GosignalsHomeFile(t *testing.T) {
+    dir := t.TempDir()
+    configFile := filepath.Join(dir, "toolconfig.json")
+    t.Setenv("GOSIGNALS_HOME", configFile)
+
+    g := &Globals{}
+    c := &ConfigData{}
+    require.NoError(t, c.checkConfigPath(g))
+
+    assert.Equal(t, configFile, g.ConfigFile,
+        "a file-valued GOSIGNALS_HOME should be used verbatim as the config file")
+    assert.Equal(t, dir, filepath.Dir(credentialsPath(g)),
+        "credentials.json should co-locate in the config file's directory")
+}

--- a/cmd/goSignals/create_poll_receive_txalias_test.go
+++ b/cmd/goSignals/create_poll_receive_txalias_test.go
@@ -9,6 +9,7 @@ import (
     "sync"
     "testing"
 
+    "github.com/i2-open/i2goSignals/pkg/authSupport"
     "github.com/i2-open/i2goSignals/pkg/ssfModels"
     "github.com/stretchr/testify/assert"
     "github.com/stretchr/testify/require"
@@ -48,9 +49,11 @@ func stagedTxServer(t *testing.T, cli *CLI, alias, nodeHost string) {
         },
     }
     cli.Data.Servers["node"] = SsfServer{
-        Alias:       "node",
-        Host:        nodeHost,
-        ClientToken: "node-admin-token",
+        Alias: "node",
+        Host:  nodeHost,
+        // An admin-scoped ClientToken so the offline precheck (#139) passes; the
+        // POST /server call requires admin and the precheck mirrors that.
+        ClientToken: mintClientToken(t, authSupport.ScopeStreamAdmin, authSupport.ScopeStreamMgmt),
         Streams:     map[string]Stream{},
     }
 }
@@ -82,7 +85,7 @@ func TestRegisterTxAliasServer_PostsRegistration(t *testing.T) {
     require.NoError(t, err)
 
     assert.Equal(t, "/server", gotPath)
-    assert.Equal(t, "Bearer node-admin-token", gotAuth)
+    assert.Equal(t, "Bearer "+node.ClientToken, gotAuth, "the node's admin ClientToken must authenticate the POST /server call")
     assert.Equal(t, "ssfTx", gotServer.Alias)
     assert.Equal(t, "kc-client", gotServer.OAuthClientConfig.ClientID)
     assert.Equal(t, "staged-secret", gotServer.OAuthClientConfig.ClientSecret,

--- a/cmd/goSignals/credentials.go
+++ b/cmd/goSignals/credentials.go
@@ -33,12 +33,19 @@ type Session struct {
 
 // Expired reports whether the access token is at/after its expiry (with a small
 // skew so we refresh slightly early rather than racing the edge).
+//
+// A zero Expiry means the expiry is unknown (e.g. the IdP omitted expires_in and
+// the token carried no usable exp claim). We treat unknown as "needs refresh"
+// (true) rather than "never expires" (false) so the resolver attempts a
+// refresh_token grant. A session that can't refresh (no refresh token) falls
+// through to the existing relogin-required path in bearerResolver.resolve, so
+// this does not loop.
 func (s *Session) Expired() bool {
     if s == nil {
         return true
     }
     if s.Expiry.IsZero() {
-        return false
+        return true
     }
     return time.Now().Add(30 * time.Second).After(s.Expiry)
 }

--- a/cmd/goSignals/register_txalias_authz_test.go
+++ b/cmd/goSignals/register_txalias_authz_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+    "crypto/rand"
+    "crypto/rsa"
+    "net/http"
+    "net/http/httptest"
+    "sync/atomic"
+    "testing"
+    "time"
+
+    jwt "github.com/golang-jwt/jwt/v5"
+    "github.com/i2-open/i2goSignals/pkg/authSupport"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// mintClientToken builds a goSignals ClientToken JWT carrying the given roles,
+// signed with a throwaway key. The CLI offline precheck decodes claims WITHOUT
+// verifying the signature, so the key is irrelevant to the test.
+func mintClientToken(t *testing.T, roles ...string) string {
+    t.Helper()
+    key, err := rsa.GenerateKey(rand.Reader, 2048)
+    require.NoError(t, err)
+    eat := authSupport.EventAuthToken{
+        ProjectId: "proj-A",
+        Roles:     roles,
+        RegisteredClaims: jwt.RegisteredClaims{
+            ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+            Issuer:    "DEFAULT",
+        },
+    }
+    tok := jwt.NewWithClaims(jwt.SigningMethodRS256, eat)
+    signed, err := tok.SignedString(key)
+    require.NoError(t, err)
+    return signed
+}
+
+// TestRegisterTxAliasServer_FailFastOnStreamScope proves the offline precheck:
+// a node credential that decodes to a stream-only ClientToken short-circuits
+// BEFORE any network call with an actionable admin-scope error.
+func TestRegisterTxAliasServer_FailFastOnStreamScope(t *testing.T) {
+    cli := newTestCLI(t)
+
+    var called int32
+    stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        atomic.AddInt32(&called, 1)
+        w.WriteHeader(http.StatusCreated)
+    }))
+    defer stub.Close()
+
+    stagedTxServer(t, cli, "ssfTx", stub.URL)
+    node := cli.Data.Servers["node"]
+    node.ClientToken = mintClientToken(t, authSupport.ScopeStreamMgmt)
+    cli.Data.Servers["node"] = node
+    n, err := cli.Data.GetServer("node")
+    require.NoError(t, err)
+
+    err = cli.registerTxAliasServer(n, "ssfTx", "", "")
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "admin", "stream-only credential must fail fast with admin-scope guidance")
+    assert.Equal(t, int32(0), atomic.LoadInt32(&called), "fail-fast must not make the network call")
+}
+
+// TestRegisterTxAliasServer_AdminTokenProceeds proves an admin ClientToken
+// passes the offline precheck and the POST /server call is made.
+func TestRegisterTxAliasServer_AdminTokenProceeds(t *testing.T) {
+    cli := newTestCLI(t)
+
+    var called int32
+    stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        atomic.AddInt32(&called, 1)
+        w.WriteHeader(http.StatusCreated)
+        _, _ = w.Write([]byte("{}"))
+    }))
+    defer stub.Close()
+
+    stagedTxServer(t, cli, "ssfTx", stub.URL)
+    node := cli.Data.Servers["node"]
+    node.ClientToken = mintClientToken(t, authSupport.ScopeStreamAdmin, authSupport.ScopeStreamMgmt)
+    cli.Data.Servers["node"] = node
+    n, err := cli.Data.GetServer("node")
+    require.NoError(t, err)
+
+    err = cli.registerTxAliasServer(n, "ssfTx", "", "")
+    require.NoError(t, err)
+    assert.Equal(t, int32(1), atomic.LoadInt32(&called), "admin credential must proceed to the network call")
+}
+
+// TestRegisterTxAliasServer_OpaqueTokenProceeds proves graceful degradation:
+// an opaque (non-JWT) credential cannot be classified locally, so the call is
+// NOT blocked and proceeds to the network.
+func TestRegisterTxAliasServer_OpaqueTokenProceeds(t *testing.T) {
+    cli := newTestCLI(t)
+
+    var called int32
+    stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        atomic.AddInt32(&called, 1)
+        w.WriteHeader(http.StatusCreated)
+    }))
+    defer stub.Close()
+
+    stagedTxServer(t, cli, "ssfTx", stub.URL) // ClientToken "node-admin-token" is opaque
+    n, err := cli.Data.GetServer("node")
+    require.NoError(t, err)
+
+    err = cli.registerTxAliasServer(n, "ssfTx", "", "")
+    require.NoError(t, err)
+    assert.Equal(t, int32(1), atomic.LoadInt32(&called), "an unclassifiable credential must not be blocked offline")
+}
+
+// TestRegisterTxAliasServer_ReactiveTranslates403 proves a 403 from POST /server
+// is translated into the SAME actionable admin-scope message rather than leaking
+// a raw status/body.
+func TestRegisterTxAliasServer_ReactiveTranslates403(t *testing.T) {
+    cli := newTestCLI(t)
+
+    stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.WriteHeader(http.StatusForbidden)
+        _, _ = w.Write([]byte("forbidden"))
+    }))
+    defer stub.Close()
+
+    stagedTxServer(t, cli, "ssfTx", stub.URL) // opaque token -> precheck proceeds
+    n, err := cli.Data.GetServer("node")
+    require.NoError(t, err)
+
+    err = cli.registerTxAliasServer(n, "ssfTx", "", "")
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "admin", "a 403 must be translated into actionable admin-scope guidance")
+}

--- a/cmd/goSignals/serverbearer_cmd_test.go
+++ b/cmd/goSignals/serverbearer_cmd_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+    "net/http"
+    "net/http/httptest"
+    "path/filepath"
+    "testing"
+    "time"
+
+    "github.com/i2-open/i2goSignals/pkg/ssfModels"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// seedOAuthSessionCLI builds a CLI wired with a single server + stream and a
+// credentials store holding a live IdP session for the server's ActiveIssuer
+// but NO ClientToken. This is the OAuth-login user shape of GH #138: a login
+// session exists, but no legacy client admin token is stored. The handler URL
+// is used for both the server Host and the ConfigurationEndpoint/StatusEndpoint
+// so management calls land on the test server.
+func seedOAuthSessionCLI(t *testing.T, handlerURL string) *CLI {
+    t.Helper()
+    dir := t.TempDir()
+    g := Globals{ConfigFile: filepath.Join(dir, "config.json")}
+
+    store := &CredentialStore{Path: credentialsPath(&g)}
+    store.Set("https://idp.example.com", &Session{
+        AccessToken: "session-token",
+        Expiry:      time.Now().Add(time.Hour),
+        LoggedInAt:  time.Now(),
+    })
+    require.NoError(t, store.Save())
+
+    server := SsfServer{
+        Alias:        "gs1",
+        Host:         handlerURL,
+        ActiveIssuer: "https://idp.example.com",
+        // ClientToken deliberately empty — OAuth-login user.
+        Streams: map[string]Stream{
+            "s1": {Alias: "s1", Id: "stream-1"},
+        },
+        ServerConfiguration: &model.TransmitterConfiguration{
+            ConfigurationEndpoint: handlerURL + "/stream",
+            StatusEndpoint:        handlerURL + "/status",
+        },
+    }
+
+    cli := &CLI{}
+    cli.Globals = g
+    cli.Data = ConfigData{
+        Selected: "gs1",
+        Servers:  map[string]SsfServer{"gs1": server},
+    }
+    return cli
+}
+
+// TestDeleteStreamCmd_UsesSessionBearer guards GH #138: an OAuth-login user
+// (session present, ClientToken empty) must authenticate `delete stream` via
+// the resolved session bearer, not emit an empty/legacy Authorization header.
+func TestDeleteStreamCmd_UsesSessionBearer(t *testing.T) {
+    var gotAuth string
+    var sawRequest bool
+    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        sawRequest = true
+        gotAuth = r.Header.Get("Authorization")
+        w.WriteHeader(http.StatusOK)
+    }))
+    defer ts.Close()
+
+    cli := seedOAuthSessionCLI(t, ts.URL)
+    cmd := &DeleteStreamCmd{Alias: "s1"}
+    err := cmd.Run(cli)
+    require.NoError(t, err)
+    require.True(t, sawRequest, "expected delete request to reach the server")
+    assert.Equal(t, "Bearer session-token", gotAuth,
+        "delete stream must carry the resolved session bearer (GH #138)")
+}
+
+// TestChangeSubjectFilter_UsesSessionBearer guards GH #138 for a subject-filter
+// command: the shared add/remove path must authenticate an OAuth-login user via
+// the resolved session bearer.
+func TestChangeSubjectFilter_UsesSessionBearer(t *testing.T) {
+    var gotAuth string
+    var sawRequest bool
+    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        sawRequest = true
+        gotAuth = r.Header.Get("Authorization")
+        w.WriteHeader(http.StatusOK)
+    }))
+    defer ts.Close()
+
+    cli := seedOAuthSessionCLI(t, ts.URL)
+    err := changeSubjectFilter(cli, "s1", `{"format":"email","email":"a@example.com"}`,
+        subjectArgFlags{}, false, "/add-subject", "added")
+    require.NoError(t, err)
+    require.True(t, sawRequest, "expected add-subject request to reach the server")
+    assert.Equal(t, "Bearer session-token", gotAuth,
+        "subject-filter change must carry the resolved session bearer (GH #138)")
+}

--- a/cmd/goSignals/use_logout_cmd_test.go
+++ b/cmd/goSignals/use_logout_cmd_test.go
@@ -68,8 +68,11 @@ func TestLogoutCmd_AllDropsEverySession(t *testing.T) {
 func TestUseServerCmd_OverridesActiveIssuer(t *testing.T) {
     c := newTestCLI(t)
     store := &CredentialStore{Path: credentialsPath(&c.Globals)}
-    store.Set("https://r1", &Session{AccessToken: "1", LoggedInAt: time.Now().Add(-time.Hour)})
-    store.Set("https://r2", &Session{AccessToken: "2", LoggedInAt: time.Now()})
+    // Give both sessions a live expiry so serverBearer presents the stored
+    // token directly (a zero Expiry is treated as "unknown -> needs refresh"
+    // per GH #142, which is not what this routing test is exercising).
+    store.Set("https://r1", &Session{AccessToken: "1", Expiry: time.Now().Add(time.Hour), LoggedInAt: time.Now().Add(-time.Hour)})
+    store.Set("https://r2", &Session{AccessToken: "2", Expiry: time.Now().Add(time.Hour), LoggedInAt: time.Now()})
     if err := store.Save(); err != nil {
         t.Fatalf("save store: %v", err)
     }

--- a/docs/adr/0009-foreign-server-provisioning-requires-admin.md
+++ b/docs/adr/0009-foreign-server-provisioning-requires-admin.md
@@ -1,0 +1,95 @@
+<!-- gosignals-brand-hero -->
+<picture><source media="(prefers-color-scheme: dark)" srcset="../../brand/logo/gosignals-hero-primary.svg"><img src="../../brand/logo/gosignals-hero-on-light.svg" alt="goSignals" height="77"></picture>
+
+# 9. Foreign-server provisioning requires admin scope
+
+Date: 2026-05-31
+
+## Status
+
+Accepted
+
+## Context
+
+A self-registered CLI client is capped at `stream`+`event` at the registration
+door (ADR 0006: `reg` is privilege-ceilinged; `admin` is provisioned out of
+band). That ceiling is correct for the common case — a SCIM receiver or an
+unattended IAT bootstrap creating its **own** stream on the local node.
+
+But two related operations are *privileged* and were not consistently gated:
+
+1. **Registering a foreign SSF transmitter** — `POST /server` (and the rest of
+   the `/server` CRUD surface). This stores a credential for, and enables remote
+   management of, another party's transmitter.
+2. **Creating a stream that targets a foreign transmitter** — `POST /stream`
+   with `tx_alias` set. The server resolves the stored foreign-server credential
+   and provisions a stream on the remote node's behalf (the TxAlias
+   auto-registration path).
+
+Issue #139 originally diagnosed this as an "opaque 403" bug: the CLI
+`create stream poll receive --tx-alias` flow calls `POST /server` with a
+`stream`-only credential and gets a bare 403. The real defects were twofold:
+(a) the authorization gate was inconsistent — `/server` accepted `reg`, and
+`/stream` had no discriminator for the privileged `tx_alias` shape; and (b) the
+denial leaked as an opaque status instead of actionable guidance. This corrects
+#139's original misdiagnosis (it is not a 403-rendering bug; it is an
+authorization-model bug).
+
+## Decision
+
+We make foreign-server provisioning **admin-only** (`root` rides free via the
+`IsScopeMatch` wildcard), with a discriminator on `/stream`:
+
+- **`POST /stream` without `tx_alias`** — UNCHANGED. Requires `stream` (the
+  base `reg`/`stream`/`admin` gate). This is the SCIM-receiver /
+  unattended-IAT-bootstrap path configuring only the local node's view; it must
+  keep working.
+- **`POST /stream` with `tx_alias` set** — requires `admin`. After decoding the
+  body, `StreamCreateHandler` checks `tx_alias` against the caller's scope using
+  the existing `EventAuthToken.IsScopeMatch([admin])` helper and returns a
+  plain-text, actionable 403 otherwise.
+- **The five `/server` endpoints** (create, get, update, delete, list) — require
+  `admin`. The previous `{reg, admin}` acceptor list drops `reg`; `admin` and
+  `root` are the only acceptors.
+
+The `/server` endpoints stay **separate** from `/stream` (they are NOT folded
+into stream creation). `/server` registers and manages a foreign transmitter's
+credential, which has an independent lifecycle from any stream that later
+references it; goSignalsAdmin's console depends on that separate contract. A
+single tx-alias stream-create still convenience-registers the transmitter
+(`POST /server`) first, but the two endpoints remain distinct.
+
+The CLI mirrors the server rule on both sides: a proactive offline precheck
+fails fast when the resolved credential decodes to a goSignals ClientToken whose
+scopes lack `admin`/`root` (degrading gracefully — an opaque/IdP token it cannot
+classify falls through to the network), and a reactive translation turns a
+`401`/`403` from `POST /server` into the same actionable message.
+
+## Consequences
+
+**Positive**
+
+- One consistent rule: foreign-server provisioning is `admin` (`root` free),
+  anchored to ADR 0006's scope ladder (`key` → `reg` → `stream`/`event`, with
+  `admin` out of band).
+- The local-only stream-create path (SCIM receiver, unattended IAT bootstrap)
+  is untouched — the regression that #139 risked is explicitly guarded.
+- The opaque 403 becomes an actionable message both before the call (offline)
+  and after (server-returned), so operators know to use an admin credential.
+
+**Negative**
+
+- A caller that previously used a `reg` (IAT) credential against `/server` now
+  needs an `admin` credential. This is the intended tightening, not a
+  regression, but it is a behavioural change for any such flow.
+- The `tx_alias` discriminator lives in the handler (post-decode) rather than in
+  the single up-front scope gate, because the required scope depends on the
+  request body.
+
+## Related
+
+- ADR 0006 — the `key` scope and the `reg` privilege ceiling (the scope model
+  this anchors to).
+- `docs/security_model.md` — endpoint → scope table.
+- `pkg/authSupport/auth_token.go` — scope constants and `IsScopeMatch`.
+- Issue #139.

--- a/docs/gosignals_tool.md
+++ b/docs/gosignals_tool.md
@@ -403,7 +403,9 @@ Parameters Used to Create Streams:
 | `--mode`          | For i2goSignals servers mode informs the server what it does with events.  See below.                                                        | `IMPORT` for receiver<BR>`PUBLISH` for publisher |
 | `--event-url`     | Used to tell Push Publishers where to deliver events using RFC8935. For Poll receivers, indicates where to retrieve events using RFC8936     | none                                             |
 | `--auth`          | The authorization header value to use when communicating with a polling or push endpoint (i.e. `--event-url`)                                | none                                             |
-| `--connect`, `-c` | Partially automates stream creation by providing the local alias for the stream being connected to.                                          | none                                             |      
+| `--connect`, `-c` | Partially automates stream creation by providing the local alias for the stream being connected to.                                          | none                                             |
+| `--tx-alias`      | (Poll receiver) Alias of a configured foreign SSF transmitter to auto-register and wire. **Requires an ADMIN credential, not the IAT** — it registers the transmitter on the node (`POST /server`, admin-only) and provisions a stream against it. | none                                             |
+| `--secret`        | OAuth client secret for the `--tx-alias` transmitter (non-interactive); resolved staged → flag → env. Rides on the request body only; never persisted. | none                                             |
 
 > [!Tip]
 > For more information on the meaning of terms like iss, aud, and event URIs, see the [JWT Specification](https://datatracker.ietf.org/doc/html/rfc7519), 

--- a/docs/security_model.md
+++ b/docs/security_model.md
@@ -54,6 +54,21 @@ This is the machine tier ladder: a bootstrap identity (`key`) seeds an issuer ke
 and a `reg` IAT; the `reg` IAT registers a client that caps at `stream`+`event`;
 `admin` clients are provisioned out of band, not through the registration door.
 
+### Foreign-server provisioning (endpoint → scope)
+
+Provisioning a *foreign* SSF transmitter is a privileged, management-plane
+operation and requires `admin` (`root` rides free). See ADR 0009.
+
+| Endpoint | Required scope |
+| :------- | :------------- |
+| `POST/GET/PUT/DELETE /server`, `GET /server` (list) | `admin` (`root` free) — `reg`/`stream` are rejected. |
+| `POST /stream` **without** `tx_alias` | `stream` (base `reg`/`stream`/`admin` gate) — the SCIM-receiver / unattended-IAT-bootstrap local-only path, unchanged. |
+| `POST /stream` **with** `tx_alias` | `admin` (`root` free) — resolves a stored foreign-server credential and provisions a stream remotely. |
+
+The `/server` endpoints stay distinct from `/stream` (they are not folded into
+stream creation) so a foreign transmitter's credential keeps an independent
+lifecycle, which goSignalsAdmin's console depends on.
+
 ### The bootstrap secret
 
 `I2SIG_BOOTSTRAP_TOKEN` is a shared secret. On the server, a bearer that

--- a/internal/server/api_out_of_band.go
+++ b/internal/server/api_out_of_band.go
@@ -648,6 +648,15 @@ func RegisterClientHandler(sa SsfApplicationInterface, w http.ResponseWriter, r 
 				// token cannot escalate its own privilege.
 			}
 		}
+		// An explicit, non-empty scope list that filters entirely to empty (every
+		// entry above the ceiling or unknown) is refused rather than silently
+		// falling back to the default — a caller asking only for above-ceiling
+		// scopes may be attempting privilege escalation (WARN-worthy).
+		if len(scopes) == 0 {
+			serverLog.Warn("RegisterClient: refusing registration; all requested scopes were dropped", "requestedScopes", jsonRequest.Scopes)
+			http.Error(w, "None of the requested scopes can be granted", http.StatusBadRequest)
+			return
+		}
 	}
 
 	client := model.SsfClient{

--- a/internal/server/api_out_of_band.go
+++ b/internal/server/api_out_of_band.go
@@ -938,7 +938,7 @@ func (sa *SignalsApplication) CreateServer(w http.ResponseWriter, r *http.Reques
 }
 
 func CreateServerHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *http.Request) {
-	authCtx, status := sa.GetAuth().ValidateAuthorizationAny(r, []string{authSupport.ScopeRegister, authSupport.ScopeStreamAdmin})
+	authCtx, status := sa.GetAuth().ValidateAuthorizationAny(r, []string{authSupport.ScopeStreamAdmin})
 	if status != http.StatusOK {
 		w.WriteHeader(status)
 		return
@@ -987,7 +987,7 @@ func (sa *SignalsApplication) ServerGet(w http.ResponseWriter, r *http.Request) 
 }
 
 func GetServerHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *http.Request) {
-	authCtx, status := sa.GetAuth().ValidateAuthorizationAny(r, []string{authSupport.ScopeRegister, authSupport.ScopeStreamAdmin})
+	authCtx, status := sa.GetAuth().ValidateAuthorizationAny(r, []string{authSupport.ScopeStreamAdmin})
 	if status != http.StatusOK {
 		w.WriteHeader(status)
 		return
@@ -1038,7 +1038,7 @@ func (sa *SignalsApplication) ServerUpdate(w http.ResponseWriter, r *http.Reques
 }
 
 func UpdateServerHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *http.Request) {
-	authCtx, status := sa.GetAuth().ValidateAuthorizationAny(r, []string{authSupport.ScopeRegister, authSupport.ScopeStreamAdmin})
+	authCtx, status := sa.GetAuth().ValidateAuthorizationAny(r, []string{authSupport.ScopeStreamAdmin})
 	if status != http.StatusOK {
 		w.WriteHeader(status)
 		return
@@ -1109,7 +1109,7 @@ func (sa *SignalsApplication) ServerDelete(w http.ResponseWriter, r *http.Reques
 }
 
 func DeleteServerHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *http.Request) {
-	authCtx, status := sa.GetAuth().ValidateAuthorizationAny(r, []string{authSupport.ScopeRegister, authSupport.ScopeStreamAdmin})
+	authCtx, status := sa.GetAuth().ValidateAuthorizationAny(r, []string{authSupport.ScopeStreamAdmin})
 	if status != http.StatusOK {
 		w.WriteHeader(status)
 		return
@@ -1160,7 +1160,7 @@ func (sa *SignalsApplication) ServerList(w http.ResponseWriter, r *http.Request)
 }
 
 func ListServerHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *http.Request) {
-	authCtx, status := sa.GetAuth().ValidateAuthorizationAny(r, []string{authSupport.ScopeRegister, authSupport.ScopeStreamAdmin})
+	authCtx, status := sa.GetAuth().ValidateAuthorizationAny(r, []string{authSupport.ScopeStreamAdmin})
 	if status != http.StatusOK {
 		w.WriteHeader(status)
 		return

--- a/internal/server/api_out_of_band.go
+++ b/internal/server/api_out_of_band.go
@@ -129,6 +129,17 @@ func CreateKeyHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *http
 	}
 
 	if len(body) > 0 {
+		// The "key" scope is create-only and server-generated. A key-scope-only
+		// (bootstrap) caller may NOT upload caller-supplied key material: a
+		// non-empty body routes to loadKeyHandler, which would install an issuer
+		// signing key of the caller's choosing (private PEM or external jwks_uri)
+		// for a brand-new issuer with no force/rotate required — enabling SET
+		// forgery under that issuer. Uploading requires stream_admin/root, the
+		// same scope LoadKeyHandler enforces.
+		if keyScopeOnly(authCtx) {
+			http.Error(w, "key scope is create-only; uploading key material requires stream_admin/root", http.StatusForbidden)
+			return
+		}
 		loadKeyHandler(sa, w, r, authCtx, body)
 	} else {
 		createKeyByNameHandler(sa, w, r, authCtx)

--- a/internal/server/api_out_of_band.go
+++ b/internal/server/api_out_of_band.go
@@ -635,6 +635,14 @@ func RegisterClientHandler(sa SsfApplicationInterface, w http.ResponseWriter, r 
 	// Privilege ceiling: a reg (IAT) caller may not self-grant stream_admin at
 	// /register. A self-registration caps at stream_mgmt + event_delivery; an
 	// admin client is provisioned out of band, not via the registration door.
+	//
+	// event_delivery granted here is persisted in the client's AllowedScopes as a
+	// capability, but is intentionally NOT minted into the stream-client
+	// (management) token (see services.ClientService.RegisterClient and
+	// authUtil.IssueStreamClientToken). Event delivery is authorized by a separate
+	// per-stream delivery token (authUtil.IssueStreamToken), issued at stream
+	// creation. The stored-capability vs minted-token-role divergence is by design
+	// (#140); do not reconcile it by adding event to the management token.
 	var scopes []string
 	if len(jsonRequest.Scopes) == 0 {
 		scopes = append(scopes, authSupport.ScopeStreamMgmt, authSupport.ScopeEventDelivery)

--- a/internal/server/api_stream_management.go
+++ b/internal/server/api_stream_management.go
@@ -456,6 +456,19 @@ func StreamCreateHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *h
 		return
 	}
 
+	// Provisioning a stream against a FOREIGN transmitter (tx_alias set) is a
+	// privileged operation: it resolves a stored foreign-server credential and
+	// remotely manages a stream on another node's behalf. It therefore requires
+	// admin (root rides free); the base stream/reg gate above is not enough. A
+	// plain create (no tx_alias) — the SCIM-receiver / unattended-IAT-bootstrap
+	// path — is unaffected. See ADR 0009.
+	if jsonRequest.TxAlias != nil && *jsonRequest.TxAlias != "" &&
+		!(authCtx.Eat != nil && authCtx.Eat.IsScopeMatch([]string{authSupport.ScopeStreamAdmin})) {
+		serverLog.Warn("StreamCreate: denied tx_alias provisioning; admin scope required", "tx_alias", *jsonRequest.TxAlias, "projectId", authCtx.ProjectId)
+		http.Error(w, "creating a stream with tx_alias (foreign-server provisioning) requires admin scope; use an admin session or an admin client token", http.StatusForbidden)
+		return
+	}
+
 	jsonRequest.ResetDate = nil
 	jsonRequest.ResetJti = ""
 

--- a/internal/server/api_subject_filter_review.go
+++ b/internal/server/api_subject_filter_review.go
@@ -28,8 +28,8 @@ type subjectFilterReviewResponse struct {
     StreamId                   string                           `json:"stream_id"`
     Mode                       string                           `json:"mode,omitempty"`
     DefaultSubjects            string                           `json:"default_subjects,omitempty"`
-    EventSource                *model.EventSource               `json:"event_source,omitempty"`
-    SubjectRemovalGraceSeconds int                              `json:"subject_removal_grace_seconds,omitempty"`
+    EventSource                *model.EventSource               `json:"event_source"`
+    SubjectRemovalGraceSeconds int                              `json:"subject_removal_grace_seconds"`
     PassthruNoLocalFilter      bool                             `json:"passthru_no_local_filter,omitempty"`
     Counts                     *subjectFilterReviewCounts       `json:"counts,omitempty"`
     Pending                    []subjectFilterReviewEntry       `json:"pending,omitempty"`
@@ -157,8 +157,8 @@ func buildSubjectFilterReviewResponse(stream *model.StreamStateRecord, review *s
         StreamId:                   stream.StreamConfiguration.Id,
         Mode:                       stream.SubjectFilterMode,
         DefaultSubjects:            stream.DefaultSubjects,
-        EventSource:                stream.EventSource,
-        SubjectRemovalGraceSeconds: stream.SubjectRemovalGraceSeconds,
+        EventSource:                effectiveEventSource(stream.EventSource),
+        SubjectRemovalGraceSeconds: effectiveRemovalGrace(stream.SubjectRemovalGraceSeconds),
         PassthruNoLocalFilter:      review.NoLocalFilter,
     }
     if review.Counts != nil {
@@ -190,4 +190,27 @@ func buildSubjectFilterReviewResponse(stream *model.StreamStateRecord, review *s
         }
     }
     return out
+}
+
+// effectiveEventSource resolves a stream's stored EventSource to the value the
+// admin review wire contract surfaces. A nil descriptor has EFFECTIVE type
+// AUDIENCE (GH #118 / the nil-EventSource→AUDIENCE decision: an unset source
+// behaves as audience matching), so it resolves to {"type":"AUDIENCE"} rather
+// than being omitted. A non-nil descriptor is surfaced unchanged.
+func effectiveEventSource(es *model.EventSource) *model.EventSource {
+    if es == nil {
+        return &model.EventSource{Type: model.EventSourceAudience}
+    }
+    return es
+}
+
+// effectiveRemovalGrace resolves the SSF §9.3 grace seconds surfaced by the
+// admin review: a non-zero per-stream override wins; otherwise the server-wide
+// I2SIG_SUBJECT_REMOVAL_GRACE default. Mirrors SubjectFilterService.resolveGrace
+// so the review reports the same effective value the service enforces.
+func effectiveRemovalGrace(perStream int) int {
+    if perStream > 0 {
+        return perStream
+    }
+    return services.SubjectRemovalGraceDefaultSeconds()
 }

--- a/internal/server/server_provisioning_authz_test.go
+++ b/internal/server/server_provisioning_authz_test.go
@@ -1,0 +1,190 @@
+package server
+
+import (
+    "bytes"
+    "context"
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+
+    "github.com/gorilla/mux"
+    "github.com/i2-open/i2goSignals/internal/authUtil"
+    "github.com/i2-open/i2goSignals/internal/eventRouter"
+    "github.com/i2-open/i2goSignals/internal/providers/dbProviders"
+    "github.com/i2-open/i2goSignals/pkg/ssfModels"
+    "github.com/stretchr/testify/suite"
+    "go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// ServerProvisioningAuthzSuite verifies the issue #139 authorization model:
+//   - POST /stream with tx_alias requires admin (root rides free); a plain
+//     create at stream scope is unchanged.
+//   - All five /server endpoints are admin-only (reg/stream are rejected).
+type ServerProvisioningAuthzSuite struct {
+    suite.Suite
+    app *SignalsApplication
+}
+
+func (s *ServerProvisioningAuthzSuite) SetupTest() {
+    persistence, err := dbProviders.OpenPersistence("memorydb:", "serverauthz-test")
+    s.Require().NoError(err)
+    err = persistence.KeyService.InitializeTokenKey(context.Background(), "DEFAULT")
+    s.Require().NoError(err)
+
+    s.app = newTestApplication(persistence)
+    s.app.DefIssuer = "DEFAULT"
+    // A plain (non-tx_alias) create reaches the post-create EventRouter wiring;
+    // give the app a real router so that regression path returns a clean 201
+    // instead of dereferencing a nil router. Poll-transmitter streams are served
+    // by every node and take no lease, so no background goroutine races here.
+    s.app.EventRouter = eventRouter.NewRouter(eventRouter.RouterDeps{
+        StreamService: persistence.StreamService,
+        KeyService:    persistence.KeyService,
+        EventService:  persistence.EventService,
+        Coordinator:   persistence.Coordinator,
+    }, "test-node")
+    s.app.pushReceivers = map[string]model.StreamStateRecord{}
+    s.app.pollClients = map[string]*ClientPollStream{}
+}
+
+// adminToken mints a stream-admin token bound to the project.
+func (s *ServerProvisioningAuthzSuite) adminToken(projectId string) string {
+    client := model.SsfClient{Id: bson.NewObjectID(), ProjectIds: []string{projectId}}
+    tok, err := s.app.GetAuth().IssueStreamClientToken(client, projectId, true, "")
+    s.Require().NoError(err)
+    return tok
+}
+
+// streamToken mints a stream-mgmt (non-admin) client token bound to the project.
+func (s *ServerProvisioningAuthzSuite) streamToken(projectId string) string {
+    client := model.SsfClient{Id: bson.NewObjectID(), ProjectIds: []string{projectId}}
+    tok, err := s.app.GetAuth().IssueStreamClientToken(client, projectId, false, "")
+    s.Require().NoError(err)
+    return tok
+}
+
+// regToken mints a register (IAT) token bound to the project.
+func (s *ServerProvisioningAuthzSuite) regToken(projectId string) string {
+    tok, err := s.app.GetAuth().IssueProjectIat(&authUtil.AuthContext{ProjectId: projectId})
+    s.Require().NoError(err)
+    return tok
+}
+
+func (s *ServerProvisioningAuthzSuite) do(handler http.HandlerFunc, method, path, bearer string, body []byte, vars map[string]string) *httptest.ResponseRecorder {
+    var rdr *bytes.Reader
+    if body != nil {
+        rdr = bytes.NewReader(body)
+    } else {
+        rdr = bytes.NewReader([]byte{})
+    }
+    req := httptest.NewRequest(method, path, rdr)
+    if bearer != "" {
+        req.Header.Set("Authorization", "Bearer "+bearer)
+    }
+    if vars != nil {
+        req = mux.SetURLVars(req, vars)
+    }
+    rr := httptest.NewRecorder()
+    handler(rr, req)
+    return rr
+}
+
+// --- StreamCreateHandler tx_alias discriminator ---
+
+func (s *ServerProvisioningAuthzSuite) TestStreamCreate_TxAliasWithStreamScope403() {
+    tok := s.streamToken("proj-A")
+    alias := "ssfTx"
+    cfg := model.StreamStateRecord{}
+    cfg.TxAlias = &alias
+    body, _ := json.Marshal(cfg)
+
+    rr := s.do(s.app.StreamCreate, http.MethodPost, "/stream", tok, body, nil)
+    s.Equal(http.StatusForbidden, rr.Code, "tx_alias create at stream scope must be denied")
+    s.Contains(rr.Body.String(), "admin", "denial message must be actionable")
+}
+
+func (s *ServerProvisioningAuthzSuite) TestStreamCreate_TxAliasWithAdminScopeSucceeds() {
+    tok := s.adminToken("proj-A")
+    alias := "ssfTx"
+    cfg := model.StreamStateRecord{}
+    cfg.TxAlias = &alias
+    body, _ := json.Marshal(cfg)
+
+    rr := s.do(s.app.StreamCreate, http.MethodPost, "/stream", tok, body, nil)
+    s.NotEqual(http.StatusForbidden, rr.Code, "tx_alias create at admin scope must pass the authz gate")
+}
+
+func (s *ServerProvisioningAuthzSuite) TestStreamCreate_PlainAtStreamScopeSucceeds() {
+    tok := s.streamToken("proj-A")
+    // No tx_alias -> the unchanged local-only path. A poll-transmitter stream is
+    // served by every node and takes no lease.
+    cfg := model.StreamStateRecord{}
+    cfg.Iss = "http://transmitter.example.com"
+    cfg.Aud = []string{"http://receiver.example.com"}
+    cfg.Delivery = &model.OneOfStreamConfigurationDelivery{
+        PollTransmitMethod: &model.PollTransmitMethod{Method: model.DeliveryPoll},
+    }
+    body, _ := json.Marshal(cfg)
+
+    rr := s.do(s.app.StreamCreate, http.MethodPost, "/stream", tok, body, nil)
+    s.Equal(http.StatusCreated, rr.Code, "a plain stream-create at stream scope must remain allowed (regression guard)")
+}
+
+// --- /server endpoints are admin-only ---
+
+func (s *ServerProvisioningAuthzSuite) TestCreateServer_RejectsRegAndStream() {
+    body, _ := json.Marshal(model.Server{Alias: "tx1"})
+    for name, tok := range map[string]string{"reg": s.regToken("proj-A"), "stream": s.streamToken("proj-A")} {
+        rr := s.do(s.app.CreateServer, http.MethodPost, "/server", tok, body, nil)
+        s.Equalf(http.StatusForbidden, rr.Code, "%s token must be rejected by POST /server", name)
+    }
+}
+
+func (s *ServerProvisioningAuthzSuite) TestCreateServer_AdminSucceeds() {
+    iat := "iat-placeholder"
+    body, _ := json.Marshal(model.Server{Alias: "tx1", Host: "https://transmitter.example.com", IatToken: &iat})
+    rr := s.do(s.app.CreateServer, http.MethodPost, "/server", s.adminToken("proj-A"), body, nil)
+    s.Equal(http.StatusCreated, rr.Code, "admin token must be accepted by POST /server")
+}
+
+func (s *ServerProvisioningAuthzSuite) TestGetServer_RejectsRegAndStream() {
+    vars := map[string]string{"alias": "tx1"}
+    for name, tok := range map[string]string{"reg": s.regToken("proj-A"), "stream": s.streamToken("proj-A")} {
+        rr := s.do(s.app.ServerGet, http.MethodGet, "/server/tx1", tok, nil, vars)
+        s.Equalf(http.StatusForbidden, rr.Code, "%s token must be rejected by GET /server", name)
+    }
+}
+
+func (s *ServerProvisioningAuthzSuite) TestUpdateServer_RejectsRegAndStream() {
+    vars := map[string]string{"alias": "tx1"}
+    body, _ := json.Marshal(model.Server{Alias: "tx1"})
+    for name, tok := range map[string]string{"reg": s.regToken("proj-A"), "stream": s.streamToken("proj-A")} {
+        rr := s.do(s.app.ServerUpdate, http.MethodPut, "/server/tx1", tok, body, vars)
+        s.Equalf(http.StatusForbidden, rr.Code, "%s token must be rejected by PUT /server", name)
+    }
+}
+
+func (s *ServerProvisioningAuthzSuite) TestDeleteServer_RejectsRegAndStream() {
+    vars := map[string]string{"alias": "tx1"}
+    for name, tok := range map[string]string{"reg": s.regToken("proj-A"), "stream": s.streamToken("proj-A")} {
+        rr := s.do(s.app.ServerDelete, http.MethodDelete, "/server/tx1", tok, nil, vars)
+        s.Equalf(http.StatusForbidden, rr.Code, "%s token must be rejected by DELETE /server", name)
+    }
+}
+
+func (s *ServerProvisioningAuthzSuite) TestListServer_RejectsRegAndStream() {
+    for name, tok := range map[string]string{"reg": s.regToken("proj-A"), "stream": s.streamToken("proj-A")} {
+        rr := s.do(s.app.ServerList, http.MethodGet, "/server", tok, nil, nil)
+        s.Equalf(http.StatusForbidden, rr.Code, "%s token must be rejected by GET /server (list)", name)
+    }
+}
+
+func (s *ServerProvisioningAuthzSuite) TestListServer_AdminSucceeds() {
+    rr := s.do(s.app.ServerList, http.MethodGet, "/server", s.adminToken("proj-A"), nil, nil)
+    s.Equal(http.StatusOK, rr.Code, "admin token must be accepted by GET /server (list)")
+}
+
+func TestServerProvisioningAuthzSuite(t *testing.T) {
+    suite.Run(t, new(ServerProvisioningAuthzSuite))
+}

--- a/internal/server/test/api_server_create_test.go
+++ b/internal/server/test/api_server_create_test.go
@@ -12,6 +12,7 @@ import (
 	ssef "github.com/i2-open/i2goSignals/internal/server"
 	"github.com/i2-open/i2goSignals/pkg/ssfModels"
 	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 type ApiServerTestSuite struct {
@@ -53,8 +54,9 @@ func (s *ApiServerTestSuite) TearDownSuite() {
 }
 
 func (s *ApiServerTestSuite) TestServerCreate() {
-	// 1. Generate an IAT token (has ScopeRegister)
-	iat, err := s.sa.Auth.IssueProjectIat(nil)
+	// 1. Mint an admin token: /server provisioning is admin-only (issue #139).
+	client := model.SsfClient{Id: bson.NewObjectID(), ProjectIds: []string{"proj-A"}}
+	iat, err := s.sa.Auth.IssueStreamClientToken(client, "proj-A", true, "")
 	s.NoError(err)
 
 	token := "valid-token"

--- a/internal/server/test/api_server_crud_test.go
+++ b/internal/server/test/api_server_crud_test.go
@@ -12,6 +12,7 @@ import (
 	ssef "github.com/i2-open/i2goSignals/internal/server"
 	"github.com/i2-open/i2goSignals/pkg/ssfModels"
 	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 type ApiServerCrudTestSuite struct {
@@ -46,7 +47,9 @@ func (s *ApiServerCrudTestSuite) SetupSuite() {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 
-	iat, err := s.sa.Auth.IssueProjectIat(nil)
+	// /server provisioning is admin-only (issue #139); mint an admin token.
+	client := model.SsfClient{Id: bson.NewObjectID(), ProjectIds: []string{"proj-A"}}
+	iat, err := s.sa.Auth.IssueStreamClientToken(client, "proj-A", true, "")
 	s.NoError(err)
 	s.iat = iat
 }

--- a/internal/server/test/bootstrap_key_test.go
+++ b/internal/server/test/bootstrap_key_test.go
@@ -2,12 +2,43 @@ package test
 
 import (
 	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// generatePrivateKeyPEM produces a PKCS#8 RSA private-key PEM, standing in for
+// the caller-chosen issuer key material an attacker would attempt to upload.
+func generatePrivateKeyPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+}
+
+// postPemKey uploads PEM key material (Content-Type application/x-pem-file) to
+// POST /key/{keyName} carrying the supplied bearer, returning the HTTP status.
+func postPemKey(t *testing.T, instance *ssfInstance, bearer, keyName string, body []byte) int {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, instance.ts.URL+"/key/"+keyName, bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-pem-file")
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	resp, err := instance.client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
 
 // postKey issues POST /key/{keyName} (optionally with a force query) carrying
 // the supplied bearer, and returns the HTTP status.
@@ -99,6 +130,39 @@ func TestKeyScopeDeniedDelete(t *testing.T) {
 
 	status := deleteKey(t, instance, "boot-secret-key", "del.example.com")
 	assert.Equal(t, http.StatusForbidden, status, "key scope must NOT permit delete")
+}
+
+// TestKeyScopeDeniedUpload verifies a key-scope-only (bootstrap) caller cannot
+// upload caller-supplied key material for a brand-new issuer. A non-empty body
+// routes to the load-key path, which installs an issuer signing key chosen by
+// the caller (private PEM or external jwks_uri) with no force/rotate required.
+// Permitting it would let a bootstrap identity forge SETs under that issuer, so
+// the create-only "key" scope must be denied this path (it requires
+// stream_admin/root, the same scope LoadKeyHandler enforces).
+func TestKeyScopeDeniedUpload(t *testing.T) {
+	t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "boot-secret-key")
+	instance, err := createServer(t, "key_upload_test", true)
+	require.NoError(t, err)
+	defer instance.app.Shutdown()
+
+	pemBody := generatePrivateKeyPEM(t)
+	status := postPemKey(t, instance, "boot-secret-key", "attacker.example.com", pemBody)
+	assert.Equal(t, http.StatusForbidden, status,
+		"key scope must NOT permit uploading caller-supplied key material (SET-forgery vector)")
+}
+
+// TestAdminCanUploadKey confirms the upload restriction is additive: a full
+// stream_admin caller may still load caller-supplied key material.
+func TestAdminCanUploadKey(t *testing.T) {
+	t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "")
+	instance, err := createServer(t, "key_admin_upload_test", true)
+	require.NoError(t, err)
+	defer instance.app.Shutdown()
+
+	pemBody := generatePrivateKeyPEM(t)
+	status := postPemKey(t, instance, instance.streamMgmtToken, "adminupload.example.com", pemBody)
+	assert.Contains(t, []int{http.StatusOK, http.StatusCreated}, status,
+		"stream_admin may upload caller-supplied key material")
 }
 
 // TestAdminCanReplaceAndDelete confirms a full stream_admin token retains the

--- a/internal/server/test/register_ceiling_test.go
+++ b/internal/server/test/register_ceiling_test.go
@@ -65,6 +65,67 @@ func TestRegisterCannotSelfGrantStreamAdmin(t *testing.T) {
 	assert.Contains(t, granted, authSupport.ScopeStreamMgmt)
 }
 
+// TestRegisterAllDroppedScopesRejected verifies that an explicit, non-empty
+// scope list that filters entirely to empty (every entry unknown or above the
+// privilege ceiling) is rejected with 400 rather than silently producing a
+// zero-scope client that authorizes nothing (#137).
+func TestRegisterAllDroppedScopesRejected(t *testing.T) {
+	t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "")
+	instance, err := createServer(t, "register_all_dropped_test", true)
+	require.NoError(t, err)
+	defer instance.app.Shutdown()
+
+	// Above the ceiling: stream_admin only.
+	status, _ := registerClient(t, instance, instance.iatToken,
+		[]string{authSupport.ScopeStreamAdmin})
+	assert.Equal(t, http.StatusBadRequest, status,
+		"an explicit scope list of only above-ceiling scopes must be rejected with 400")
+
+	// Unknown scope only.
+	status, _ = registerClient(t, instance, instance.iatToken, []string{"bogus"})
+	assert.Equal(t, http.StatusBadRequest, status,
+		"an explicit scope list of only unknown scopes must be rejected with 400")
+}
+
+// TestRegisterNoScopesDefaults verifies the preserved behavior: a request with
+// NO scopes at all still yields the [stream, event] default grant (#137).
+func TestRegisterNoScopesDefaults(t *testing.T) {
+	t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "")
+	instance, err := createServer(t, "register_no_scopes_test", true)
+	require.NoError(t, err)
+	defer instance.app.Shutdown()
+
+	// No requested scopes falls back to the [stream, event] default at the
+	// handler. The issued stream-client token carries stream_mgmt (never admin)
+	// — the observable signal that the default grant succeeded.
+	status, granted := registerClient(t, instance, instance.iatToken, nil)
+	require.Equal(t, http.StatusOK, status,
+		"no requested scopes must succeed via the default grant")
+	assert.Contains(t, granted, authSupport.ScopeStreamMgmt)
+	assert.NotContains(t, granted, authSupport.ScopeStreamAdmin)
+}
+
+// TestRegisterMixedScopesAcceptedSubset verifies the preserved silent-drop
+// behavior for mixed requests (ADR 0006): an accepted scope alongside a dropped
+// one still succeeds, granting only the accepted subset (#137).
+func TestRegisterMixedScopesAcceptedSubset(t *testing.T) {
+	t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "")
+	instance, err := createServer(t, "register_mixed_scopes_test", true)
+	require.NoError(t, err)
+	defer instance.app.Shutdown()
+
+	// stream_mgmt is accepted; stream_admin is dropped (above the ceiling). The
+	// request still succeeds with the accepted subset, and the issued token must
+	// not carry admin.
+	status, granted := registerClient(t, instance, instance.iatToken,
+		[]string{authSupport.ScopeStreamMgmt, authSupport.ScopeStreamAdmin})
+	require.Equal(t, http.StatusOK, status,
+		"a mixed request must succeed with the accepted subset")
+	assert.Contains(t, granted, authSupport.ScopeStreamMgmt)
+	assert.NotContains(t, granted, authSupport.ScopeStreamAdmin,
+		"the dropped admin scope must not appear in the issued token")
+}
+
 // TestStreamMgmtClientCanCreateStream verifies the end-to-end SCIM-receiver
 // bootstrap: a client self-registered through /register is capped at
 // stream_mgmt + event_delivery (never stream_admin), and must still be able to

--- a/internal/server/test/register_scope_divergence_test.go
+++ b/internal/server/test/register_scope_divergence_test.go
@@ -1,0 +1,84 @@
+package test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/i2-open/i2goSignals/pkg/authSupport"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisterEventScopeIsCapabilityNotTokenRole pins the intentional divergence
+// reported in #140: a self-registered client's persisted AllowedScopes records
+// event_delivery as a *capability*, but the minted stream-client (management)
+// token never carries the event scope as a role.
+//
+// This is correct-by-design. Event delivery is authorized by a separate
+// per-stream delivery token (IssueStreamToken: Roles=[event] + StreamIds=[sid]),
+// minted at stream creation and handed to the counterparty — never by the
+// client/management token, which carries only stream_mgmt (and stream_admin only
+// for out-of-band-provisioned clients). The delivery endpoints additionally
+// require a StreamId the management token does not carry, so threading event into
+// the management token would produce a token that is still 403'd everywhere.
+//
+// The test guards against a future change that "reconciles" the divergence by
+// minting event into the management token (rejected option (a) in #140 triage):
+// that would flip the NotContains assertion and fail here.
+func TestRegisterEventScopeIsCapabilityNotTokenRole(t *testing.T) {
+	t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "")
+	instance, err := createServer(t, "register_scope_divergence_test", true)
+	require.NoError(t, err)
+	defer instance.app.Shutdown()
+
+	// Default path: no requested scopes yields the [stream, event] default grant.
+	status, clientToken, roles := registerClientToken(t, instance, instance.iatToken, nil)
+	require.Equal(t, http.StatusOK, status, "default registration must succeed")
+	require.NotEmpty(t, clientToken)
+
+	// Minted management token carries stream_mgmt but NOT event_delivery.
+	assert.Contains(t, roles, authSupport.ScopeStreamMgmt,
+		"the management token must carry stream_mgmt")
+	assert.NotContains(t, roles, authSupport.ScopeEventDelivery,
+		"event_delivery is a capability, never minted as a management-token role (#140)")
+
+	// Persisted AllowedScopes records event_delivery as a granted capability.
+	eat, err := instance.GetAuthIssuer().ParseAuthToken(clientToken)
+	require.NoError(t, err)
+	require.NotEmpty(t, eat.ClientId, "the management token must identify its client")
+	client, err := instance.clientSvc().GetClient(context.Background(), eat.ClientId)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.Contains(t, client.AllowedScopes, authSupport.ScopeEventDelivery,
+		"persisted AllowedScopes must record event_delivery as a granted capability")
+	assert.Contains(t, client.AllowedScopes, authSupport.ScopeStreamMgmt)
+}
+
+// TestRegisterExplicitEventScopeDivergence pins the same divergence (#140) on the
+// explicit-request path: a caller asking for [stream_mgmt, event_delivery] has
+// both granted and persisted, but the minted management token still omits event.
+func TestRegisterExplicitEventScopeDivergence(t *testing.T) {
+	t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "")
+	instance, err := createServer(t, "register_explicit_event_divergence_test", true)
+	require.NoError(t, err)
+	defer instance.app.Shutdown()
+
+	status, clientToken, roles := registerClientToken(t, instance, instance.iatToken,
+		[]string{authSupport.ScopeStreamMgmt, authSupport.ScopeEventDelivery})
+	require.Equal(t, http.StatusOK, status, "explicit [stream, event] registration must succeed")
+	require.NotEmpty(t, clientToken)
+
+	assert.Contains(t, roles, authSupport.ScopeStreamMgmt)
+	assert.NotContains(t, roles, authSupport.ScopeEventDelivery,
+		"an explicitly requested event scope is still not minted as a management-token role (#140)")
+
+	eat, err := instance.GetAuthIssuer().ParseAuthToken(clientToken)
+	require.NoError(t, err)
+	require.NotEmpty(t, eat.ClientId)
+	client, err := instance.clientSvc().GetClient(context.Background(), eat.ClientId)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.Contains(t, client.AllowedScopes, authSupport.ScopeEventDelivery,
+		"explicitly requested event_delivery must be persisted as a granted capability")
+}

--- a/internal/server/test/subject_filter_review_test.go
+++ b/internal/server/test/subject_filter_review_test.go
@@ -357,6 +357,59 @@ func (suite *SubjectFilterReviewSuite) TestReviewReturnsEventSourceAndGraceOverr
     assert.Equal(t, 600, review.SubjectRemovalGraceSeconds, "subject_removal_grace_seconds round-trips")
 }
 
+// TestReviewSurfacesEffectiveEventSourceAndGrace verifies that when a stream
+// carries Go zero-values — EventSource==nil and SubjectRemovalGraceSeconds==0 —
+// the admin review response still ALWAYS carries both fields on the wire (GH
+// #118): event_source resolves to the effective {"type":"AUDIENCE"} default and
+// subject_removal_grace_seconds is present as an explicit integer (the
+// configured I2SIG_SUBJECT_REMOVAL_GRACE default). goSignalsAdmin's Subjects
+// overview relies on these columns never being silently omitted.
+func (suite *SubjectFilterReviewSuite) TestReviewSurfacesEffectiveEventSourceAndGrace() {
+    t := suite.T()
+    t.Setenv("I2SIG_SUBJECT_REMOVAL_GRACE", "45")
+    instance := suite.instance
+    ctx := context.WithValue(context.Background(), authUtil.AuthContextKey,
+        &authUtil.AuthContext{ProjectId: instance.projectId})
+    created, err := instance.streamSvc().CreateStream(ctx, model.StreamStateRecord{
+        StreamConfiguration: model.StreamConfiguration{
+            Iss: "DEFAULT",
+            Aud: []string{"https://receiver.example.com"},
+            Delivery: &model.OneOfStreamConfigurationDelivery{
+                PollTransmitMethod: &model.PollTransmitMethod{Method: model.DeliveryPoll},
+            },
+        },
+        DefaultSubjects:   model.DefaultSubjectsNone,
+        SubjectFilterMode: model.SubjectFilterModeLocal,
+        // EventSource left nil and SubjectRemovalGraceSeconds left 0 — the
+        // zero-values that previously got omitted from the wire.
+    }, instance.projectId, nil)
+    require.NoError(t, err)
+
+    body := `{"stream_id":"` + created.Id + `"}`
+    resp := suite.postReview(suite.instance.streamMgmtToken, body)
+    require.Equal(t, http.StatusOK, resp.StatusCode)
+
+    raw, _ := io.ReadAll(resp.Body)
+    // Decode into a presence-sensitive map: the typed reviewResponse uses
+    // omitempty, which cannot distinguish "key absent" from "zero value".
+    var wire map[string]json.RawMessage
+    require.NoError(t, json.Unmarshal(raw, &wire), "response must be JSON: %s", string(raw))
+
+    esRaw, esPresent := wire["event_source"]
+    require.True(t, esPresent, "event_source key must always be present: %s", string(raw))
+    var es model.EventSource
+    require.NoError(t, json.Unmarshal(esRaw, &es))
+    assert.Equal(t, model.EventSourceAudience, es.Type,
+        "nil stream EventSource must resolve to effective AUDIENCE")
+
+    graceRaw, gracePresent := wire["subject_removal_grace_seconds"]
+    require.True(t, gracePresent, "subject_removal_grace_seconds key must always be present: %s", string(raw))
+    var grace int
+    require.NoError(t, json.Unmarshal(graceRaw, &grace))
+    assert.Equal(t, 45, grace,
+        "zero per-stream grace must resolve to the configured I2SIG_SUBJECT_REMOVAL_GRACE default")
+}
+
 // reviewResponse mirrors the wire shape of the admin review endpoint. It is
 // kept inside the test package so the test pins the JSON contract independently
 // of the server's internal types.

--- a/internal/services/client_service.go
+++ b/internal/services/client_service.go
@@ -34,10 +34,14 @@ func (s *ClientService) RegisterClient(ctx context.Context, client model.SsfClie
 		return nil
 	}
 
-	// Issue a token reflecting only the scopes the client was actually granted.
-	// A self-registered client is capped below stream_admin by the registration
-	// handler's privilege ceiling, so admin is granted only when the client's
-	// AllowedScopes explicitly carry stream_admin (out-of-band provisioning).
+	// Issue the stream-client (management) token. Only stream-management roles are
+	// minted here: stream_mgmt always, and stream_admin when AllowedScopes carries
+	// it (out-of-band provisioning, capped below by the /register ceiling).
+	//
+	// event_delivery is deliberately NOT minted, even when AllowedScopes records it
+	// as a granted capability. Event delivery is authorized by a separate per-stream
+	// delivery token (IssueStreamToken), so the management token's roles diverge
+	// from AllowedScopes by design (#140). See SsfClient.AllowedScopes.
 	admin := slices.Contains(client.AllowedScopes, authSupport.ScopeStreamAdmin)
 	token, err := s.keyService.GetAuthIssuer().IssueStreamClientToken(client, projectID, admin, parentJTI)
 	if err != nil {

--- a/pkg/ssfModels/model_client.go
+++ b/pkg/ssfModels/model_client.go
@@ -4,11 +4,19 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
-// SsfClient describes a client entity that may manage one or more streams within one or more projects
+// SsfClient describes a client entity that may manage one or more streams within one or more projects.
+//
+// AllowedScopes records the capabilities the client was granted, which is not the
+// same as the roles minted into its stream-client (management) token. In
+// particular, event_delivery may appear here as a granted capability while the
+// management token never carries it as a role: event delivery is authorized by a
+// separate per-stream delivery token (see authUtil.IssueStreamToken), not by the
+// management token. This divergence is intentional (#140) — do not "reconcile" it
+// by minting event_delivery into the management token.
 type SsfClient struct {
 	Id            bson.ObjectID `bson:"_id" json:"client_id"`  // The Client identifier or client_id
 	ProjectIds    []string      `json:"project_ids"`           // Project ids that the client is allowed to access
-	AllowedScopes []string      `json:"allowed_scopes"`        // What scopes the client may be issued
+	AllowedScopes []string      `json:"allowed_scopes"`        // Capabilities granted to the client; see note below
 	Email         string        `json:"email,omitempty"`       // The contact email address
 	Description   string        `json:"description,omitempty"` // A description of the client
 }


### PR DESCRIPTION
## Summary

Integration branch consolidating a batch of token-lifecycle, authorization, CLI, and SSF-conformance fixes accumulated since the last merge to `master`. Each commit maps to a tracked issue and is independently reviewable; they are bundled here as one PR.

## What's included (newest first)

**Authorization & registration**
- `#140` — docs(authz): pin event-scope capability/token-role divergence. Document that a registered client's `AllowedScopes` records `event` as a *capability* while the management token intentionally never mints it (delivery is authorized per-stream); add a characterization test guarding against re-introducing the rejected reconciliation.
- `#139` — fix(authz): foreign-server provisioning requires admin scope.
- `#137` — fix(register): reject all-dropped explicit scopes with 400 (no silent zero-scope client).
- `#127` follow-up — fix(keys): deny key-scope callers uploading key material.

**Token lifecycle (revoke/introspect/retention/provenance)**
- `#133` — feat(tokens): RFC 7009 `/revoke` + RFC 7662 `/introspect` conformance + project guard.
- `#132` — feat(tokens): caller-scoped enriched `GET /token` list.
- `#131` — feat(tokens): Mongo TTL auto-expiry for token records + `I2SIG_TOKEN_RETENTION`.
- `#130` — feat(tokens): record redemption provenance + parent lineage.
- TTL index ensured once per process; bound-check retention before int32 narrowing.
- code-review fixes: CLI usage IP, project fail-closed, single introspect read, shared liveness.
- docs(adr): ADR 0007 (track redemption not issuance), ADR 0008 (two revocation endpoints).

**CLI**
- `#143` — fix(cli): `credentialsPath` honors directory-valued `GOSIGNALS_HOME`.
- `#142` — fix(cli): treat zero session `Expiry` as needs-refresh, not never-expiring.
- `#138` — fix(cli): migrate management commands to `serverBearer` for OAuth-login users.
- `#129` — fix(cli): token subcommands use `serverBearer` auth + table/JSON rendering.

**SSF event handling**
- `#118` — fix(subject-filter): review surfaces effective `event_source` + grace.

## Testing

- `go build ./...` clean.
- Touched-package suites pass (`internal/server/test`, `internal/services`, `internal/authUtil`).
- No new `go vet` warnings beyond the pre-existing duplicate-JSON-tag set in `pkg/ssfModels`/`pkg/goScim`.

## Notes for reviewers

Commits are scoped per issue for granular review. The branch name reflects its origin (`#127` key-scope upload guard) but the branch has since served as the integration point for the issues above.



Closes #140
