### PR TITLE
fix(authz): honor OAuth/STS scope in token-admin + tx_alias/stream/key gates (#128, #150)

### DIFF
--- a/DECISIONS_LOG.md
+++ b/DECISIONS_LOG.md
@@ -3,6 +3,40 @@
 
 # Architectural Decision & Regression Log
 
+## [2026-06-02] Token-admin endpoints honor OAuth/STS admin scope (PRD #128 regression)
+
+### Change
+The PRD #128 token-admin endpoints (`GET /token`, `DELETE /token/{jti}`,
+`POST /introspect`) returned nothing / acted as no-ops for an admin caller whose
+token was obtained via STS/OAuth exchange (e.g. the GoSignalsAdmin console).
+`ProjectScope` derived "admin sees all" from `AuthContext.Eat`, but
+`validateOAuthToken` returns `Eat: nil` for every OAuth-validated caller, so
+`ProjectScope(nil)` fell through to the fail-closed empty-project branch.
+
+`internal/authUtil/auth_token.go` now records the AS-granted scopes on the
+`AuthContext` (`GrantedScopes`), and `services.ProjectScope` takes the whole
+`*authUtil.AuthContext` (not just the EAT) so it can grant the unrestricted view
+to an OAuth caller on the strength of its `admin` grant.
+
+### Decisions
+*   **OAuth callers are gated on `admin`, never on a foreign `root`.** Consistent
+    with the [#144] decision below, a scope literally named `root` on an external
+    token does NOT confer the unrestricted view — only `admin` does. The root
+    super-power remains reserved for locally issued tokens (whose EAT roles are
+    still evaluated via `EventAuthToken.IsScopeMatch`, unchanged).
+*   **`ProjectScope` is the single source of truth, now AuthContext-typed.** Both
+    `ListForAuthority` and the single-token guard `callerMayActOnProject` route
+    through it, so the OAuth fix lands on list, revoke, and introspect together.
+    `internal/services` already depends on `internal/authUtil` (no new cycle).
+*   **Fail-closed posture is preserved.** A non-admin OAuth caller (no project,
+    no `admin`) still sees nothing rather than the empty-project bucket.
+*   **CLI `token list` reworked to match.** Dropped the `--project`/`--client`
+    flags (the server ignored them and the "must specify…" client-side error
+    blocked admins entirely); added an optional `<alias>` arg to target a
+    specific configured server and `--type`/`--active` filters that map to the
+    query params the server actually honors. CLI bearer/STS acquisition is
+    explicitly out of scope for this fix.
+
 ## [2026-06-02] OAuth bearer validation: audience + algorithm allow-list, drop bare-root role (issue #144)
 
 ### Change

--- a/DECISIONS_LOG.md
+++ b/DECISIONS_LOG.md
@@ -3,6 +3,50 @@
 
 # Architectural Decision & Regression Log
 
+## [2026-06-02] tx_alias provisioning scope policy + shape-aware scope checks (issue #150)
+
+### Change
+Creating a stream against a FOREIGN transmitter (`tx_alias` set) failed with
+`403 "...requires admin scope"` for an admin caller whose token came via STS/OAuth
+(the GoSignalsAdmin console), even with scopes `admin, stream, reg, event`. Same
+root cause as [#128]: the gate added by the #139 tx_alias work read scope off
+`AuthContext.Eat`, but `validateOAuthToken` returns `Eat: nil` for every
+OAuth/STS caller, so the check denied them regardless of granted scope.
+
+`internal/authUtil/auth_token.go` gained two shape-aware predicates that are the
+ONLY sanctioned way to scope-check a caller:
+*   `AuthContext.HasScope(scopes...)` — OR semantics; reads `GrantedScopes` for
+    OAuth callers and the EAT for local tokens.
+*   `AuthContext.IsAuthorizedForStream(streamId, scopes...)` — the stream-bound
+    companion; preserves the EAT's stream-id binding for local tokens and reduces
+    to `HasScope` for OAuth callers (the bearer token carries no per-stream bind).
+
+Three direct-`Eat` scope sites were migrated onto them: the new tx_alias gate
+(`canProvisionTxAlias` in `api_stream_management.go`), the `StreamUpdate` payload
+re-check (`api_stream_management.go`), and the create-only key guard
+(`keyScopeOnly` in `api_out_of_band.go`).
+
+### Decisions
+*   **tx_alias provisioning needs `admin` OR the full `reg`+`stream`+`event` set.**
+    A `tx_alias` stream drives a remote stream's entire lifecycle (create, start,
+    poll), so a partial subset is not enough. `admin` covers it (local `root`
+    rides free); otherwise the caller must hold all three of register (create),
+    stream (manage/status), and event (poll) together. Register alone is
+    deliberately denied. Plain (non-`tx_alias`) stream create is unchanged and
+    still accepts any of `reg`/`stream`/`admin`.
+*   **`reg` is a first-class create scope, not a legacy IAT-only path.** A
+    `reg, stream, event` credential can create, start, monitor, and poll a plain
+    stream. Locked by `TestStreamCreate_PlainAtRegScopeSucceeds`.
+*   **Never scope-check via `authCtx.Eat` directly.** This bug class has bitten
+    twice (#128, #139); the `Eat`-only shape silently denies every OAuth/STS
+    caller. `HasScope`/`IsAuthorizedForStream` are now the house pattern. Foreign
+    `root` is never honored for OAuth callers, consistent with [#144].
+*   **`keyScopeOnly` migration also closed a latent privilege escalation.** The
+    old `Eat`-only predicate returned `false` for OAuth callers (`Eat==nil`),
+    which *exempted* an OAuth key-only caller from the create-only guard and
+    granted full key takeover/upload. Routing through `HasScope` correctly
+    restricts them; local behavior is unchanged. Locked by `TestKeyScopeOnly`.
+
 ## [2026-06-02] Token-admin endpoints honor OAuth/STS admin scope (PRD #128 regression)
 
 ### Change

--- a/cmd/goSignals/commands.go
+++ b/cmd/goSignals/commands.go
@@ -2137,29 +2137,30 @@ func renderTokenTable(records []tokenListEntry) string {
 }
 
 type TokenListCmd struct {
-	Project string `help:"Filter by project ID"`
-	Client  string `help:"Filter by client ID"`
-	Json    bool   `help:"Emit the raw JSON response instead of a table"`
+	Alias  string `arg:"" optional:"" help:"Alias of the server to query (default is the selected server)"`
+	Type   string `help:"Filter by token type: IAT or STREAM" enum:"IAT,STREAM," default:""`
+	Active string `help:"Filter by liveness: true (active) or false (revoked/expired)" enum:"true,false," default:""`
+	Json   bool   `help:"Emit the raw JSON response instead of a table"`
 }
 
 func (t *TokenListCmd) Run(cli *CLI) error {
-	server, err := cli.Data.GetServer("")
+	server, err := cli.Data.GetServer(t.Alias)
 	if err != nil {
 		return err
 	}
 
+	// Project/client scope is derived server-side from the caller's bearer, never
+	// from a query param. The only filters the server honors are type and active.
+	q := url.Values{}
+	if t.Type != "" {
+		q.Set("type", t.Type)
+	}
+	if t.Active != "" {
+		q.Set("active", t.Active)
+	}
 	reqUrl := server.Host + "/token"
-	if t.Client != "" {
-		reqUrl += "?client_id=" + t.Client
-	} else if t.Project != "" {
-		reqUrl += "?project_id=" + t.Project
-	} else {
-		// Default to current project if available
-		if server.ProjectId != "" {
-			reqUrl += "?project_id=" + server.ProjectId
-		} else {
-			return errors.New("must specify --project or --client")
-		}
+	if len(q) > 0 {
+		reqUrl += "?" + q.Encode()
 	}
 
 	req, err := http.NewRequest(http.MethodGet, reqUrl, nil)

--- a/cmd/goSignals/token_cmd_test.go
+++ b/cmd/goSignals/token_cmd_test.go
@@ -174,6 +174,71 @@ func TestTokenListCmd_TableByDefault(t *testing.T) {
     assert.NotContains(t, out, `"jti":`, "default output should be a table, not JSON")
 }
 
+// TestTokenListCmd_NoProjectFilter is the CLI half of the PRD-128 fix: the
+// command must NOT inject a project_id/client_id query param (the server ignores
+// them and derives scope from the bearer), and must not hard-error when no
+// filter is given. An admin caller relies on this to list all tokens.
+func TestTokenListCmd_NoProjectFilter(t *testing.T) {
+    var gotQuery string
+    stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        gotQuery = r.URL.RawQuery
+        w.Header().Set("Content-Type", "application/json")
+        _ = json.NewEncoder(w).Encode(fixedTokenRecords())
+    }))
+    defer stub.Close()
+
+    cli := configuredTokenCLI(t, stub.URL)
+    require.NoError(t, (&TokenListCmd{}).Run(cli))
+    assert.NotContains(t, gotQuery, "project_id", "token list must not send project_id")
+    assert.NotContains(t, gotQuery, "client_id", "token list must not send client_id")
+}
+
+// TestTokenListCmd_TypeAndActiveFilters proves the supported server-side filters
+// (type, active) are passed through as query params.
+func TestTokenListCmd_TypeAndActiveFilters(t *testing.T) {
+    var gotQuery string
+    stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        gotQuery = r.URL.RawQuery
+        w.Header().Set("Content-Type", "application/json")
+        _ = json.NewEncoder(w).Encode(fixedTokenRecords())
+    }))
+    defer stub.Close()
+
+    cli := configuredTokenCLI(t, stub.URL)
+    require.NoError(t, (&TokenListCmd{Type: "IAT", Active: "true"}).Run(cli))
+    assert.Contains(t, gotQuery, "type=IAT")
+    assert.Contains(t, gotQuery, "active=true")
+}
+
+// TestTokenListCmd_Alias proves "token list <alias>" targets the named server
+// rather than the currently-selected one.
+func TestTokenListCmd_Alias(t *testing.T) {
+    var selectedHit, aliasHit bool
+    selected := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        selectedHit = true
+        w.Header().Set("Content-Type", "application/json")
+        _ = json.NewEncoder(w).Encode(fixedTokenRecords())
+    }))
+    defer selected.Close()
+    other := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        aliasHit = true
+        w.Header().Set("Content-Type", "application/json")
+        _ = json.NewEncoder(w).Encode(fixedTokenRecords())
+    }))
+    defer other.Close()
+
+    cli := configuredTokenCLI(t, selected.URL)
+    cli.Data.Servers["gs2"] = SsfServer{
+        Alias:       "gs2",
+        Host:        other.URL,
+        ClientToken: "gs2-token",
+    }
+
+    require.NoError(t, (&TokenListCmd{Alias: "gs2"}).Run(cli))
+    assert.True(t, aliasHit, "token list gs2 should hit the gs2 server")
+    assert.False(t, selectedHit, "token list gs2 should not hit the selected server")
+}
+
 // TestTokenIntrospectCmd_UsesSessionBearer proves introspect authenticates via
 // the session bearer.
 func TestTokenIntrospectCmd_UsesSessionBearer(t *testing.T) {

--- a/docs/gosignals_tool.md
+++ b/docs/gosignals_tool.md
@@ -398,9 +398,10 @@ for the authorization rules and provenance model, and ADRs
 
 > ```
 > Commands:
-> token list        List issued tokens
->     --project=STRING   Filter by project ID
->     --client=STRING    Filter by client ID
+> token list [<alias>]       List issued tokens
+>     <alias>            Server to query (default is the selected server)
+>     --type=STRING      Filter by token type: IAT or STREAM
+>     --active=STRING    Filter by liveness: true (active) or false (revoked/expired)
 >     --json             Emit the raw JSON response instead of a table
 > token introspect <token>   Introspect a token (RFC 7662)
 >     --json             Emit the raw JSON response instead of a table
@@ -408,11 +409,15 @@ for the authorization rules and provenance model, and ADRs
 >     --json             Emit the raw JSON response instead of a confirmation message
 > ```
 
-- **`token list`** renders a human-readable table by default — JTI, client,
-  subject, type, scopes, issued, expires, state (revoked &gt; expired &gt;
-  active), and usage IP (the stream's last-seen IP or the IAT's last-redemption
-  IP). With neither `--client` nor `--project`, it defaults to the selected
-  server's current project; if none is known it errors asking for one. `--json`
+- **`token list [<alias>]`** renders a human-readable table by default — JTI,
+  client, subject, type, scopes, issued, expires, state (revoked &gt; expired
+  &gt; active), and usage IP (the stream's last-seen IP or the IAT's
+  last-redemption IP). The optional `<alias>` selects which configured server to
+  query (default is the selected server). Project/client visibility is derived
+  server-side from the caller's bearer — never from a query param — so there are
+  no `--project`/`--client` flags: a non-admin sees its own project, `admin`/`root`
+  (including an admin scope obtained via STS exchange) see every project. The
+  `--type` (IAT|STREAM) and `--active` (true|false) filters compose. `--json`
   emits the raw enriched response (for scripting / the GoSignalsAdmin backend).
 - **`token introspect <token>`** POSTs the token string to `/introspect`
   (RFC 7662) and prints the JSON response: `active`, the RFC 7662 `token_type`,

--- a/internal/authUtil/auth_token.go
+++ b/internal/authUtil/auth_token.go
@@ -43,9 +43,15 @@ var oauthAllowedAlgs = []string{"RS256", "RS384", "RS512", "PS256", "PS384", "PS
 var oauthAudWarnOnce sync.Once
 
 type AuthContext struct {
-	StreamId      string
-	ProjectId     string
-	Eat           *authSupport.EventAuthToken
+	StreamId  string
+	ProjectId string
+	Eat       *authSupport.EventAuthToken
+	// GrantedScopes carries the scopes the caller was actually granted. For an
+	// OAuth/STS-validated caller (IsOAuthClient) there is no local EAT to read
+	// roles from, so this is the only record of its authority — used by
+	// ProjectScope to grant the unrestricted (admin) view. For a locally issued
+	// token the EAT roles remain authoritative.
+	GrantedScopes []string
 	IsOAuthClient bool
 }
 
@@ -624,11 +630,16 @@ func (a *AuthIssuer) validateOAuthToken(tokenString string, streamRequested stri
 					hasScopes = append(hasScopes, strings.Fields(claims.Scope)...)
 				}
 				if oidcRolesMatchScopes(hasScopes, scopesAccepted) {
-					// External tokens don't carry our ProjectId or stream restrictions; accept scope-based access
+					// External tokens don't carry our ProjectId or stream restrictions; accept scope-based access.
+					// GrantedScopes preserves the AS-granted scope set so downstream
+					// authorization (e.g. the token-admin endpoints' ProjectScope) can
+					// still tell an admin caller apart from a confined one — the nil
+					// Eat would otherwise erase that distinction.
 					return &AuthContext{
 						StreamId:      streamRequested,
 						ProjectId:     "",
 						Eat:           nil,
+						GrantedScopes: hasScopes,
 						IsOAuthClient: true,
 					}, true, false
 				}

--- a/internal/authUtil/auth_token.go
+++ b/internal/authUtil/auth_token.go
@@ -55,6 +55,57 @@ type AuthContext struct {
 	IsOAuthClient bool
 }
 
+// HasScope reports whether the caller holds any of the named scopes, accounting
+// for both caller shapes so a scope check never silently fails for an OAuth/STS
+// caller. A locally issued token's EAT is authoritative (root rides free, per
+// EventAuthToken.IsScopeMatch). An OAuth/STS-validated caller has no EAT; its
+// authority is the scope set granted by the trusted authorization server
+// (GrantedScopes), matched literally and case-insensitively. A foreign scope
+// literally named "root" is never honored for OAuth callers (issue #144) — that
+// super-power is reserved for locally issued tokens.
+//
+// Prefer this over reaching into authCtx.Eat directly: an Eat-only check denies
+// every OAuth/STS caller because their Eat is nil (see #128, #139).
+func (a *AuthContext) HasScope(scopes ...string) bool {
+	if a == nil {
+		return false
+	}
+	if a.IsOAuthClient {
+		for _, want := range scopes {
+			if strings.EqualFold(want, authSupport.ScopeRoot) {
+				continue // foreign root is never honored (#144)
+			}
+			for _, granted := range a.GrantedScopes {
+				if strings.EqualFold(granted, want) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	return a.Eat != nil && a.Eat.IsScopeMatch(scopes)
+}
+
+// IsAuthorizedForStream reports whether the caller may act on a specific stream
+// with any of the named scopes. It is the stream-bound companion to HasScope and
+// must be used in place of a bare authCtx.Eat.IsAuthorized check, which denies
+// every OAuth/STS caller because their Eat is nil (see #128, #139).
+//
+// For a locally issued token the EAT is authoritative: it both checks scope and
+// enforces the token's stream-id binding (an EAT issued for stream A cannot act on
+// stream B). For an OAuth/STS-validated caller there is no per-stream binding in
+// the bearer token — its authority is the granted scope set — so this reduces to
+// HasScope(scopes...). A foreign scope named "root" is never honored (#144).
+func (a *AuthContext) IsAuthorizedForStream(streamId string, scopes ...string) bool {
+	if a == nil {
+		return false
+	}
+	if a.IsOAuthClient {
+		return a.HasScope(scopes...)
+	}
+	return a.Eat != nil && a.Eat.IsAuthorized(streamId, scopes)
+}
+
 type AuthIssuer struct {
 	mu           sync.RWMutex
 	TokenIssuer  string

--- a/internal/authUtil/auth_token_test.go
+++ b/internal/authUtil/auth_token_test.go
@@ -822,6 +822,43 @@ func TestValidateAuthorizationAny_withOAuthToken_success(t *testing.T) {
 
 }
 
+// TestValidateAuthorizationAny_OAuthCarriesGrantedScopes is the auth-layer half
+// of the PRD-128 fix: an OAuth/STS token has no local EAT, so the AuthContext
+// must surface the AS-granted scopes (GrantedScopes) for downstream
+// project-scope decisions (admin sees all tokens). Without this the admin view
+// silently fails closed.
+func TestValidateAuthorizationAny_OAuthCarriesGrantedScopes(t *testing.T) {
+	srv, kid, priv := startOIDCTestServer(t)
+	defer srv.Close()
+
+	t.Setenv("I2SIG_AUTH_OAUTH_SERVERS", srv.URL+"/.well-known/openid-configuration")
+	auth.OAuthServer = nil
+	auth.OAuthPubKeys = nil
+
+	// An STS-exchanged admin token: realm role maps to our "admin" scope.
+	tok := mintOAuthToken(t, priv, kid, []string{authSupport.ScopeStreamAdmin})
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example/token", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+
+	got, code := auth.ValidateAuthorizationAny(req, []string{authSupport.ScopeStreamAdmin})
+	if code != http.StatusOK {
+		t.Fatalf("expected 200 from ValidateAuthorizationAny, got %d", code)
+	}
+	if got == nil || !got.IsOAuthClient {
+		t.Fatalf("expected OAuth AuthContext, got %+v", got)
+	}
+	found := false
+	for _, s := range got.GrantedScopes {
+		if s == authSupport.ScopeStreamAdmin {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected GrantedScopes to include %q, got %v", authSupport.ScopeStreamAdmin, got.GrantedScopes)
+	}
+}
+
 func TestValidateAuthorization_withOAuthFallback_success(t *testing.T) {
 	srv, kid, priv := startOIDCTestServer(t)
 	defer srv.Close()

--- a/internal/authUtil/auth_token_test.go
+++ b/internal/authUtil/auth_token_test.go
@@ -26,6 +26,144 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
+// TestAuthContext_HasScope locks the shape-aware scope predicate that the
+// tx_alias and other admin gates rely on. The OAuth/STS rows are the ones the
+// bare authCtx.Eat check used to get wrong (nil Eat -> always denied), plus the
+// #144 rule that a foreign "root" scope confers nothing.
+func TestAuthContext_HasScope(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  *AuthContext
+		want bool
+	}{
+		{name: "nil context", ctx: nil, want: false},
+		{
+			name: "OAuth admin grant matches admin",
+			ctx:  &AuthContext{IsOAuthClient: true, GrantedScopes: []string{"admin"}},
+			want: true,
+		},
+		{
+			name: "OAuth admin grant case-insensitive",
+			ctx:  &AuthContext{IsOAuthClient: true, GrantedScopes: []string{"ADMIN"}},
+			want: true,
+		},
+		{
+			name: "OAuth non-admin grant denied",
+			ctx:  &AuthContext{IsOAuthClient: true, GrantedScopes: []string{"stream", "event"}},
+			want: false,
+		},
+		{
+			name: "OAuth foreign root is not honored (#144)",
+			ctx:  &AuthContext{IsOAuthClient: true, GrantedScopes: []string{"root"}},
+			want: false,
+		},
+		{
+			name: "OAuth empty grant denied",
+			ctx:  &AuthContext{IsOAuthClient: true, GrantedScopes: nil},
+			want: false,
+		},
+		{
+			name: "local EAT admin role matches",
+			ctx:  &AuthContext{Eat: &authSupport.EventAuthToken{Roles: []string{"admin"}}},
+			want: true,
+		},
+		{
+			name: "local EAT root rides free",
+			ctx:  &AuthContext{Eat: &authSupport.EventAuthToken{Roles: []string{"root"}}},
+			want: true,
+		},
+		{
+			name: "local EAT non-admin denied",
+			ctx:  &AuthContext{Eat: &authSupport.EventAuthToken{Roles: []string{"stream"}}},
+			want: false,
+		},
+		{
+			name: "local EAT nil denied",
+			ctx:  &AuthContext{Eat: nil},
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.ctx.HasScope(authSupport.ScopeStreamAdmin); got != tc.want {
+				t.Errorf("HasScope(admin) = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAuthContext_IsAuthorizedForStream locks the stream-bound companion to
+// HasScope. The local rows prove the EAT's stream-id binding is still enforced
+// (an EAT issued for stream A cannot act on stream B); the OAuth rows prove the
+// check no longer silently denies an OAuth/STS caller (nil Eat) and reduces to a
+// pure scope check since the bearer token carries no per-stream binding.
+func TestAuthContext_IsAuthorizedForStream(t *testing.T) {
+	scopes := []string{authSupport.ScopeStreamMgmt, authSupport.ScopeStreamAdmin}
+	tests := []struct {
+		name     string
+		ctx      *AuthContext
+		streamId string
+		want     bool
+	}{
+		{name: "nil context", ctx: nil, streamId: "A", want: false},
+		{
+			name:     "local EAT bound to the same stream",
+			ctx:      &AuthContext{Eat: &authSupport.EventAuthToken{Roles: []string{"stream"}, StreamIds: []string{"A"}}},
+			streamId: "A",
+			want:     true,
+		},
+		{
+			name:     "local EAT bound to a different stream denied",
+			ctx:      &AuthContext{Eat: &authSupport.EventAuthToken{Roles: []string{"stream"}, StreamIds: []string{"A"}}},
+			streamId: "B",
+			want:     false,
+		},
+		{
+			name:     "local EAT unbound (any stream) with scope",
+			ctx:      &AuthContext{Eat: &authSupport.EventAuthToken{Roles: []string{"stream"}}},
+			streamId: "B",
+			want:     true,
+		},
+		{
+			name:     "local EAT lacking scope denied",
+			ctx:      &AuthContext{Eat: &authSupport.EventAuthToken{Roles: []string{"event"}, StreamIds: []string{"A"}}},
+			streamId: "A",
+			want:     false,
+		},
+		{
+			name:     "OAuth with stream scope authorized regardless of stream id",
+			ctx:      &AuthContext{IsOAuthClient: true, GrantedScopes: []string{"stream"}},
+			streamId: "B",
+			want:     true,
+		},
+		{
+			name:     "OAuth admin authorized",
+			ctx:      &AuthContext{IsOAuthClient: true, GrantedScopes: []string{"admin"}},
+			streamId: "B",
+			want:     true,
+		},
+		{
+			name:     "OAuth lacking scope denied",
+			ctx:      &AuthContext{IsOAuthClient: true, GrantedScopes: []string{"event"}},
+			streamId: "B",
+			want:     false,
+		},
+		{
+			name:     "OAuth foreign root is not honored (#144)",
+			ctx:      &AuthContext{IsOAuthClient: true, GrantedScopes: []string{"root"}},
+			streamId: "B",
+			want:     false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.ctx.IsAuthorizedForStream(tc.streamId, scopes...); got != tc.want {
+				t.Errorf("IsAuthorizedForStream(%q) = %v, want %v", tc.streamId, got, tc.want)
+			}
+		})
+	}
+}
+
 type testTokensSet struct {
 	iat            string
 	client         string

--- a/internal/server/api_out_of_band.go
+++ b/internal/server/api_out_of_band.go
@@ -1267,11 +1267,7 @@ func (sa *SignalsApplication) GetSummaries(w http.ResponseWriter, r *http.Reques
 // the callers turn into a no-op (revoke) or active:false (introspect) without
 // leaking existence.
 func callerMayActOnProject(authCtx *authUtil.AuthContext, targetProjectID string) bool {
-	var eat *authSupport.EventAuthToken
-	if authCtx != nil {
-		eat = authCtx.Eat
-	}
-	unrestricted, projectID := services.ProjectScope(eat)
+	unrestricted, projectID := services.ProjectScope(authCtx)
 	if unrestricted {
 		return true
 	}
@@ -1475,7 +1471,7 @@ func (sa *SignalsApplication) TokenListHandler(w http.ResponseWriter, r *http.Re
 		filters.Active = &active
 	}
 
-	tokens, err := sa.GetTokenService().ListForAuthority(r.Context(), authCtx.Eat, filters)
+	tokens, err := sa.GetTokenService().ListForAuthority(r.Context(), authCtx, filters)
 	if err != nil {
 		serverLog.Error("Token list error", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/server/api_out_of_band.go
+++ b/internal/server/api_out_of_band.go
@@ -149,15 +149,19 @@ func CreateKeyHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *http
 // keyScopeOnly reports whether the AuthContext carries the narrow "key" scope
 // but NOT a broader stream_admin/root capability. Such a caller is a bootstrap
 // identity and is restricted to create-only key operations.
+//
+// It routes through HasScope (never a bare authCtx.Eat check) so the restriction
+// applies to OAuth/STS callers too: an Eat-only check returned false for them
+// (Eat==nil), which silently exempted an OAuth key-only caller from the
+// create-only guard and granted full key takeover/upload (see #128, #139, #150).
 func keyScopeOnly(authCtx *authUtil.AuthContext) bool {
-	if authCtx == nil || authCtx.Eat == nil {
+	if authCtx == nil {
 		return false
 	}
-	if authCtx.Eat.IsScopeMatch([]string{authSupport.ScopeStreamAdmin}) ||
-		authCtx.Eat.IsScopeMatch([]string{authSupport.ScopeRoot}) {
+	if authCtx.HasScope(authSupport.ScopeStreamAdmin) || authCtx.HasScope(authSupport.ScopeRoot) {
 		return false
 	}
-	return authCtx.Eat.IsScopeMatch([]string{authSupport.ScopeKey})
+	return authCtx.HasScope(authSupport.ScopeKey)
 }
 
 // requestIsKeyTakeover reports whether the key request asks to replace or rotate

--- a/internal/server/api_out_of_band_authz_test.go
+++ b/internal/server/api_out_of_band_authz_test.go
@@ -1,0 +1,75 @@
+package server
+
+import (
+    "testing"
+
+    "github.com/i2-open/i2goSignals/internal/authUtil"
+    "github.com/i2-open/i2goSignals/pkg/authSupport"
+)
+
+// TestKeyScopeOnly locks the create-only key guard across both caller shapes.
+//
+// The OAuth/STS rows are the important ones: before keyScopeOnly was migrated off
+// a bare authCtx.Eat check it returned false for every OAuth caller (Eat==nil),
+// which silently exempted an OAuth key-only caller from the create-only guard and
+// granted full key takeover/upload — a privilege escalation (#150). After the
+// migration to HasScope, an OAuth key-only caller is correctly restricted while
+// an OAuth admin/root caller is not.
+func TestKeyScopeOnly(t *testing.T) {
+    tests := []struct {
+        name string
+        ctx  *authUtil.AuthContext
+        want bool
+    }{
+        {name: "nil context", ctx: nil, want: false},
+        // Local (EAT-backed) callers.
+        {
+            name: "local key-only is restricted",
+            ctx:  &authUtil.AuthContext{Eat: &authSupport.EventAuthToken{Roles: []string{authSupport.ScopeKey}}},
+            want: true,
+        },
+        {
+            name: "local admin is not restricted",
+            ctx:  &authUtil.AuthContext{Eat: &authSupport.EventAuthToken{Roles: []string{authSupport.ScopeStreamAdmin}}},
+            want: false,
+        },
+        {
+            name: "local root rides free (not restricted)",
+            ctx:  &authUtil.AuthContext{Eat: &authSupport.EventAuthToken{Roles: []string{authSupport.ScopeRoot}}},
+            want: false,
+        },
+        {
+            name: "local key+admin is not restricted",
+            ctx:  &authUtil.AuthContext{Eat: &authSupport.EventAuthToken{Roles: []string{authSupport.ScopeKey, authSupport.ScopeStreamAdmin}}},
+            want: false,
+        },
+        // OAuth/STS callers — the regression-fix rows.
+        {
+            name: "OAuth key-only is restricted (privilege-escalation fix)",
+            ctx:  &authUtil.AuthContext{IsOAuthClient: true, GrantedScopes: []string{authSupport.ScopeKey}},
+            want: true,
+        },
+        {
+            name: "OAuth admin is not restricted",
+            ctx:  &authUtil.AuthContext{IsOAuthClient: true, GrantedScopes: []string{authSupport.ScopeStreamAdmin}},
+            want: false,
+        },
+        {
+            name: "OAuth key+admin is not restricted",
+            ctx:  &authUtil.AuthContext{IsOAuthClient: true, GrantedScopes: []string{authSupport.ScopeKey, authSupport.ScopeStreamAdmin}},
+            want: false,
+        },
+        {
+            name: "OAuth foreign root does not bypass the guard (#144)",
+            ctx:  &authUtil.AuthContext{IsOAuthClient: true, GrantedScopes: []string{authSupport.ScopeKey, authSupport.ScopeRoot}},
+            want: true,
+        },
+    }
+    for _, tc := range tests {
+        t.Run(tc.name, func(t *testing.T) {
+            if got := keyScopeOnly(tc.ctx); got != tc.want {
+                t.Errorf("keyScopeOnly() = %v, want %v", got, tc.want)
+            }
+        })
+    }
+}

--- a/internal/server/api_stream_management.go
+++ b/internal/server/api_stream_management.go
@@ -433,6 +433,23 @@ func (sa *SignalsApplication) StreamCreate(w http.ResponseWriter, r *http.Reques
 	StreamCreateHandler(sa, w, r)
 }
 
+// canProvisionTxAlias reports whether the caller may create a stream against a
+// FOREIGN transmitter (tx_alias set). Foreign-server provisioning resolves a
+// stored credential and drives the remote stream's whole lifecycle, so the caller
+// must hold either admin (root rides free) or the full operational scope set —
+// register (create) + stream (manage/status) + event (poll) together. Register
+// alone is deliberately not enough. It routes through HasScope (never a bare
+// authCtx.Eat check) so an OAuth/STS caller — whose Eat is nil and whose grants
+// live in GrantedScopes — is evaluated correctly rather than always denied (#128).
+func canProvisionTxAlias(authCtx *authUtil.AuthContext) bool {
+	if authCtx.HasScope(authSupport.ScopeStreamAdmin) {
+		return true
+	}
+	return authCtx.HasScope(authSupport.ScopeRegister) &&
+		authCtx.HasScope(authSupport.ScopeStreamMgmt) &&
+		authCtx.HasScope(authSupport.ScopeEventDelivery)
+}
+
 func StreamCreateHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *http.Request) {
 	// Creating a stream is a stream-management operation: a self-registered
 	// receiver (capped at stream_mgmt by the /register privilege ceiling, never
@@ -458,14 +475,14 @@ func StreamCreateHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *h
 
 	// Provisioning a stream against a FOREIGN transmitter (tx_alias set) is a
 	// privileged operation: it resolves a stored foreign-server credential and
-	// remotely manages a stream on another node's behalf. It therefore requires
-	// admin (root rides free); the base stream/reg gate above is not enough. A
-	// plain create (no tx_alias) — the SCIM-receiver / unattended-IAT-bootstrap
-	// path — is unaffected. See ADR 0009.
-	if jsonRequest.TxAlias != nil && *jsonRequest.TxAlias != "" &&
-		!(authCtx.Eat != nil && authCtx.Eat.IsScopeMatch([]string{authSupport.ScopeStreamAdmin})) {
-		serverLog.Warn("StreamCreate: denied tx_alias provisioning; admin scope required", "tx_alias", *jsonRequest.TxAlias, "projectId", authCtx.ProjectId)
-		http.Error(w, "creating a stream with tx_alias (foreign-server provisioning) requires admin scope; use an admin session or an admin client token", http.StatusForbidden)
+	// remotely manages a stream on another node's behalf. The caller must be able
+	// to operate the whole foreign stream lifecycle, so the base stream/reg gate
+	// above is not enough — it needs canProvisionTxAlias (admin, or the full
+	// reg+stream+event set). A plain create (no tx_alias) — the SCIM-receiver /
+	// unattended-IAT-bootstrap path — is unaffected. See ADR 0009.
+	if jsonRequest.TxAlias != nil && *jsonRequest.TxAlias != "" && !canProvisionTxAlias(authCtx) {
+		serverLog.Warn("StreamCreate: denied tx_alias provisioning; needs admin or reg+stream+event", "tx_alias", *jsonRequest.TxAlias, "projectId", authCtx.ProjectId)
+		http.Error(w, "creating a stream with tx_alias (foreign-server provisioning) requires admin scope, or the full reg+stream+event scope set", http.StatusForbidden)
 		return
 	}
 
@@ -542,8 +559,10 @@ func StreamUpdateHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *h
 		return
 	}
 
-	// Because the PUT/PATCH request does not have a stream id parameter, we extract from payload and re-check
-	if authCtx.Eat != nil && !authCtx.Eat.IsAuthorized(jsonRequest.StreamConfiguration.Id, []string{authSupport.ScopeStreamMgmt, authSupport.ScopeStreamAdmin}) {
+	// Because the PUT/PATCH request does not have a stream id parameter, we extract from payload and re-check.
+	// Use IsAuthorizedForStream (not a bare Eat check) so local tokens keep their stream-id binding while
+	// OAuth/STS callers — who carry no per-stream binding — are still validated against the granted scope set.
+	if !authCtx.IsAuthorizedForStream(jsonRequest.StreamConfiguration.Id, authSupport.ScopeStreamMgmt, authSupport.ScopeStreamAdmin) {
 		http.Error(w, "Stream identifier not authorized", http.StatusForbidden)
 		return
 	}

--- a/internal/server/server_provisioning_authz_test.go
+++ b/internal/server/server_provisioning_authz_test.go
@@ -3,15 +3,21 @@ package server
 import (
     "bytes"
     "context"
+    "crypto/rand"
+    "crypto/rsa"
+    "encoding/base64"
     "encoding/json"
     "net/http"
     "net/http/httptest"
     "testing"
+    "time"
 
+    "github.com/golang-jwt/jwt/v5"
     "github.com/gorilla/mux"
     "github.com/i2-open/i2goSignals/internal/authUtil"
     "github.com/i2-open/i2goSignals/internal/eventRouter"
     "github.com/i2-open/i2goSignals/internal/providers/dbProviders"
+    "github.com/i2-open/i2goSignals/pkg/authSupport"
     "github.com/i2-open/i2goSignals/pkg/ssfModels"
     "github.com/stretchr/testify/suite"
     "go.mongodb.org/mongo-driver/v2/bson"
@@ -115,6 +121,179 @@ func (s *ServerProvisioningAuthzSuite) TestStreamCreate_TxAliasWithAdminScopeSuc
     s.NotEqual(http.StatusForbidden, rr.Code, "tx_alias create at admin scope must pass the authz gate")
 }
 
+// TestCanProvisionTxAlias locks the tx_alias authorization policy directly,
+// across both caller shapes, without minting tokens: foreign-server provisioning
+// needs admin (root rides free) OR the full reg+stream+event operate-the-stream
+// set. Any subset short of that — including register alone — is denied.
+func TestCanProvisionTxAlias(t *testing.T) {
+    oauth := func(scopes ...string) *authUtil.AuthContext {
+        return &authUtil.AuthContext{IsOAuthClient: true, GrantedScopes: scopes}
+    }
+    local := func(roles ...string) *authUtil.AuthContext {
+        return &authUtil.AuthContext{Eat: &authSupport.EventAuthToken{Roles: roles}}
+    }
+    const (
+        reg    = authSupport.ScopeRegister
+        stream = authSupport.ScopeStreamMgmt
+        event  = authSupport.ScopeEventDelivery
+        admin  = authSupport.ScopeStreamAdmin
+        root   = authSupport.ScopeRoot
+    )
+    tests := []struct {
+        name string
+        ctx  *authUtil.AuthContext
+        want bool
+    }{
+        {"oauth admin", oauth(admin), true},
+        {"oauth full set", oauth(reg, stream, event), true},
+        {"oauth full set unordered", oauth(event, reg, stream), true},
+        {"oauth reg only", oauth(reg), false},
+        {"oauth reg+stream missing event", oauth(reg, stream), false},
+        {"oauth reg+event missing stream", oauth(reg, event), false},
+        {"oauth stream+event missing reg", oauth(stream, event), false},
+        {"oauth foreign root not honored", oauth(root), false},
+        {"local admin", local(admin), true},
+        {"local root rides free", local(root), true},
+        {"local full set", local(reg, stream, event), true},
+        {"local reg only", local(reg), false},
+        {"local stream only", local(stream), false},
+    }
+    for _, tc := range tests {
+        t.Run(tc.name, func(t *testing.T) {
+            if got := canProvisionTxAlias(tc.ctx); got != tc.want {
+                t.Errorf("canProvisionTxAlias(%s) = %v, want %v", tc.name, got, tc.want)
+            }
+        })
+    }
+}
+
+// startOIDC stands up a throwaway OIDC discovery + JWKS endpoint and returns the
+// discovery URL plus the signing key/kid that mintOAuth uses to forge tokens the
+// server's OAuth validator will accept. It mirrors the fixture in
+// internal/authUtil's tests; duplicated here because test helpers don't cross
+// package boundaries.
+func (s *ServerProvisioningAuthzSuite) startOIDC() (discoveryURL, kid string, priv *rsa.PrivateKey) {
+    var err error
+    priv, err = rsa.GenerateKey(rand.Reader, 2048)
+    s.Require().NoError(err)
+    pub := &priv.PublicKey
+    n := base64.RawURLEncoding.EncodeToString(pub.N.Bytes())
+    e := base64.RawURLEncoding.EncodeToString([]byte{0x01, 0x00, 0x01}) // 65537
+    kid = "oauth-kid-authz"
+
+    var jwksURL string
+    srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        switch r.URL.Path {
+        case "/.well-known/openid-configuration":
+            w.Header().Set("Content-Type", "application/json")
+            _ = json.NewEncoder(w).Encode(map[string]string{"jwks_uri": jwksURL})
+        case "/jwks":
+            w.Header().Set("Content-Type", "application/json")
+            _ = json.NewEncoder(w).Encode(map[string]any{"keys": []map[string]string{
+                {"kty": "RSA", "kid": kid, "use": "sig", "alg": "RS256", "n": n, "e": e},
+            }})
+        default:
+            http.NotFound(w, r)
+        }
+    }))
+    jwksURL = srv.URL + "/jwks"
+    s.T().Cleanup(srv.Close)
+    return srv.URL + "/.well-known/openid-configuration", kid, priv
+}
+
+// mintOAuth forges an OIDC-shaped RS256 token whose realm roles carry the given
+// scopes — the shape of an STS/OAuth-exchanged caller (no local EAT).
+func (s *ServerProvisioningAuthzSuite) mintOAuth(priv *rsa.PrivateKey, kid string, roles []string) string {
+    claims := authSupport.OidcClaims{
+        RegisteredClaims: jwt.RegisteredClaims{
+            IssuedAt:  jwt.NewNumericDate(time.Now().Add(-time.Minute)),
+            ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+            Issuer:    "http://oidc-issuer.example",
+            Audience:  []string{"gosignals"},
+            ID:        "oauth-test-jti",
+        },
+    }
+    claims.RealmAccess.Roles = roles
+    tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+    tok.Header["kid"] = kid
+    signed, err := tok.SignedString(priv)
+    s.Require().NoError(err)
+    return signed
+}
+
+// Regression for the OAuth/STS admin caller: an admin token obtained by exchange
+// has Eat==nil and carries its authority in GrantedScopes. The tx_alias gate must
+// honor that admin grant, not deny it for lacking a local EAT (the #139 gate read
+// authCtx.Eat directly; #128 had already fixed the same bug class for the
+// token-admin endpoints but did not touch this stream-create gate).
+func (s *ServerProvisioningAuthzSuite) TestStreamCreate_TxAliasWithOAuthAdminScopeSucceeds() {
+    discoveryURL, kid, priv := s.startOIDC()
+    s.T().Setenv("I2SIG_AUTH_OAUTH_SERVERS", discoveryURL)
+    tok := s.mintOAuth(priv, kid, []string{authSupport.ScopeStreamAdmin})
+
+    alias := "ssfTx"
+    cfg := model.StreamStateRecord{}
+    cfg.TxAlias = &alias
+    body, _ := json.Marshal(cfg)
+
+    rr := s.do(s.app.StreamCreate, http.MethodPost, "/stream", tok, body, nil)
+    s.NotEqual(http.StatusForbidden, rr.Code,
+        "tx_alias create by an OAuth/STS admin caller (Eat==nil, GrantedScopes=[admin]) must pass the authz gate")
+}
+
+// A non-admin OAuth caller (e.g. only the stream scope) must still be denied at
+// the tx_alias gate — the fix admits admins, not every OAuth caller.
+func (s *ServerProvisioningAuthzSuite) TestStreamCreate_TxAliasWithOAuthStreamScopeDenied() {
+    discoveryURL, kid, priv := s.startOIDC()
+    s.T().Setenv("I2SIG_AUTH_OAUTH_SERVERS", discoveryURL)
+    tok := s.mintOAuth(priv, kid, []string{authSupport.ScopeStreamMgmt})
+
+    alias := "ssfTx"
+    cfg := model.StreamStateRecord{}
+    cfg.TxAlias = &alias
+    body, _ := json.Marshal(cfg)
+
+    rr := s.do(s.app.StreamCreate, http.MethodPost, "/stream", tok, body, nil)
+    s.Equal(http.StatusForbidden, rr.Code,
+        "tx_alias create by a non-admin OAuth caller must remain denied")
+}
+
+// A non-admin caller holding the full reg+stream+event operational set can
+// provision a foreign (tx_alias) stream — it can drive the whole remote lifecycle.
+func (s *ServerProvisioningAuthzSuite) TestStreamCreate_TxAliasWithOAuthFullScopeSetSucceeds() {
+    discoveryURL, kid, priv := s.startOIDC()
+    s.T().Setenv("I2SIG_AUTH_OAUTH_SERVERS", discoveryURL)
+    tok := s.mintOAuth(priv, kid, []string{
+        authSupport.ScopeRegister, authSupport.ScopeStreamMgmt, authSupport.ScopeEventDelivery,
+    })
+
+    alias := "ssfTx"
+    cfg := model.StreamStateRecord{}
+    cfg.TxAlias = &alias
+    body, _ := json.Marshal(cfg)
+
+    rr := s.do(s.app.StreamCreate, http.MethodPost, "/stream", tok, body, nil)
+    s.NotEqual(http.StatusForbidden, rr.Code,
+        "tx_alias create with the full reg+stream+event set must pass the authz gate")
+}
+
+// The full set is required: reg+stream without event is still denied (register
+// alone, or any partial set, is not enough to provision a foreign stream).
+func (s *ServerProvisioningAuthzSuite) TestStreamCreate_TxAliasWithOAuthPartialScopeSetDenied() {
+    discoveryURL, kid, priv := s.startOIDC()
+    s.T().Setenv("I2SIG_AUTH_OAUTH_SERVERS", discoveryURL)
+    tok := s.mintOAuth(priv, kid, []string{authSupport.ScopeRegister, authSupport.ScopeStreamMgmt})
+
+    alias := "ssfTx"
+    cfg := model.StreamStateRecord{}
+    cfg.TxAlias = &alias
+    body, _ := json.Marshal(cfg)
+
+    rr := s.do(s.app.StreamCreate, http.MethodPost, "/stream", tok, body, nil)
+    s.Equal(http.StatusForbidden, rr.Code,
+        "tx_alias create with reg+stream but missing event must remain denied")
+}
+
 func (s *ServerProvisioningAuthzSuite) TestStreamCreate_PlainAtStreamScopeSucceeds() {
     tok := s.streamToken("proj-A")
     // No tx_alias -> the unchanged local-only path. A poll-transmitter stream is
@@ -129,6 +308,23 @@ func (s *ServerProvisioningAuthzSuite) TestStreamCreate_PlainAtStreamScopeSuccee
 
     rr := s.do(s.app.StreamCreate, http.MethodPost, "/stream", tok, body, nil)
     s.Equal(http.StatusCreated, rr.Code, "a plain stream-create at stream scope must remain allowed (regression guard)")
+}
+
+// reg is a first-class alternate for plain stream creation (alongside stream and
+// admin): a register-scoped credential must be able to create a stream. Only the
+// tx_alias (foreign-server provisioning) variant escalates to admin.
+func (s *ServerProvisioningAuthzSuite) TestStreamCreate_PlainAtRegScopeSucceeds() {
+    tok := s.regToken("proj-A")
+    cfg := model.StreamStateRecord{}
+    cfg.Iss = "http://transmitter.example.com"
+    cfg.Aud = []string{"http://receiver.example.com"}
+    cfg.Delivery = &model.OneOfStreamConfigurationDelivery{
+        PollTransmitMethod: &model.PollTransmitMethod{Method: model.DeliveryPoll},
+    }
+    body, _ := json.Marshal(cfg)
+
+    rr := s.do(s.app.StreamCreate, http.MethodPost, "/stream", tok, body, nil)
+    s.Equal(http.StatusCreated, rr.Code, "a plain stream-create with the reg scope must be allowed")
 }
 
 // --- /server endpoints are admin-only ---

--- a/internal/services/token_list_authority_test.go
+++ b/internal/services/token_list_authority_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/i2-open/i2goSignals/internal/authUtil"
 	"github.com/i2-open/i2goSignals/internal/dao/interfaces"
 	"github.com/i2-open/i2goSignals/internal/dao/memory"
 	"github.com/i2-open/i2goSignals/pkg/authSupport"
@@ -59,8 +60,27 @@ func (s *TokenListAuthorityTestSuite) seedStream(hexID, projectID, ip string) {
 	s.NoError(s.streamDAO.Create(context.Background(), rec))
 }
 
-func nonAdmin(projectID string) *authSupport.EventAuthToken {
-	return &authSupport.EventAuthToken{ProjectId: projectID, Roles: []string{authSupport.ScopeStreamMgmt}}
+// nonAdmin builds a locally-issued, project-confined caller (stream scope).
+func nonAdmin(projectID string) *authUtil.AuthContext {
+	return localScoped(projectID, authSupport.ScopeStreamMgmt)
+}
+
+// localScoped builds a locally-issued caller (an EAT) with the given roles.
+func localScoped(projectID string, roles ...string) *authUtil.AuthContext {
+	return &authUtil.AuthContext{
+		ProjectId: projectID,
+		Eat:       &authSupport.EventAuthToken{ProjectId: projectID, Roles: roles},
+	}
+}
+
+// oauthScoped builds an OAuth/STS-validated caller. Such callers carry no local
+// EAT or ProjectId — their authority is only the scope set granted by the
+// trusted authorization server (issue #144).
+func oauthScoped(grantedScopes ...string) *authUtil.AuthContext {
+	return &authUtil.AuthContext{
+		IsOAuthClient: true,
+		GrantedScopes: grantedScopes,
+	}
 }
 
 func (s *TokenListAuthorityTestSuite) TestNonAdminSeesOnlyOwnProject() {
@@ -79,7 +99,7 @@ func (s *TokenListAuthorityTestSuite) TestAdminSeesAllProjects() {
 	s.track("j1", "p1", "c1", model.TokenTypeIAT, "")
 	s.track("j2", "p2", "c2", model.TokenTypeIAT, "")
 
-	admin := &authSupport.EventAuthToken{ProjectId: "p1", Roles: []string{authSupport.ScopeStreamAdmin}}
+	admin := localScoped("p1", authSupport.ScopeStreamAdmin)
 	rows, err := s.service.ListForAuthority(ctx, admin, TokenListFilters{})
 	s.NoError(err)
 	s.Len(rows, 2)
@@ -90,10 +110,49 @@ func (s *TokenListAuthorityTestSuite) TestRootSeesAllProjects() {
 	s.track("j1", "p1", "c1", model.TokenTypeIAT, "")
 	s.track("j2", "p2", "c2", model.TokenTypeIAT, "")
 
-	root := &authSupport.EventAuthToken{ProjectId: "", Roles: []string{authSupport.ScopeRoot}}
+	root := localScoped("", authSupport.ScopeRoot)
 	rows, err := s.service.ListForAuthority(ctx, root, TokenListFilters{})
 	s.NoError(err)
 	s.Len(rows, 2)
+}
+
+// TestOAuthAdminSeesAllProjects is the regression test for the PRD-128 bug: an
+// admin token obtained via STS/OAuth exchange validates through the OAuth path,
+// which carries no local EAT or ProjectId. It must still be treated as
+// unrestricted (see all projects) on the strength of its granted "admin" scope.
+func (s *TokenListAuthorityTestSuite) TestOAuthAdminSeesAllProjects() {
+	ctx := context.Background()
+	s.track("j1", "p1", "c1", model.TokenTypeIAT, "")
+	s.track("j2", "p2", "c2", model.TokenTypeIAT, "")
+
+	rows, err := s.service.ListForAuthority(ctx, oauthScoped(authSupport.ScopeStreamAdmin), TokenListFilters{})
+	s.NoError(err)
+	s.Len(rows, 2)
+}
+
+// TestOAuthNonAdminSeesNothing: an OAuth caller without admin scope carries no
+// ProjectId, so it must fail closed (see nothing) rather than leak the
+// empty-project bucket.
+func (s *TokenListAuthorityTestSuite) TestOAuthNonAdminSeesNothing() {
+	ctx := context.Background()
+	s.track("j1", "p1", "c1", model.TokenTypeIAT, "")
+
+	rows, err := s.service.ListForAuthority(ctx, oauthScoped(authSupport.ScopeStreamMgmt), TokenListFilters{})
+	s.NoError(err)
+	s.Len(rows, 0)
+}
+
+// TestOAuthForeignRootDoesNotSeeAll guards issue #144: a foreign realm role
+// literally named "root" must NOT confer the cluster super-power. Only an
+// "admin" grant unlocks the unrestricted view for OAuth callers.
+func (s *TokenListAuthorityTestSuite) TestOAuthForeignRootDoesNotSeeAll() {
+	ctx := context.Background()
+	s.track("j1", "p1", "c1", model.TokenTypeIAT, "")
+	s.track("j2", "p2", "c2", model.TokenTypeIAT, "")
+
+	rows, err := s.service.ListForAuthority(ctx, oauthScoped(authSupport.ScopeRoot), TokenListFilters{})
+	s.NoError(err)
+	s.Len(rows, 0)
 }
 
 func (s *TokenListAuthorityTestSuite) TestTypeFilter() {
@@ -162,4 +221,32 @@ func (s *TokenListAuthorityTestSuite) TestStreamRowJoinsLastSeenIP() {
 
 func TestTokenListAuthoritySuite(t *testing.T) {
 	suite.Run(t, new(TokenListAuthorityTestSuite))
+}
+
+// TestProjectScope locks the single source of truth for caller visibility,
+// covering both the locally-issued (EAT) and OAuth/STS (granted-scope) paths.
+func TestProjectScope(t *testing.T) {
+	cases := []struct {
+		name             string
+		authCtx          *authUtil.AuthContext
+		wantUnrestricted bool
+		wantProjectID    string
+	}{
+		{"nil", nil, false, ""},
+		{"local admin", localScoped("p1", authSupport.ScopeStreamAdmin), true, ""},
+		{"local root", localScoped("", authSupport.ScopeRoot), true, ""},
+		{"local stream confined", localScoped("p1", authSupport.ScopeStreamMgmt), false, "p1"},
+		{"oauth admin", oauthScoped(authSupport.ScopeStreamAdmin), true, ""},
+		{"oauth stream", oauthScoped(authSupport.ScopeStreamMgmt), false, ""},
+		{"oauth foreign root (#144)", oauthScoped(authSupport.ScopeRoot), false, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			unrestricted, projectID := ProjectScope(c.authCtx)
+			if unrestricted != c.wantUnrestricted || projectID != c.wantProjectID {
+				t.Fatalf("ProjectScope() = (%v, %q), want (%v, %q)",
+					unrestricted, projectID, c.wantUnrestricted, c.wantProjectID)
+			}
+		})
+	}
 }

--- a/internal/services/token_service.go
+++ b/internal/services/token_service.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/i2-open/i2goSignals/internal/authUtil"
 	"github.com/i2-open/i2goSignals/internal/dao/interfaces"
 	"github.com/i2-open/i2goSignals/pkg/authSupport"
 	"github.com/i2-open/i2goSignals/pkg/logger"
@@ -44,21 +45,48 @@ type TokenListFilters struct {
 	Active *bool
 }
 
-// ProjectScope derives the project visibility for a caller from its
-// AuthContext, never from a client-supplied query parameter. admin/root
-// callers are unrestricted (see all projects); every other caller is confined
-// to its own AuthContext.ProjectId. This is the shared scoping derivation that
-// the single-token endpoints (revoke/introspect) reuse.
+// ProjectScope derives the project visibility for a caller from its validated
+// AuthContext, never from a client-supplied query parameter. It is the single
+// source of truth reused by the token-admin endpoints (list/revoke/introspect).
+//
+// Two caller shapes feed in:
+//   - Locally issued tokens carry an EAT whose roles are authoritative:
+//     root/admin are unrestricted (see all projects); everyone else is confined
+//     to the EAT's own ProjectId.
+//   - OAuth/STS-validated callers carry no EAT or ProjectId — only the scope set
+//     granted by the trusted authorization server (GrantedScopes). An "admin"
+//     grant is unrestricted. A scope literally named "root" is deliberately NOT
+//     honored for these foreign callers (issue #144): only a locally issued
+//     token may wield root.
 //
 // Returns (unrestricted, confinedProjectID).
-func ProjectScope(authCtx *authSupport.EventAuthToken) (bool, string) {
+func ProjectScope(authCtx *authUtil.AuthContext) (bool, string) {
 	if authCtx == nil {
 		return false, ""
 	}
-	if authCtx.IsScopeMatch([]string{authSupport.ScopeRoot, authSupport.ScopeStreamAdmin}) {
+	if authCtx.IsOAuthClient {
+		if containsFold(authCtx.GrantedScopes, authSupport.ScopeStreamAdmin) {
+			return true, ""
+		}
+		return false, ""
+	}
+	if authCtx.Eat == nil {
+		return false, ""
+	}
+	if authCtx.Eat.IsScopeMatch([]string{authSupport.ScopeRoot, authSupport.ScopeStreamAdmin}) {
 		return true, ""
 	}
-	return false, authCtx.ProjectId
+	return false, authCtx.Eat.ProjectId
+}
+
+// containsFold reports whether scopes contains target (case-insensitive).
+func containsFold(scopes []string, target string) bool {
+	for _, s := range scopes {
+		if strings.EqualFold(s, target) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *TokenService) TrackToken(ctx context.Context, claims *authSupport.EventAuthToken, parent string, tokenPurpose string) error {
@@ -197,7 +225,7 @@ func (s *TokenService) ListByClient(ctx context.Context, clientID string) ([]*mo
 // param. The type and active filters compose. STREAM-typed rows are joined to
 // the stream's live RemoteAddress (last-seen IP); the IP is not stored on the
 // token. The result is capped (cap-and-log) since there is no pagination here.
-func (s *TokenService) ListForAuthority(ctx context.Context, authCtx *authSupport.EventAuthToken, filters TokenListFilters) ([]*model.TokenListEntry, error) {
+func (s *TokenService) ListForAuthority(ctx context.Context, authCtx *authUtil.AuthContext, filters TokenListFilters) ([]*model.TokenListEntry, error) {
 	unrestricted, projectID := ProjectScope(authCtx)
 
 	// Fail closed: a confined caller with no resolved project (e.g. an OAuth


### PR DESCRIPTION
## Problem

PRD #128's token-admin endpoints (`GET /token`, `DELETE /token/{jti}`, `POST /introspect`) returned nothing / acted as silent no-ops for an admin caller whose token was obtained via **STS/OAuth exchange** (e.g. the GoSignalsAdmin console). Despite holding `admin` scope, `token list` came back empty even with tokens present.

### Root cause

OAuth/STS tokens validate through `validateOAuthToken`, which returned `AuthContext{Eat: nil, ...}` — **discarding the granted scopes**. Every admin endpoint then derived "admin sees all" from that now-nil `Eat`:

- `TokenListHandler` → `ProjectScope(nil)` → `(false, "")` → fail-closed **empty list**.
- `callerMayActOnProject` (revoke + introspect) → identical bug → silent no-op / `active:false`.

The PRD-128 unit tests passed because they build *local* admin EATs and never exercise the OAuth path, so the gap was never caught.

## Fix

**Server (the actual bug):**
- `validateOAuthToken` records the AS-granted scopes on `AuthContext.GrantedScopes` instead of dropping them.
- `ProjectScope` now takes the whole `*authUtil.AuthContext` and is the single source of truth for list/revoke/introspect. An OAuth caller gets the unrestricted view on the strength of its **`admin`** grant — a foreign `root` is deliberately **not** honored (consistent with #144). Local-token behavior is unchanged; non-admin OAuth callers still fail closed.

**CLI (`token list`):**
- Added optional `<alias>` arg to target a specific configured server.
- Dropped `--project`/`--client` (the server ignored them, and the "must specify…" client-side error blocked admins entirely); added `--type` (IAT|STREAM) and `--active` (true|false) — the filters the server actually honors.

> **Out of scope** (per discussion): CLI bearer/STS-token *acquisition*. The CLI still sends whatever bearer it already has, so it isn't admin-scoped until that separate work is done. This PR makes the admin path reachable and correct on the server (GoSignalsAdmin works now) and correct in shape on the CLI.

## Tests
- `internal/services`: OAuth admin-sees-all, non-admin fail-closed, foreign-root denied (#144), `ProjectScope` truth table.
- `internal/authUtil`: `GrantedScopes` populated on the OAuth validation path.
- `cmd/goSignals`: `token list <alias>` targeting, no project_id query, `--type`/`--active` passthrough.
- All touched packages pass; `-race` clean on services/authUtil/CLI.

## Docs
- `DECISIONS_LOG.md` entry for the scope-derivation change.
- `docs/gosignals_tool.md` updated for the new `token list` surface.

---

## Also in this PR — #150: OAuth/STS scope honored in tx_alias, StreamUpdate, and key guards

### Problem
Same bug class as #128. Creating a stream against a **foreign transmitter** (`tx_alias`) returned `403 "...requires admin scope"` for an admin caller authenticated via STS/OAuth (the GoSignalsAdmin console), even with scopes `admin, stream, reg, event`. The #139 `tx_alias` gate read scope off `AuthContext.Eat`, which `validateOAuthToken` sets to `nil` for every OAuth/STS caller — so the check denied them regardless of granted scope.

### Fix
- Added `AuthContext.HasScope(scopes...)` and its stream-bound companion `AuthContext.IsAuthorizedForStream(streamId, scopes...)` — the only sanctioned way to scope-check a caller. Local tokens keep their EAT stream-id binding; OAuth callers reduce to a scope check (no per-stream bind in the bearer). Foreign `root` is never honored (#144).
- Migrated the three remaining direct-`Eat` scope sites onto them: the `tx_alias` gate (`canProvisionTxAlias`) and the `StreamUpdate` payload re-check (`api_stream_management.go`), and the create-only key guard (`keyScopeOnly` in `api_out_of_band.go`).
- **The `keyScopeOnly` migration also closes a latent privilege escalation:** the old `Eat==nil` path exempted OAuth key-only callers from the create-only key guard, granting full key takeover/upload. They are now correctly restricted; local behavior is unchanged.

**`tx_alias` provisioning policy:** requires `admin` (local `root` rides free) **OR** the full `reg`+`stream`+`event` scope set together; partial subsets are denied. Plain (non-`tx_alias`) stream create is unchanged (accepts `reg`, `stream`, or `admin`).

### Tests (#150)
- `internal/authUtil`: `TestAuthContext_HasScope`, `TestAuthContext_IsAuthorizedForStream` (local binding enforced, OAuth reduces to scope, foreign-root denied).
- `internal/server`: `TestCanProvisionTxAlias`, `TestKeyScopeOnly` (incl. the OAuth key-only-now-restricted escalation-fix row), and `TestStreamCreate_TxAlias*` OIDC end-to-end cases.
- `DECISIONS_LOG.md` entry added (2026-06-02, #150).


Closes #150
