### PR TITLE
fix(authz): determine server type from well-known gosignals_version (#141)

### DIFF
--- a/internal/services/server_service.go
+++ b/internal/services/server_service.go
@@ -57,22 +57,73 @@ func (s *ServerService) CreateServer(ctx context.Context, server *model.Server) 
 		// TODO: Validate IAT token based config? Issue is that validation of an IAT may cause IAT to expire
 	}
 
-	// Infer the server Type from the resolved auth mode when the caller leaves
-	// it empty. A foreign SSF transmitter authenticated via OAuth client
-	// credentials is ServerTypeSsf; everything else defaults to
-	// ServerTypeGosignals. The CLI deliberately leaves Type unset (PRD #83 /
-	// #85: no --type flag).
+	// Determine the server Type via well-known discovery when the caller leaves
+	// it empty. An explicit caller value always wins. The CLI deliberately
+	// leaves Type unset (PRD #83 / #85: no --type flag), so the server is
+	// authoritative. See resolveServerType for the discovery ladder.
 	if server.Type == "" {
-		if server.GetAuthMode() == model.AuthModeClient {
-			server.Type = model.ServerTypeSsf
-		} else {
-			server.Type = model.ServerTypeGosignals
-		}
+		server.Type = s.resolveServerType(ctx, server)
 	}
 
 	// We are assuming the client previously validated the server. We may still need to deal with connectivity issues where the admin server can reach the SSF server but this server cannot.
 
 	return s.serverDAO.Create(ctx, server)
+}
+
+// resolveServerType classifies a peer server by querying its well-known
+// metadata rather than guessing from the auth mode (issue #141). The only
+// positive signal for a goSignals peer is gosignals_version in SSF discovery;
+// PRM/OIDC are used for reachability + endpoint harvest, never to decide type.
+//
+// Discovery ladder (runs for OAuth-client / token / IAT modes):
+//
+//	1. SSF discovery parses AND has gosignals_version -> gosignals
+//	2. SSF discovery parses, but no gosignals_version  -> ssf
+//	3. No SSF discovery, but PRM resolves              -> ssf (harvest endpoints)
+//	4. Nothing resolves                                -> gosignals (provenance)
+//
+// SPIFFE skips the ladder and stays gosignals by provenance (closed trust
+// domain, never a foreign SSF peer; avoids a handshake just to classify).
+func (s *ServerService) resolveServerType(ctx context.Context, server *model.Server) string {
+	if server.GetAuthMode() == model.AuthModeSpiffe {
+		return model.ServerTypeGosignals
+	}
+
+	client, closeClient, err := oauthClient.GetClientForServer(ctx, server)
+	if err != nil {
+		srvLog.Debug("Type discovery: could not build client, defaulting to gosignals by provenance",
+			"alias", server.Alias, "err", err)
+		return model.ServerTypeGosignals
+	}
+	defer closeClient()
+
+	// Step 1 & 2: SSF discovery is the only signal that can yield gosignals.
+	if cfg, err := wellKnownSupport.FetchSSFConfiguration(ctx, client, server.Host); err == nil && cfg != nil {
+		server.ServerConfiguration = cfg
+		if cfg.IsGoSignalsServer() {
+			return model.ServerTypeGosignals
+		}
+		return model.ServerTypeSsf
+	}
+
+	// Step 3: No (parseable) SSF discovery -> try PRM. An external RFC8935/8936
+	// server is ssf; harvest its overlapping metadata into ServerConfiguration.
+	if prm, err := wellKnownSupport.FetchProtectedResourceMetadata(ctx, client, server.Host); err == nil && prm != nil {
+		if server.ServerConfiguration == nil {
+			server.ServerConfiguration = &model.TransmitterConfiguration{}
+		}
+		server.ServerConfiguration.AuthorizationServers = prm.AuthorizationServers
+		server.ServerConfiguration.ScopesSupported = prm.ScopesSupported
+		server.ServerConfiguration.BearerMethodsSupported = prm.BearerMethodsSupported
+		return model.ServerTypeSsf
+	}
+
+	// Step 4: Nothing resolved -> keep gosignals by provenance. OAuth-client
+	// mode has already hard-failed reachability upstream, so this path is for
+	// token/IAT peers we simply could not probe.
+	srvLog.Debug("Type discovery: no SSF/PRM metadata, defaulting to gosignals by provenance",
+		"alias", server.Alias, "host", server.Host)
+	return model.ServerTypeGosignals
 }
 
 func (s *ServerService) GetServer(ctx context.Context, id string) (*model.Server, error) {

--- a/internal/services/server_service_test.go
+++ b/internal/services/server_service_test.go
@@ -21,9 +21,16 @@ type ServerServiceTestSuite struct {
 func (s *ServerServiceTestSuite) SetupTest() {
 	dao := memory.NewServerDAO()
 	s.service = NewServerService(dao)
+	// s.ssfServer represents a reachable goSignals peer: its SSF discovery
+	// document parses AND advertises gosignals_version. A 200 with an empty
+	// body is a parse failure under Fetch*, so the body must be valid JSON.
 	s.ssfServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/.well-known/ssf-configuration" {
-			w.WriteHeader(http.StatusOK)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issuer":            r.Host,
+				"gosignals_version": "1.0.0",
+			})
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
@@ -250,6 +257,11 @@ func (s *ServerServiceTestSuite) TestCreateServer_SelfSignedCertDiscovery() {
 // Type empty but supplies an OAuthClientConfig, CreateServer infers and
 // persists Type == ssf (the foreign SSF transmitter case for PRD #83 / #85).
 func (s *ServerServiceTestSuite) TestCreateServer_InfersSsfTypeFromOAuth() {
+	// Foreign SSF transmitter: SSF discovery parses but advertises NO
+	// gosignals_version -> step 2 of the ladder yields ssf.
+	ssfPeer := newSsfOnlyServer()
+	defer ssfPeer.Close()
+
 	asServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -262,7 +274,7 @@ func (s *ServerServiceTestSuite) TestCreateServer_InfersSsfTypeFromOAuth() {
 
 	server := &model.Server{
 		Alias: "ssf-tx",
-		Host:  s.ssfServer.URL,
+		Host:  ssfPeer.URL,
 		OAuthClientConfig: &model.OAuthClientConfig{
 			TokenURL:     asServer.URL,
 			ClientID:     "client",
@@ -295,6 +307,181 @@ func (s *ServerServiceTestSuite) TestCreateServer_InfersGosignalsTypeFromToken()
 	retrieved, err := s.service.GetServerByAlias(s.T().Context(), "gs-server")
 	s.NoError(err)
 	s.Equal(model.ServerTypeGosignals, retrieved.Type)
+}
+
+// newSsfOnlyServer returns a mock that advertises SSF discovery WITHOUT a
+// gosignals_version (a genuine foreign SSF transmitter) plus a token endpoint.
+func newSsfOnlyServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/.well-known/ssf-configuration":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issuer": r.Host,
+			})
+		case "/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "test-token",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// TestCreateServer_OAuthClientGosignalsPeer_NotMislabeled is the issue #141
+// regression: an OAuth-client peer whose SSF discovery advertises
+// gosignals_version must be persisted as gosignals, not ssf.
+func (s *ServerServiceTestSuite) TestCreateServer_OAuthClientGosignalsPeer_NotMislabeled() {
+	asServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "test-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer asServer.Close()
+
+	server := &model.Server{
+		Alias: "gosignals-oauth-peer",
+		Host:  s.ssfServer.URL, // advertises gosignals_version
+		OAuthClientConfig: &model.OAuthClientConfig{
+			TokenURL:     asServer.URL,
+			ClientID:     "client",
+			ClientSecret: "secret",
+		},
+	}
+
+	err := s.service.CreateServer(s.T().Context(), server)
+	s.NoError(err)
+
+	retrieved, err := s.service.GetServerByAlias(s.T().Context(), "gosignals-oauth-peer")
+	s.NoError(err)
+	s.Equal(model.ServerTypeGosignals, retrieved.Type)
+}
+
+// TestCreateServer_ExternalRfc8935NoSsfDiscovery_PrmFallback is step 3: a peer
+// with no SSF discovery but a resolvable PRM is classified ssf, and its
+// authorization_servers are harvested onto ServerConfiguration.
+func (s *ServerServiceTestSuite) TestCreateServer_ExternalRfc8935NoSsfDiscovery_PrmFallback() {
+	var asURL string
+	prmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/.well-known/oauth-protected-resource":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"authorization_servers": []string{asURL},
+				"scopes_supported":      []string{"ssf.manage"},
+			})
+		case "/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "test-token",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			})
+		case "/.well-known/ssf-configuration":
+			// Reachable (status-only validation passes) but a 200 with an
+			// empty body is a parse failure under Fetch*, dropping the ladder
+			// to the PRM branch (step 3) -- the empty-body gotcha.
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer prmServer.Close()
+	asURL = prmServer.URL
+
+	server := &model.Server{
+		Alias: "external-rfc8935",
+		Host:  prmServer.URL,
+		OAuthClientConfig: &model.OAuthClientConfig{
+			TokenURL:     prmServer.URL + "/token",
+			ClientID:     "client",
+			ClientSecret: "secret",
+		},
+	}
+
+	err := s.service.CreateServer(s.T().Context(), server)
+	s.NoError(err)
+
+	retrieved, err := s.service.GetServerByAlias(s.T().Context(), "external-rfc8935")
+	s.NoError(err)
+	s.Equal(model.ServerTypeSsf, retrieved.Type)
+	s.Require().NotNil(retrieved.ServerConfiguration)
+	s.Equal([]string{asURL}, retrieved.ServerConfiguration.AuthorizationServers)
+}
+
+// TestCreateServer_UnreachablePeerTokenMode_FallsBackGosignals is step 4: a
+// token-mode peer whose host cannot be probed keeps gosignals by provenance.
+func (s *ServerServiceTestSuite) TestCreateServer_UnreachablePeerTokenMode_FallsBackGosignals() {
+	token := "valid-token"
+	// Reachable-but-empty server: validation passes (status-only), but neither
+	// SSF nor PRM parses, so the ladder reaches step 4.
+	bareServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/ssf-configuration" {
+			// 200 with empty body == parse failure under Fetch*.
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer bareServer.Close()
+
+	server := &model.Server{
+		Alias:       "unreachable-token-peer",
+		Host:        bareServer.URL,
+		ClientToken: &token,
+	}
+
+	err := s.service.CreateServer(s.T().Context(), server)
+	s.NoError(err)
+
+	retrieved, err := s.service.GetServerByAlias(s.T().Context(), "unreachable-token-peer")
+	s.NoError(err)
+	s.Equal(model.ServerTypeGosignals, retrieved.Type)
+}
+
+// TestCreateServer_ExplicitTypeWins proves an explicit caller Type is preserved
+// and the discovery ladder is skipped (even when discovery would say otherwise).
+func (s *ServerServiceTestSuite) TestCreateServer_ExplicitTypeWins() {
+	token := "valid-token"
+	// s.ssfServer advertises gosignals_version (would resolve to gosignals),
+	// but the caller explicitly asks for ssf.
+	server := &model.Server{
+		Alias:       "explicit-type",
+		Type:        model.ServerTypeSsf,
+		Host:        s.ssfServer.URL,
+		ClientToken: &token,
+	}
+
+	err := s.service.CreateServer(s.T().Context(), server)
+	s.NoError(err)
+
+	retrieved, err := s.service.GetServerByAlias(s.T().Context(), "explicit-type")
+	s.NoError(err)
+	s.Equal(model.ServerTypeSsf, retrieved.Type)
+}
+
+// TestCreateServer_PersistsDiscoveredConfiguration proves a step-1 success
+// records the decoded SSF configuration (including gosignals_version).
+func (s *ServerServiceTestSuite) TestCreateServer_PersistsDiscoveredConfiguration() {
+	token := "valid-token"
+	server := &model.Server{
+		Alias:       "persist-config",
+		Host:        s.ssfServer.URL,
+		ClientToken: &token,
+	}
+
+	err := s.service.CreateServer(s.T().Context(), server)
+	s.NoError(err)
+
+	retrieved, err := s.service.GetServerByAlias(s.T().Context(), "persist-config")
+	s.NoError(err)
+	s.Require().NotNil(retrieved.ServerConfiguration)
+	s.Equal("1.0.0", retrieved.ServerConfiguration.GoSignalsVersion)
 }
 
 func TestServerServiceSuite(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #141. `CreateServer` previously inferred `Type = ssf` whenever `GetAuthMode() == AuthModeClient`, which mislabeled genuine **gosignals** peers reached via OAuth client-credentials as `ssf`.

This replaces the auth-mode heuristic with a `resolveServerType` discovery ladder driven by the peer's well-known SSF configuration. `gosignals_version` in SSF discovery is the *only* positive signal for a goSignals server; PRM/OIDC are used for reachability + endpoint harvest, never to decide type. An explicit caller `Type` always wins.

## Discovery ladder

Runs for OAuth-client / token / IAT modes:

| Step | Condition | Result |
|------|-----------|--------|
| 1 | SSF discovery parses **and** has `gosignals_version` | `gosignals` ← the bug fix |
| 2 | SSF discovery parses, no `gosignals_version` | `ssf` |
| 3 | No SSF discovery, PRM resolves | `ssf` (harvest endpoints) |
| 4 | Nothing resolves | `gosignals` by provenance |

SPIFFE skips the ladder and stays `gosignals` by provenance. On a successful SSF fetch the decoded config is persisted into `server.ServerConfiguration`; on the PRM branch the overlapping fields (`AuthorizationServers`, `ScopesSupported`, `BearerMethodsSupported`) are harvested.

## Tests

All 7 planned tests added/updated and passing under `go test -race ./internal/services/...`:

- `TestCreateServer_OAuthClientGosignalsPeer_NotMislabeled` (the #141 regression)
- `TestCreateServer_InfersSsfTypeFromOAuth`
- `TestCreateServer_InfersGosignalsTypeFromToken`
- `TestCreateServer_ExternalRfc8935NoSsfDiscovery_PrmFallback`
- `TestCreateServer_UnreachablePeerTokenMode_FallsBackGosignals`
- `TestCreateServer_ExplicitTypeWins`
- `TestCreateServer_PersistsDiscoveredConfiguration`