### PR TITLE
SSF 1.0 conformance for goSignalsServer

### DIFF
--- a/cmd/goSignals/commands.go
+++ b/cmd/goSignals/commands.go
@@ -1708,7 +1708,9 @@ func (d *DeleteStreamCmd) Run(cli *CLI) error {
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode != http.StatusOK {
+	// SSF 1.0 §8.1.5 Stream Configuration Delete answers 204 No Content on
+	// success; tolerate a 200 OK as well for transmitters that still return it.
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
 		return errors.New(fmt.Sprintf("Error completing delete request: %s", resp.Status))
 	}
 	if _, ok := cli.Data.streamConfigs[stream.Alias]; ok {

--- a/cmd/goSignals/goSignals_test.go
+++ b/cmd/goSignals/goSignals_test.go
@@ -81,6 +81,16 @@ func (suite *toolSuite) initialize(t *testing.T) error {
 	// server reads the same env var via the bootstrap-secret resolver.
 	t.Setenv("I2SIG_BOOTSTRAP_TOKEN", "tool-test-bootstrap")
 
+	// Cap the long-poll timeout to 1s for the in-process servers. Poll-receive
+	// streams default to TimeoutSecs=10, and DrainReceiver waits for the
+	// in-flight long-poll to return before a delete cascade, so each poll-stream
+	// delete would otherwise block ~10s (Test4 deletes two → ~20s). The cap
+	// clamps every long-poll to 1s, keeping event delivery correct (events still
+	// flush on the next poll) while cutting the suite from ~40s to a few seconds.
+	// Test-only; production poll timeouts are unaffected.
+	t.Setenv("I2SIG_POLL_DEFAULT_TIMEOUT", "1")
+	t.Setenv("I2SIG_POLL_MAX_TIMEOUT", "1")
+
 	cli := &CLI{}
 	cli.Globals.Config = configName
 

--- a/conformance/.gitignore
+++ b/conformance/.gitignore
@@ -1,0 +1,3 @@
+# bootstrap-token.sh writes the suite config with a live minted access token
+# here; it is a per-run local artifact, never committed.
+suite-configs/*.local.json

--- a/conformance/Dockerfile.conformance
+++ b/conformance/Dockerfile.conformance
@@ -1,0 +1,57 @@
+# syntax=docker/dockerfile:1
+#
+# Source-built image for SSF conformance testing. Unlike the production
+# Dockerfile (which COPYs pre-staged binaries produced by `make
+# cross-compile-linux`), this compiles goSignalsServer + healthcheck directly
+# from the working tree, so `docker compose build` rebuilds the SUT from
+# whatever fix is checked out — the iterative fix/test loop for conformance.
+#
+# Used by docker-compose-conformance.build.yml (layer it over
+# docker-compose-conformance.yml to replace the published image with a local
+# build). Build context is the repo root so the whole Go module is available.
+
+##
+## Build stage — compile from source (pinned to go.mod's toolchain).
+##
+FROM golang:1.26.4-bookworm AS build
+
+WORKDIR /src
+
+# Prime the module cache on go.mod/go.sum alone so dependency downloads are
+# cached independently of source edits (the common case while iterating).
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
+
+COPY . .
+
+# CGO disabled -> static binaries that run on a distroless base. Only the two
+# binaries the conformance compose invokes (server + healthcheck probe).
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux go build -o /out/goSignalsServer ./cmd/goSignalsServer/... && \
+    CGO_ENABLED=0 GOOS=linux go build -o /out/healthcheck     ./cmd/healthcheck/...
+
+# Stage a writable resume-token directory; distroless has no shell to mkdir it
+# in the runtime stage, so create it here and COPY it across with nonroot owner.
+RUN mkdir -p /out/resources
+
+##
+## Runtime stage — lean image matching the layout the conformance compose
+## expects: /app/goSignalsServer (command), /app/healthcheck (healthcheck).
+## base-debian12 ships ca-certificates for outbound TLS (PUSH callbacks).
+##
+FROM gcr.io/distroless/base-debian12:nonroot
+
+WORKDIR /app
+
+# nonroot's uid is 65532. /app/resources is where the mongo watchtokens code
+# persists its resume-token file (matches the production Dockerfile).
+COPY --from=build --chown=65532:65532 /out/resources       ./resources
+COPY --from=build --chown=65532:65532 /out/goSignalsServer ./goSignalsServer
+COPY --from=build --chown=65532:65532 /out/healthcheck     ./healthcheck
+
+EXPOSE 8888
+
+CMD ["/app/goSignalsServer"]

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -1,0 +1,184 @@
+# SSF Conformance Testing — goSignalsServer
+
+A minimal, single-SUT deployment of **goSignalsServer** for running the
+[OpenID conformance suite](https://gitlab.com/openid/conformance-suite) **Shared
+Signals Framework (SSF)** test plans against it — both **Transmitter** and
+**Receiver** roles, over both **PUSH** and **POLL** delivery.
+
+## How the pieces fit
+
+```
+ host (127.0.0.1)
+ ├─ OpenID conformance suite (native Spring Boot)   https://localhost.emobix.co.uk:8443
+ │     plays Receiver  -> drives goSignals' transmitter   (transmitter plans)
+ │     plays Transmitter <- goSignals registers a stream  (receiver plans)
+ │
+ └─ this deployment (docker-compose-conformance.yml)
+        ├─ gosignals  goSignalsServer (SUT)  published 127.0.0.1:9443  (container :8888)
+        │     BASE_URL / issuer = https://localhost.emobix.co.uk:9443
+        │     extra_hosts: localhost.emobix.co.uk -> host-gateway   (PUSH callback)
+        └─ mongo      single-node replica set rs0 (+ one-shot mongo-init)
+```
+
+Two facts about the suite make this simple (verified in
+`AbstractCondition.java`): its HTTP client **trusts all TLS certs** and uses a
+**no-op hostname verifier**. So goSignals' self-signed `config/certs/server-cert.pem`
+is accepted as-is, and the issuer host need not match the cert. The hostname
+`localhost.emobix.co.uk` is real public DNS that resolves to `127.0.0.1`.
+
+## Authorization model (read this before POLL)
+
+The suite (STATIC auth mode) sends one bearer — `ssf.transmitter.access_token` —
+for **every** call. goSignals' scope requirements:
+
+| Operation | Scope accepted |
+|---|---|
+| Create / Get / Update / Replace / Delete stream, Get/Update status | `stream` (or `admin`/`root`) |
+| Verify | `event` or `stream` |
+| **`/poll` (POLL delivery)** | **`event`** |
+
+So the token must carry **both `stream` and `event`**:
+- **PUSH** runs work with a plain `stream` management token (the suite receives
+  pushes; it never calls `/poll`).
+- **POLL** runs need a **`stream`+`event`** token. The default `/register` path
+  mints a `stream`-only token; supply a combined token via `GOSIGNALS_TOKEN`
+  (see step 2).
+
+## Prerequisites
+
+- `make build-docker` in the repo root → produces `i2gosignals:latest`.
+- Docker / Docker Compose.
+- The OpenID conformance suite running at `https://localhost.emobix.co.uk:8443`
+  (its own `devenv up` / `docker-compose-dev`).
+
+## 1. Start goSignals
+
+```bash
+cd conformance
+docker compose -f docker-compose-conformance.yml up -d
+# verify metadata is reachable from the host the way the suite will fetch it:
+curl -k https://localhost.emobix.co.uk:9443/.well-known/ssf-configuration | jq .
+```
+Expect `issuer`, `configuration_endpoint`, `status_endpoint`,
+`verification_endpoint`, `jwks_uri`, `delivery_methods_supported`,
+`authorization_schemes`, and `spec_version: "1_0"`, all on
+`https://localhost.emobix.co.uk:9443`.
+
+### Testing local fixes (build from source)
+
+The default stack runs the published release image. While iterating on a fix,
+layer the build override to compile the SUT from the working tree instead — each
+rebuild picks up your latest changes:
+
+```bash
+docker compose \
+  -f docker-compose-conformance.yml \
+  -f docker-compose-conformance.build.yml \
+  up -d --build
+```
+
+`--build` recompiles `goSignalsServer` + `healthcheck` (see
+`Dockerfile.conformance`) and tags them `i2gosignals:conformance-dev`. The Go
+module cache is reused across rebuilds, so after the first build only changed
+packages recompile. Use the same two `-f` flags for any later
+`up`/`down`/`logs` on this variant.
+
+## 2. Mint the access token
+
+```bash
+# PUSH-only (stream-scoped token is sufficient):
+./bootstrap-token.sh
+
+# POLL (and combined PUSH+POLL): supply a stream+event token issued by goSignals:
+GOSIGNALS_TOKEN="eyJ..." ./bootstrap-token.sh
+```
+Writes `suite-configs/ssf-transmitter-gosignals.local.json` with the token filled
+in, and prints the token.
+
+## 3. Run the Transmitter plans (suite plays Receiver)
+
+Import `suite-configs/ssf-transmitter-gosignals.local.json` on the suite's
+`schedule-test.html`, or use the CLI test runner. Variants:
+
+- `ssf_server_metadata = discovery`  (suite fetches `<issuer>/.well-known/ssf-configuration`)
+- `ssf_auth_mode = static`
+- `ssf_delivery_mode = push`  then  `poll`
+- `ssf_profile = default`  then  `caep_interop`
+
+Suggested order (fail fast, then widen):
+1. `openid-ssf-transmitter-test-plan[push]` → run **`openid-ssf-transmitter-metadata`**
+   then **`openid-ssf-stream-control-happy-path`**.
+2. Stream verification + subject control modules.
+3. `openid-ssf-transmitter-caep-test-plan[push]` → CAEP event delivery
+   (`openid-ssf-transmitter-stream-caep-interop`).
+4. Repeat the applicable modules with `[poll]`.
+
+### PUSH callback trust
+For PUSH, goSignals POSTs SETs back to the suite at
+`https://localhost.emobix.co.uk:8443`. The container reaches the host via
+`extra_hosts`, but must also **trust the suite's TLS cert**. Append the suite's
+root CA into the mounted CA file before `up` (or point `I2SIG_TLS_CA_CERT` at a
+bundle):
+
+```bash
+# example: the suite uses a mkcert cert
+cat "$(mkcert -CAROOT)/rootCA.pem" >> ../config/certs/ca-cert.pem
+docker compose -f docker-compose-conformance.yml up -d --force-recreate gosignals
+```
+POLL needs no callback and no extra CA.
+
+## 4. Run the Receiver plans (suite plays Transmitter)
+
+Here goSignals is the **receiver** and must register a stream against the
+suite's emulated transmitter, which is exposed under the suite base URL + the
+config alias:
+
+- Transmitter metadata (emulated by suite):
+  `https://localhost.emobix.co.uk:8443/test/a/gosignals-ssf-rx/.well-known/ssf-configuration`
+
+Drive the goSignals CLI against the running container (the bearer it presents to
+the suite must equal `ssf.transmitter.access_token` in
+`suite-configs/ssf-receiver-gosignals.json`, i.e. `ssf-conformance-rx-token`):
+
+```bash
+docker exec -it ssfconf-gosignals /app/goSignals
+# then, inside the CLI:
+#   add server suite https://localhost.emobix.co.uk:8443/test/a/gosignals-ssf-rx
+#   create stream push receive suite --events="*"     # for PUSH receiver tests
+#   create stream poll  receive suite --events="*"    # for POLL receiver tests
+```
+Import `suite-configs/ssf-receiver-gosignals.json` and run
+`openid-ssf-receiver-test-plan` / `openid-ssf-receiver-caep-test-plan`. The suite
+waits for goSignals to create/manage/poll the stream.
+
+## 5. CI-style runner (optional)
+
+From the conformance-suite checkout, the transmitter/receiver config paths above
+can be passed to `.gitlab-ci/run-tests.sh --ssf-tests` plan specs (see the
+suite's `makeSsfTests()` for the `plan[variant]:module{...}config` syntax).
+
+## Interpreting results
+
+- The transmitter plan's **negative modules** (invalid token, unknown stream id,
+  malformed JSON, duplicate config) expect goSignals to *reject* the request —
+  those rejections are **passes**.
+- Items the suite tags as expected warnings/skips are not failures.
+
+## Teardown
+
+```bash
+docker compose -f docker-compose-conformance.yml down -v
+```
+Each run starts from clean in-database state (the `-v` drops the Mongo volume).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `docker-compose-conformance.yml` | goSignals + single-node Mongo |
+| `docker-compose-conformance.build.yml` | override: build the SUT from source for local-fix testing |
+| `Dockerfile.conformance` | multi-stage source build used by the override |
+| `gosignals-conformance.env` | goSignalsServer environment |
+| `bootstrap-token.sh` | mint the suite's access token, template the tx config |
+| `suite-configs/ssf-transmitter-gosignals.json` | suite config (token placeholder) |
+| `suite-configs/ssf-receiver-gosignals.json` | suite config for receiver plans |

--- a/conformance/bootstrap-token.sh
+++ b/conformance/bootstrap-token.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# Mint the bearer token the OpenID conformance suite uses (ssf.transmitter.access_token)
+# and write a ready-to-import suite config at suite-configs/ssf-transmitter-gosignals.local.json.
+#
+# The suite (STATIC auth mode) presents this one token for BOTH stream management
+# and /poll. goSignals requires `stream` (or admin) for management and `event`
+# for /poll, so the token MUST carry both `stream` and `event`.
+#
+# Token source, in priority order:
+#   1. bootstrap /iat -> /register, requesting scopes "$SCOPES" (default
+#      "stream event"). As of v0.12.0-alpha.2, /register mints `event` into the
+#      registered client token, so this single token drives BOTH stream
+#      management and /poll. This is the default path.
+#   2. $GOSIGNALS_TOKEN   - a pre-minted bearer you supply, used verbatim. Use
+#      this to test with a token minted out-of-band.
+#
+# Usage:
+#   ./bootstrap-token.sh                       # default /iat -> /register flow
+#   GOSIGNALS_TOKEN="eyJ..." ./bootstrap-token.sh   # use a supplied stream+event token
+#
+# Env:
+#   GOSIGNALS_URL    default https://localhost.emobix.co.uk:9443
+#   BOOTSTRAP_TOKEN  default dev-bootstrap-secret  (must match I2SIG_BOOTSTRAP_TOKEN)
+#   SCOPES           default "stream event"
+set -euo pipefail
+
+GOSIGNALS_URL="${GOSIGNALS_URL:-https://localhost.emobix.co.uk:9443}"
+BOOTSTRAP_TOKEN="${BOOTSTRAP_TOKEN:-dev-bootstrap-secret}"
+SCOPES="${SCOPES:-stream event}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATE="$SCRIPT_DIR/suite-configs/ssf-transmitter-gosignals.json"
+OUT="$SCRIPT_DIR/suite-configs/ssf-transmitter-gosignals.local.json"
+
+# --- JSON helpers (jq preferred, python3 fallback) -------------------------
+json_field() { # json_field <field>   (reads stdin)
+  if command -v jq >/dev/null 2>&1; then
+    jq -r ".$1 // empty"
+  else
+    python3 -c "import sys,json;print(json.load(sys.stdin).get('$1',''))"
+  fi
+}
+scopes_json_array() { # "stream event" -> ["stream","event"]
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$SCOPES" | jq -R 'split(" ") | map(select(length>0))'
+  else
+    python3 -c "import sys,json;print(json.dumps(sys.argv[1].split()))" "$SCOPES"
+  fi
+}
+
+TOKEN="${GOSIGNALS_TOKEN:-}"
+
+if [[ -n "$TOKEN" ]]; then
+  echo ">> Using supplied GOSIGNALS_TOKEN (assumed to carry: $SCOPES)"
+else
+  echo ">> Minting IAT via $GOSIGNALS_URL/iat (bootstrap bearer)"
+  # /iat is a GET in goSignals (routers.go: GenerateIat, http.MethodGet).
+  IAT="$(curl -sk -X GET "$GOSIGNALS_URL/iat" \
+          -H "Authorization: Bearer $BOOTSTRAP_TOKEN" | json_field token)"
+  if [[ -z "$IAT" ]]; then
+    echo "ERROR: failed to obtain IAT (check BOOTSTRAP_TOKEN / server up)." >&2
+    exit 1
+  fi
+
+  echo ">> Registering client via $GOSIGNALS_URL/register (scopes: $SCOPES)"
+  BODY="$(printf '{"email":"ssf-conformance@example.com","description":"OIDF SSF conformance","scopes":%s}' "$(scopes_json_array)")"
+  TOKEN="$(curl -sk -X POST "$GOSIGNALS_URL/register" \
+            -H "Authorization: Bearer $IAT" \
+            -H "Content-Type: application/json" \
+            -d "$BODY" | json_field token)"
+  if [[ -z "$TOKEN" ]]; then
+    echo "ERROR: registration returned no token." >&2
+    exit 1
+  fi
+fi
+
+# --- write the suite config with the token substituted ---------------------
+sed "s|__GOSIGNALS_STREAM_EVENT_TOKEN__|$TOKEN|" "$TEMPLATE" > "$OUT"
+
+echo
+echo ">> Access token:"
+echo "$TOKEN"
+echo
+echo ">> Wrote suite config: $OUT"
+echo "   Import it on the conformance suite's schedule-test page, or pass it to"
+echo "   .gitlab-ci/run-tests.sh as the transmitter config path."

--- a/conformance/docker-compose-conformance.build.yml
+++ b/conformance/docker-compose-conformance.build.yml
@@ -1,0 +1,30 @@
+# Build-from-source override for the SSF conformance stack.
+#
+# Layer this OVER docker-compose-conformance.yml to replace the published
+# i2gosignals image with one compiled from the current working tree, so each
+# fix/enhancement can be tested by rebuilding instead of pulling a release:
+#
+#   # from the conformance/ directory:
+#   docker compose \
+#     -f docker-compose-conformance.yml \
+#     -f docker-compose-conformance.build.yml \
+#     up -d --build
+#
+# `--build` recompiles goSignalsServer + healthcheck from source (see
+# Dockerfile.conformance). The module cache is reused across rebuilds, so after
+# the first build only changed packages recompile. To force a from-scratch
+# rebuild add `--no-cache` to a `docker compose build` invocation.
+#
+# The local tag i2gosignals:conformance-dev keeps source builds distinct from
+# any pulled release image. Everything else (ports, env, cert mount, healthcheck,
+# extra_hosts) is inherited from docker-compose-conformance.yml unchanged.
+
+services:
+  gosignals:
+    image: i2gosignals:conformance-dev
+    build:
+      # Repo root: the whole Go module must be in the build context.
+      context: ..
+      dockerfile: conformance/Dockerfile.conformance
+    # The base file pins command to /app/goSignalsServer, which is also this
+    # image's CMD; left inherited.

--- a/conformance/docker-compose-conformance.yml
+++ b/conformance/docker-compose-conformance.yml
@@ -1,0 +1,84 @@
+name: i2gosignals-ssf-conformance
+
+# Minimal, single-SUT deployment of goSignalsServer for running the OpenID
+# conformance suite SSF test plans against it. Brings up exactly:
+#   - mongo        : single-node MongoDB replica set (rs0) for change streams
+#   - mongo-init   : one-shot rs.initiate()
+#   - gosignals    : goSignalsServer, the System-Under-Test, published on :9443
+#
+# Prereqs:
+#   - `make build-docker` in the repo root to produce i2gosignals:latest
+#   - The conformance suite running at https://localhost.emobix.co.uk:8443
+#
+# See README.md for the full runbook.
+
+volumes:
+  ssfconf_mongo_data: {}
+
+networks:
+  ssfconf: {}
+
+services:
+  mongo:
+    image: mongo:latest
+    container_name: ssfconf-mongo
+    networks: [ssfconf]
+    command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
+    volumes:
+      - ssfconf_mongo_data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  mongo-init:
+    image: mongo:latest
+    container_name: ssfconf-mongo-init
+    networks: [ssfconf]
+    restart: "no"
+    depends_on:
+      mongo:
+        condition: service_healthy
+    entrypoint:
+      - bash
+      - -c
+      - |
+        mongosh --host mongo:27017 --quiet --eval '
+          try { rs.status().ok }
+          catch (e) {
+            rs.initiate({ _id: "rs0", members: [{ _id: 0, host: "mongo:27017" }] });
+          }'
+
+  gosignals:
+    # Override with GOSIGNALS_IMAGE=... ; defaults to the published alpha image.
+    image: ${GOSIGNALS_IMAGE:-independentid/i2gosignals:0.12.0.alpha.2}
+    container_name: ssfconf-gosignals
+    command: /app/goSignalsServer
+    hostname: gosignals
+    networks: [ssfconf]
+    depends_on:
+      mongo-init:
+        condition: service_completed_successfully
+    env_file:
+      - ./gosignals-conformance.env
+    ports:
+      # Published only on loopback; the suite reaches it via the public DNS name
+      # localhost.emobix.co.uk -> 127.0.0.1. Container :8888 -> host :9443.
+      - "127.0.0.1:9443:8888"
+    extra_hosts:
+      # PUSH callback: inside the container localhost.emobix.co.uk would resolve
+      # to the container itself. Map it to the docker host so goSignals can POST
+      # SETs back to the suite at https://localhost.emobix.co.uk:8443.
+      - "localhost.emobix.co.uk:host-gateway"
+    volumes:
+      # Server cert/key + outbound CA (see gosignals-conformance.env). Read-only.
+      - ../config/certs:/app/config/certs:ro
+    healthcheck:
+      # healthcheck binary requires a URL arg; -k skips TLS verification (the
+      # server presents the conformance cert for localhost.emobix.co.uk, not
+      # the in-container "localhost" host it's probed on).
+      test: ["CMD", "/app/healthcheck", "-k", "https://localhost:8888/.well-known/ssf-configuration"]
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/conformance/gosignals-conformance.env
+++ b/conformance/gosignals-conformance.env
@@ -42,5 +42,11 @@ I2SIG_TLS_KEY_PATH=/app/config/certs/server-key.pem
 # POLL-only run no outbound call is made, so the default below is harmless.
 I2SIG_TLS_CA_CERT=/app/config/certs/ca-cert.pem
 
+# SSF subject filtering (§8.1.3). DISABLED by default, which suppresses the
+# add_subject_endpoint / remove_subject_endpoint from transmitter metadata and
+# makes the suite SKIP openid-ssf-stream-subject-control. Enable it so discovery
+# advertises the endpoints and the subject add/remove modules can be exercised.
+I2SIG_SUBJECT_FILTERING=ENABLED
+
 LOG_LEVEL=DEBUG
 I2SIG_CLUSTER_NAME=ssf-conformance

--- a/conformance/gosignals-conformance.env
+++ b/conformance/gosignals-conformance.env
@@ -1,0 +1,46 @@
+# Environment for goSignalsServer when run as the System-Under-Test for the
+# OpenID conformance suite SSF (Shared Signals Framework) test plans.
+#
+# Consumed by docker-compose-conformance.yml (env_file). All values are tuned for
+# a local conformance run where the suite is reachable at
+# https://localhost.emobix.co.uk:8443 and goSignals is published on host :9443.
+
+# Internal listen port (the container port; published to the host as 9443).
+PORT=8888
+
+# Public-facing base URL the suite uses. goSignals generates the metadata
+# endpoint URLs (configuration/status/verification/jwks/poll) from this, so it
+# MUST be the host:port the suite can reach. 9443 is the published host port.
+# Trailing slash is required by goSignals link generation.
+BASE_URL=https://localhost.emobix.co.uk:9443/
+
+# Issuer asserted in transmitter metadata and in the `iss` of every SET. The
+# suite's discovery config (ssf.transmitter.issuer) must match this exactly.
+I2SIG_ISSUER_DEFAULT=https://localhost.emobix.co.uk:9443
+
+# Single-node MongoDB replica set (goSignals uses change streams, which require a
+# replica set). No auth for the throwaway conformance database.
+MONGO_URL=mongodb://mongo:27017/?replicaSet=rs0&serverSelectionTimeoutMS=5000&connectTimeoutMS=10000
+I2SIG_STORE_MONGO_DBNAME=ssfconf
+I2SIG_STORE_MONGO_RESUME_FILE=/app/resources/mongo_token.json
+
+# Bootstrap secret. Presented as the bearer on the goSignals CLI `create iat` /
+# `create key` bootstrap calls (see bootstrap-token.sh). The anonymous /iat door
+# is closed, so this must be set.
+I2SIG_BOOTSTRAP_TOKEN=dev-bootstrap-secret
+
+# TLS. The suite's HTTP client trusts all certs and uses a no-op hostname
+# verifier (AbstractCondition.java), so the self-signed server cert that ships in
+# config/certs is accepted as-is for the suite -> goSignals direction.
+I2SIG_TLS_ENABLED=true
+I2SIG_TLS_CERT_PATH=/app/config/certs/server-cert.pem
+I2SIG_TLS_KEY_PATH=/app/config/certs/server-key.pem
+
+# Outbound trust for the PUSH callback (goSignals -> suite). This CA must verify
+# the suite's HTTPS endpoint (its nginx). For a PUSH run, append the suite's root
+# CA into config/certs/ca-cert.pem (see README "PUSH callback trust"). For a
+# POLL-only run no outbound call is made, so the default below is harmless.
+I2SIG_TLS_CA_CERT=/app/config/certs/ca-cert.pem
+
+LOG_LEVEL=DEBUG
+I2SIG_CLUSTER_NAME=ssf-conformance

--- a/conformance/gosignals-conformance.env
+++ b/conformance/gosignals-conformance.env
@@ -48,5 +48,21 @@ I2SIG_TLS_CA_CERT=/app/config/certs/ca-cert.pem
 # advertises the endpoints and the subject add/remove modules can be exercised.
 I2SIG_SUBJECT_FILTERING=ENABLED
 
+# PUSH callback TLS. For PUSH delivery goSignals POSTs SETs to the suite at
+# https://localhost.emobix.co.uk:8443. The suite's nginx serves a self-signed
+# cert with subject "/CN=localhost" and NO subjectAltName, so Go's push client
+# rejects it ("certificate is not valid for any names"). Default new streams to
+# skip receiver TLS verification so PUSH delivery (verification, CAEP) can run.
+# Honors the per-stream tx_tls_skip_verify field; POLL runs are unaffected.
+I2SIG_TX_TLS_SKIP_VERIFY=true
+
+# PUSH receiver status-poll. goSignals' T2 pre-flight / recovery loop GETs
+# <push-endpoint>/status on the receiver, but SSF (§7.1.3) places the status
+# endpoint on the TRANSMITTER — a standard RFC 8935 receiver (and the suite's
+# emulated receiver) exposes none and fails the test on the unexpected request.
+# Disable the receiver status-poll; goSignals logs a warning and delivers without
+# it (a receiver pause is still observed via the push response).
+I2SIG_PUSH_DISABLE_RECEIVER_STATUS=true
+
 LOG_LEVEL=DEBUG
 I2SIG_CLUSTER_NAME=ssf-conformance

--- a/conformance/gosignals-conformance.env
+++ b/conformance/gosignals-conformance.env
@@ -64,5 +64,21 @@ I2SIG_TX_TLS_SKIP_VERIFY=true
 # it (a receiver pause is still observed via the push response).
 I2SIG_PUSH_DISABLE_RECEIVER_STATUS=true
 
+# Receiver management self-exercise. The OpenID SSF receiver conformance plan
+# (happypath, stream-status-update modules) waits to OBSERVE the receiver drive
+# the transmitter's stream-management API: read, update, replace and
+# status-update. A production receiver never spontaneously mutates its own
+# stream, so this is off by default; enable it here so the suite sees those
+# receiver-initiated calls once each stream is established (SSF 1.0 §8.1.1.2-4,
+# §8.1.2.2). Requests run in the pre-poll window, serialized, best-effort.
+I2SIG_RCV_MANAGEMENT_EXERCISE=true
+
+# Receiver verification-on-establish. A polling receiver requests a verification
+# event from the transmitter (SSF 1.0 §8.1.4.2) once its stream is established,
+# so the suite's openid-ssf-receiver-stream-verification module observes the
+# receiver-initiated request. Off by default (it adds an outbound request and
+# retries when a transmitter rejects it); enable it here for the conformance run.
+I2SIG_RCV_VERIFY_ON_ESTABLISH=true
+
 LOG_LEVEL=DEBUG
 I2SIG_CLUSTER_NAME=ssf-conformance

--- a/conformance/suite-configs/ssf-receiver-gosignals.json
+++ b/conformance/suite-configs/ssf-receiver-gosignals.json
@@ -1,0 +1,22 @@
+{
+    "alias": "gosignals-ssf-rx",
+    "description": "SSF Receiver conformance: suite emulates a Transmitter; goSignals registers a stream against it",
+    "ssf": {
+        "stream": {
+            "audience": "{BASEURL}test/a/gosignals-ssf-rx"
+        },
+        "subjects": {
+            "valid": {
+                "format": "opaque",
+                "id": "valid"
+            },
+            "invalid": {
+                "format": "opaque",
+                "id": "invalid"
+            }
+        },
+        "transmitter": {
+            "access_token": "ssf-conformance-rx-token"
+        }
+    }
+}

--- a/conformance/suite-configs/ssf-transmitter-gosignals.json
+++ b/conformance/suite-configs/ssf-transmitter-gosignals.json
@@ -1,0 +1,21 @@
+{
+    "alias": "gosignals-ssf-tx",
+    "description": "SSF Transmitter conformance against goSignalsServer (suite emulates a Receiver)",
+    "ssf": {
+        "subjects": {
+            "valid": {
+                "format": "opaque",
+                "id": "valid"
+            },
+            "invalid": {
+                "format": "opaque",
+                "id": "invalid"
+            }
+        },
+        "transmitter": {
+            "issuer": "https://localhost.emobix.co.uk:9443",
+            "access_token": "__GOSIGNALS_STREAM_EVENT_TOKEN__",
+            "push_endpoint_authorization_header": "Bearer ssf-conformance-push"
+        }
+    }
+}

--- a/internal/eventRouter/delivery/http.go
+++ b/internal/eventRouter/delivery/http.go
@@ -96,8 +96,9 @@ func (a *HTTPAdapter) attempt(ctx context.Context, req PushRequest) PushOutcome 
 	traceCtx := httptrace.WithClientTrace(ctx, trace)
 
 	result := goSetPush.PushSET(traceCtx, tokenString, goSetPush.TransmitterConfig{
-		EndpointURL:   pushCfg.EndpointUrl,
-		Authorization: pushCfg.AuthorizationHeader,
+		EndpointURL:        pushCfg.EndpointUrl,
+		Authorization:      pushCfg.AuthorizationHeader,
+		InsecureSkipVerify: cfg.TxTLSSkipVerify,
 	})
 
 	cls := goSetPush.ClassifyResult(result)

--- a/internal/eventRouter/event_router.go
+++ b/internal/eventRouter/event_router.go
@@ -1257,11 +1257,21 @@ func (r *router) runPushLoop(resource string, stream *model.StreamStateRecord, e
 	// attempt the first push; that wastes a JTI on a known failure and produces noise in logs.
 	// Transport/auth/decode errors are tolerated — they will surface immediately on the first
 	// push attempt and dispatch to T1 with the right RecoveryMode.
-	switch outcome := r.preflightCheckStatus(heartbeatCtx, stream, statusFetcher, recoveryCfg); outcome {
-	case RecoveryOutcomeDisabled:
-		return false
-	case RecoveryOutcomeContextDone:
-		return true
+	//
+	// The receiver status-poll is a goSignals/SSTP extension; standard SSF (§7.1.3) puts the
+	// status endpoint on the transmitter, so a plain RFC 8935 receiver exposes none. When
+	// disabled, skip the pre-flight (and recovery polls below) entirely — a receiver pause is
+	// still observed via the push response, not a status GET.
+	if PushReceiverStatusDisabled() {
+		eventLogger.Warn("PUSH-SRV: receiver status-poll disabled (I2SIG_PUSH_DISABLE_RECEIVER_STATUS); "+
+			"skipping T2 pre-flight /status check — push delivery proceeds without it", "sid", sid)
+	} else {
+		switch outcome := r.preflightCheckStatus(heartbeatCtx, stream, statusFetcher, recoveryCfg); outcome {
+		case RecoveryOutcomeDisabled:
+			return false
+		case RecoveryOutcomeContextDone:
+			return true
+		}
 	}
 
 	backfillTicker := time.NewTicker(r.backfillInterval)

--- a/internal/eventRouter/push_receiver_status.go
+++ b/internal/eventRouter/push_receiver_status.go
@@ -1,0 +1,30 @@
+package eventRouter
+
+import (
+	"os"
+	"strings"
+)
+
+// pushReceiverStatusDisabledEnvVar opts goSignals out of polling a PUSH
+// receiver's /status endpoint. SSF (§7.1.3) and RFC 8935 place the stream
+// status endpoint on the TRANSMITTER: a receiver controls status by POSTing to
+// the transmitter's status endpoint, never the reverse. goSignals' T2 pre-flight
+// and recovery loop nonetheless GET <push-endpoint>/status on the receiver, which
+// is meaningful only for goSignals↔goSignals (SSTP) peers. A standard SSF
+// receiver exposes no such endpoint (and the OpenID conformance suite fails the
+// test on the unexpected request). Setting this skips the receiver status-poll
+// and logs a warning instead; push delivery still works (a receiver pause is
+// observed via the push response, not a status poll).
+const pushReceiverStatusDisabledEnvVar = "I2SIG_PUSH_DISABLE_RECEIVER_STATUS"
+
+// PushReceiverStatusDisabled reports whether goSignals must NOT poll a PUSH
+// receiver's /status endpoint. True only when I2SIG_PUSH_DISABLE_RECEIVER_STATUS
+// is a truthy value (true/1/enabled/yes, case-insensitive).
+func PushReceiverStatusDisabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(pushReceiverStatusDisabledEnvVar))) {
+	case "true", "1", "enabled", "yes":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/eventRouter/push_status.go
+++ b/internal/eventRouter/push_status.go
@@ -2,15 +2,39 @@ package eventRouter
 
 import (
     "context"
+    "crypto/tls"
     "encoding/json"
     "fmt"
     "net/http"
     "net/url"
     "strings"
+    "sync"
+    "time"
 
     "github.com/i2-open/i2goSignals/pkg/httpSupport"
     "github.com/i2-open/i2goSignals/pkg/ssfModels"
 )
+
+// insecureStatusClient is the lazily-built HTTP client used for push /status
+// pre-flight checks against receivers whose stream sets tx_tls_skip_verify. It
+// mirrors the push delivery path so the status check and the delivery agree on
+// TLS posture (otherwise the pre-flight would fail verification on every cycle).
+var (
+    insecureStatusClient     *http.Client
+    insecureStatusClientOnce sync.Once
+)
+
+func getInsecureStatusClient() *http.Client {
+    insecureStatusClientOnce.Do(func() {
+        insecureStatusClient = &http.Client{
+            Timeout: 5 * time.Second,
+            Transport: &http.Transport{
+                TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // per-stream tx_tls_skip_verify opt-in
+            },
+        }
+    })
+    return insecureStatusClient
+}
 
 // derivePushStatusURL converts a push receiver's events URL (POST <base>/events/<sid>) into
 // the corresponding /status URL used by recoveryLoop's StatusFetcher. The receiver authoritatively
@@ -54,6 +78,13 @@ func derivePushStatusURL(endpointURL, sid string) (string, error) {
 // credential that authorizes event delivery also authorizes /status reads.
 func (r *router) pushStatusFetcher() StatusFetcher {
     return func(ctx context.Context, stream *model.StreamStateRecord) (*model.StreamStatus, error) {
+        // The receiver status-poll is a goSignals/SSTP extension with no basis in
+        // standard SSF push (§7.1.3 places the status endpoint on the transmitter).
+        // When disabled, make no request: callers treat the error as "couldn't
+        // determine state" and fall back to push-response-driven behavior.
+        if PushReceiverStatusDisabled() {
+            return nil, fmt.Errorf("PUSH-SRV: receiver status-poll disabled (%s)", pushReceiverStatusDisabledEnvVar)
+        }
         if stream == nil || stream.StreamConfiguration.Delivery == nil ||
             stream.StreamConfiguration.Delivery.PushTransmitMethod == nil {
             return nil, fmt.Errorf("PUSH-SRV: stream missing push transmit method")
@@ -73,7 +104,11 @@ func (r *router) pushStatusFetcher() StatusFetcher {
         }
         req.Header.Set("Accept", "application/json")
 
-        resp, err := r.httpClient.Do(req)
+        client := r.httpClient
+        if stream.StreamConfiguration.TxTLSSkipVerify {
+            client = getInsecureStatusClient()
+        }
+        resp, err := client.Do(req)
         if err != nil {
             return nil, fmt.Errorf("PUSH-SRV: status request failed: %w", err)
         }

--- a/internal/eventRouter/push_status_test.go
+++ b/internal/eventRouter/push_status_test.go
@@ -74,6 +74,38 @@ func TestPushStatusFetcher_ReturnsStreamStatus(t *testing.T) {
     assert.Equal(t, "Bearer fake-token", capturedAuth, "fetcher must reuse pushConfig.AuthorizationHeader")
 }
 
+// TestPushStatusFetcher_DisabledMakesNoRequest pins the I2SIG_PUSH_DISABLE_RECEIVER_STATUS
+// opt-out: when set, the fetcher returns an error WITHOUT contacting the receiver,
+// so goSignals never GETs a /status endpoint that standard SSF push receivers don't expose.
+func TestPushStatusFetcher_DisabledMakesNoRequest(t *testing.T) {
+    t.Setenv("I2SIG_PUSH_DISABLE_RECEIVER_STATUS", "true")
+
+    var hits int
+    server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+        hits++
+        w.WriteHeader(http.StatusOK)
+    }))
+    defer server.Close()
+
+    r := newTestRouter(t).router
+    stream := &model.StreamStateRecord{}
+    stream.StreamConfiguration = model.StreamConfiguration{
+        Id: "abc123",
+        Delivery: &model.OneOfStreamConfigurationDelivery{
+            PushTransmitMethod: &model.PushTransmitMethod{
+                Method:              model.DeliveryPush,
+                EndpointUrl:         server.URL + "/events/abc123",
+                AuthorizationHeader: "Bearer fake-token",
+            },
+        },
+    }
+
+    status, err := r.pushStatusFetcher()(context.Background(), stream)
+    require.Error(t, err, "fetcher must report disabled rather than poll the receiver")
+    assert.Nil(t, status)
+    assert.Equal(t, 0, hits, "no /status request must reach the receiver when disabled")
+}
+
 func TestPushStatusFetcher_NonOKReturnsError(t *testing.T) {
     server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
         w.WriteHeader(http.StatusUnauthorized)

--- a/internal/server/api_receiver.go
+++ b/internal/server/api_receiver.go
@@ -160,6 +160,17 @@ func (sa *SignalsApplication) getHTTPClientForWellKnownEndpoint(ctx context.Cont
 		}
 	}
 
+	// No TxAlias server: honor any per-stream transmitter-TLS settings recorded on
+	// the stream itself (self-signed or hostname-mismatched transmitter), so the
+	// inline static-token receiver path can discover a transmitter whose cert the
+	// system roots don't trust.
+	if conf.TxTLSSkipVerify || conf.TxTLSCertificate != "" {
+		srv := &model.Server{TLSSkipVerify: conf.TxTLSSkipVerify, TLSCertificate: conf.TxTLSCertificate}
+		client := oauthClient.GetBaseHTTPClientForServer(srv)
+		client.Timeout = 10 * time.Second
+		return client
+	}
+
 	// Fallback to default client with CA check
 	client := &http.Client{Timeout: 10 * time.Second}
 	tlsSupport.CheckCaInstalled(client)
@@ -186,10 +197,14 @@ func (sa *SignalsApplication) getHTTPClientForStream(ctx context.Context, stream
 		serverLog.Warn("RCV: Server not found for alias", "alias", *conf.TxAlias, "error", err)
 	}
 
-	// 2. Backward compatibility: TxToken (no server object)
+	// 2. Backward compatibility: TxToken (no server object). Carry the per-stream
+	// transmitter-TLS settings so the inline static-token path honors a
+	// self-signed / hostname-mismatched transmitter cert.
 	if server == nil && conf.TxToken != nil && *conf.TxToken != "" {
 		server = &model.Server{
-			ClientToken: conf.TxToken,
+			ClientToken:    conf.TxToken,
+			TLSCertificate: conf.TxTLSCertificate,
+			TLSSkipVerify:  conf.TxTLSSkipVerify,
 		}
 	}
 

--- a/internal/server/api_receiver.go
+++ b/internal/server/api_receiver.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -28,17 +30,18 @@ import (
 )
 
 type ClientPollStream struct {
-	mu        sync.RWMutex
-	sa        *SignalsApplication
-	stream    *model.StreamStateRecord
-	ctx       context.Context
-	cancel    context.CancelFunc
-	active          bool          // false once Close() or a terminal error asked the receiver to stop
-	running         bool          // true while the polling goroutine is alive (set on launch, cleared on goroutine exit)
-	done            chan struct{} // closed by the polling goroutine when it exits; lets StopGracefully wait for an in-flight poll to drain
-	statusUrl       string
-	verifyUrl       string // cached transmitter verification endpoint
-	verifyRequested bool   // true once a verification has been requested for this goroutine (one-shot on stream establishment)
+	mu                  sync.RWMutex
+	sa                  *SignalsApplication
+	stream              *model.StreamStateRecord
+	ctx                 context.Context
+	cancel              context.CancelFunc
+	active              bool          // false once Close() or a terminal error asked the receiver to stop
+	running             bool          // true while the polling goroutine is alive (set on launch, cleared on goroutine exit)
+	done                chan struct{} // closed by the polling goroutine when it exits; lets StopGracefully wait for an in-flight poll to drain
+	statusUrl           string
+	verifyUrl           string // cached transmitter verification endpoint
+	verifyRequested     bool   // true once a verification has been requested for this goroutine (one-shot on stream establishment)
+	managementExercised bool   // true once the management self-exercise has run for this goroutine (one-shot, conformance only)
 }
 
 type ReceiverPushStream struct {
@@ -285,19 +288,7 @@ func (sa *SignalsApplication) CascadeReceiverStreamDelete(ctx context.Context, s
 
 	// Resolve the transmitter's configuration_endpoint: prefer a registered
 	// TxAlias server's cached metadata, else discover it from the well-known URL.
-	configEndpoint := ""
-	if server, _ := sa.getServerForStream(ctx, state); server != nil && server.ServerConfiguration != nil {
-		configEndpoint = server.ServerConfiguration.ConfigurationEndpoint
-	}
-	if configEndpoint == "" && conf.TxWellKnownUrl != nil && *conf.TxWellKnownUrl != "" {
-		wkClient := sa.getHTTPClientForWellKnownEndpoint(ctx, state)
-		txConfig, err := wellKnownSupport.FetchSSFConfiguration(ctx, wkClient, *conf.TxWellKnownUrl)
-		if err != nil {
-			serverLog.Warn("RCV: delete cascade skipped — failed to discover transmitter config", "sid", conf.Id, "error", err)
-			return
-		}
-		configEndpoint = txConfig.ConfigurationEndpoint
-	}
+	configEndpoint := sa.resolveTransmitterConfigEndpoint(ctx, state)
 	if configEndpoint == "" {
 		serverLog.Warn("RCV: delete cascade skipped — no transmitter configuration_endpoint", "sid", conf.Id)
 		return
@@ -333,6 +324,182 @@ func (sa *SignalsApplication) CascadeReceiverStreamDelete(ctx context.Context, s
 		return
 	}
 	serverLog.Info("RCV: delete cascaded to transmitter", "sid", conf.Id, "remote", *conf.RemoteStreamId, "status", resp.StatusCode)
+}
+
+// resolveTransmitterConfigEndpoint returns the transmitter's
+// configuration_endpoint for a receiver stream: a registered TxAlias server's
+// cached metadata if present, else discovered from the stream's well-known URL.
+// Returns "" if neither is available.
+func (sa *SignalsApplication) resolveTransmitterConfigEndpoint(ctx context.Context, state *model.StreamStateRecord) string {
+	conf := state.StreamConfiguration
+	if server, _ := sa.getServerForStream(ctx, state); server != nil && server.ServerConfiguration != nil {
+		if server.ServerConfiguration.ConfigurationEndpoint != "" {
+			return server.ServerConfiguration.ConfigurationEndpoint
+		}
+	}
+	if conf.TxWellKnownUrl != nil && *conf.TxWellKnownUrl != "" {
+		wkClient := sa.getHTTPClientForWellKnownEndpoint(ctx, state)
+		txConfig, err := wellKnownSupport.FetchSSFConfiguration(ctx, wkClient, *conf.TxWellKnownUrl)
+		if err != nil {
+			serverLog.Warn("RCV: failed to discover transmitter configuration_endpoint", "sid", conf.Id, "error", err)
+			return ""
+		}
+		return txConfig.ConfigurationEndpoint
+	}
+	return ""
+}
+
+// resolveTransmitterStatusEndpoint mirrors resolveTransmitterConfigEndpoint for
+// the status_endpoint (SSF 1.0 §8.1.2). Returns "" if it cannot be resolved.
+func (sa *SignalsApplication) resolveTransmitterStatusEndpoint(ctx context.Context, state *model.StreamStateRecord) string {
+	conf := state.StreamConfiguration
+	if server, _ := sa.getServerForStream(ctx, state); server != nil && server.ServerConfiguration != nil {
+		if server.ServerConfiguration.StatusEndpoint != "" {
+			return server.ServerConfiguration.StatusEndpoint
+		}
+	}
+	if conf.TxWellKnownUrl != nil && *conf.TxWellKnownUrl != "" {
+		wkClient := sa.getHTTPClientForWellKnownEndpoint(ctx, state)
+		txConfig, err := wellKnownSupport.FetchSSFConfiguration(ctx, wkClient, *conf.TxWellKnownUrl)
+		if err != nil {
+			serverLog.Warn("RCV: failed to discover transmitter status_endpoint", "sid", conf.Id, "error", err)
+			return ""
+		}
+		return txConfig.StatusEndpoint
+	}
+	return ""
+}
+
+// ExerciseReceiverManagement performs a one-shot, best-effort self-exercise of
+// the transmitter's stream-management API against a receiver stream once it is
+// established: read (GET), update (PATCH), replace (PUT) and status-update
+// (POST status). It is gated by I2SIG_RCV_MANAGEMENT_EXERCISE (off by default)
+// because a production receiver does not spontaneously mutate its own stream;
+// the OpenID SSF receiver conformance plan (happypath, stream-status-update)
+// requires the suite to observe these receiver-initiated calls.
+//
+// Every request is best-effort: any failure is logged and swallowed so the
+// receiver keeps polling. Each request body carries only Receiver-Supplied
+// properties plus the remote stream_id — Read-Only/transmitter-supplied
+// properties are omitted, as strict transmitters reject them (SSF 1.0 §8.1.1.3,
+// §8.1.1.4). Callers must invoke this OUTSIDE any in-flight long-poll window so
+// the requests run sequentially and never race a concurrent poll at a
+// single-threaded transmitter.
+func (sa *SignalsApplication) ExerciseReceiverManagement(ctx context.Context, state *model.StreamStateRecord) {
+	if !services.RcvManagementExerciseEnabled() {
+		return
+	}
+	conf := state.StreamConfiguration
+	if !(state.GetType() == model.ReceivePoll || state.GetType() == model.ReceivePush) {
+		return
+	}
+	if conf.RemoteStreamId == nil || *conf.RemoteStreamId == "" {
+		return
+	}
+	remoteId := *conf.RemoteStreamId
+
+	configEndpoint := sa.resolveTransmitterConfigEndpoint(ctx, state)
+	if configEndpoint == "" {
+		serverLog.Warn("RCV: management exercise skipped — no transmitter configuration_endpoint", "sid", conf.Id)
+		return
+	}
+
+	client, auth, closeClient, err := sa.getHTTPClientForStream(ctx, state)
+	if err != nil {
+		serverLog.Warn("RCV: management exercise skipped — client error", "sid", conf.Id, "error", err)
+		return
+	}
+	defer closeClient()
+
+	// 1. Read the stream configuration (SSF 1.0 §8.1.1.2 — stream_id as query param).
+	readURL := goSsfUtils.AddStreamIdToUrl(configEndpoint, remoteId)
+	sa.doReceiverManagementRequest(ctx, client, auth, http.MethodGet, readURL, nil, conf.Id, "read")
+
+	// 2. Update the stream configuration (SSF 1.0 §8.1.1.3 — PATCH, Receiver-Supplied only).
+	updateBody := map[string]any{
+		"stream_id":   remoteId,
+		"description": "i2goSignals receiver (management exercise: update)",
+	}
+	sa.doReceiverManagementRequest(ctx, client, auth, http.MethodPatch, configEndpoint, updateBody, conf.Id, "update")
+
+	// 3. Replace the stream configuration (SSF 1.0 §8.1.1.4 — PUT, full Receiver-Supplied set).
+	replaceBody := map[string]any{
+		"stream_id":   remoteId,
+		"description": "i2goSignals receiver (management exercise: replace)",
+		"delivery":    receiverDeliveryBody(state),
+	}
+	if len(conf.EventsRequested) > 0 {
+		replaceBody["events_requested"] = conf.EventsRequested
+	}
+	sa.doReceiverManagementRequest(ctx, client, auth, http.MethodPut, configEndpoint, replaceBody, conf.Id, "replace")
+
+	// 4. Update the stream status (SSF 1.0 §8.1.2.2 — POST status). enabled→enabled
+	// is a safe no-op transition that keeps the stream running.
+	statusEndpoint := sa.resolveTransmitterStatusEndpoint(ctx, state)
+	if statusEndpoint == "" {
+		serverLog.Warn("RCV: management exercise — no transmitter status_endpoint, skipping status update", "sid", conf.Id)
+		return
+	}
+	statusBody := map[string]any{
+		"stream_id": remoteId,
+		"status":    string(model.StreamStateEnabled),
+		"reason":    "i2goSignals receiver (management exercise: status update)",
+	}
+	sa.doReceiverManagementRequest(ctx, client, auth, http.MethodPost, statusEndpoint, statusBody, conf.Id, "status-update")
+}
+
+// receiverDeliveryBody builds the Receiver-Supplied delivery sub-object for a
+// replace request, expressed with the management-API (transmit-direction)
+// method URN the transmitter expects, derived from the receiver's own delivery.
+func receiverDeliveryBody(state *model.StreamStateRecord) map[string]any {
+	if state.GetType() == model.ReceivePush && state.Delivery != nil && state.Delivery.PushReceiveMethod != nil {
+		return map[string]any{
+			"method":       model.DeliveryPush,
+			"endpoint_url": state.Delivery.PushReceiveMethod.EndpointUrl,
+		}
+	}
+	return map[string]any{"method": model.DeliveryPoll}
+}
+
+// doReceiverManagementRequest issues one best-effort management request to the
+// transmitter and logs the outcome. A nil body sends no payload. The
+// Authorization header is set only when an explicit token is supplied; for
+// TxAlias/OAuth clients the returned http.Client injects credentials itself.
+func (sa *SignalsApplication) doReceiverManagementRequest(ctx context.Context, client *http.Client, auth, method, url string, body map[string]any, sid, op string) {
+	var reader io.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			serverLog.Warn("RCV: management exercise — failed to marshal body", "sid", sid, "op", op, "error", err)
+			return
+		}
+		reader = bytes.NewReader(raw)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, reader)
+	if err != nil {
+		serverLog.Warn("RCV: management exercise — request build failed", "sid", sid, "op", op, "error", err)
+		return
+	}
+	if auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		serverLog.Warn("RCV: management exercise request failed", "sid", sid, "op", op, "error", err)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		serverLog.Warn("RCV: management exercise — unexpected transmitter status", "sid", sid, "op", op, "status", resp.StatusCode)
+		return
+	}
+	serverLog.Info("RCV: management exercise step ok", "sid", sid, "op", op, "remote", url, "status", resp.StatusCode)
 }
 
 /*
@@ -1217,6 +1384,18 @@ func (ps *ClientPollStream) runPollLoop(resource string) {
 	ps.mu.Unlock()
 	if shouldVerify {
 		ps.initiateVerification()
+	}
+
+	// Conformance-only (I2SIG_RCV_MANAGEMENT_EXERCISE): once per goroutine, drive a
+	// read/update/replace/status-update round against the transmitter. Runs here,
+	// in the pre-poll window before any long-poll is open, so the calls are
+	// sequential and never race a concurrent poll at a single-threaded transmitter.
+	ps.mu.Lock()
+	shouldExercise := !ps.managementExercised
+	ps.managementExercised = true
+	ps.mu.Unlock()
+	if shouldExercise {
+		ps.sa.ExerciseReceiverManagement(ps.ctx, ps.stream)
 	}
 
 	retryCount := 0

--- a/internal/server/api_receiver.go
+++ b/internal/server/api_receiver.go
@@ -526,7 +526,7 @@ func (rps *ReceiverPushStream) getVerifyEndpoint() string {
 
 	if rps.stream.StreamConfiguration.TxWellKnownUrl != nil && *rps.stream.StreamConfiguration.TxWellKnownUrl != "" {
 		client := rps.sa.getHTTPClientForWellKnownEndpoint(rps.ctx, rps.stream)
-		txConfig, err := wellKnownSupport.Fetch[model.TransmitterConfiguration](rps.ctx, client, *rps.stream.StreamConfiguration.TxWellKnownUrl)
+		txConfig, err := wellKnownSupport.FetchSSFConfiguration(rps.ctx, client, *rps.stream.StreamConfiguration.TxWellKnownUrl)
 		if err == nil && txConfig.VerificationEndpoint != "" {
 			rps.verifyUrl = txConfig.VerificationEndpoint
 			return rps.verifyUrl
@@ -574,7 +574,7 @@ func (rps *ReceiverPushStream) getStatusEndpointLocked() string {
 
 	if rps.stream.StreamConfiguration.TxWellKnownUrl != nil && *rps.stream.StreamConfiguration.TxWellKnownUrl != "" {
 		client := rps.sa.getHTTPClientForWellKnownEndpoint(rps.ctx, rps.stream)
-		txConfig, err := wellKnownSupport.Fetch[model.TransmitterConfiguration](rps.ctx, client, *rps.stream.StreamConfiguration.TxWellKnownUrl)
+		txConfig, err := wellKnownSupport.FetchSSFConfiguration(rps.ctx, client, *rps.stream.StreamConfiguration.TxWellKnownUrl)
 		if err == nil && txConfig.StatusEndpoint != "" {
 			rps.statusUrl = goSsfUtils.AddStreamIdToUrl(txConfig.StatusEndpoint, rps.stream.StreamConfiguration.Id)
 			return rps.statusUrl
@@ -694,13 +694,20 @@ func (ps *ClientPollStream) getStatusEndpoint() string {
 		return ps.statusUrl
 	}
 
+	// Remote calls must reference the TRANSMITTER's stream_id (remote_stream_id),
+	// not our local id — they identify different streams on each side.
+	remoteId := ps.stream.StreamConfiguration.Id
+	if rid := ps.stream.StreamConfiguration.RemoteStreamId; rid != nil && *rid != "" {
+		remoteId = *rid
+	}
+
 	// Using goSsfUtils if server is available
 	server, _ := ps.sa.getServerForStream(ps.ctx, ps.stream)
 	if server != nil {
 		client := ps.sa.getHTTPClientForWellKnownEndpoint(ps.ctx, ps.stream)
 		endpoint, err := goSsfUtils.GetStatusEndpoint(ps.ctx, client, server)
 		if err == nil && endpoint != "" {
-			ps.statusUrl = goSsfUtils.AddStreamIdToUrl(endpoint, ps.stream.StreamConfiguration.Id)
+			ps.statusUrl = goSsfUtils.AddStreamIdToUrl(endpoint, remoteId)
 			return ps.statusUrl
 		}
 	}
@@ -713,9 +720,9 @@ func (ps *ClientPollStream) getStatusEndpoint() string {
 	// Step a: Use TxWellKnownUrl if defined.
 	if ps.stream.StreamConfiguration.TxWellKnownUrl != nil && *ps.stream.StreamConfiguration.TxWellKnownUrl != "" {
 		client := ps.sa.getHTTPClientForWellKnownEndpoint(ps.ctx, ps.stream)
-		txConfig, err := wellKnownSupport.Fetch[model.TransmitterConfiguration](ps.ctx, client, *ps.stream.StreamConfiguration.TxWellKnownUrl)
+		txConfig, err := wellKnownSupport.FetchSSFConfiguration(ps.ctx, client, *ps.stream.StreamConfiguration.TxWellKnownUrl)
 		if err == nil && txConfig.StatusEndpoint != "" {
-			ps.statusUrl = goSsfUtils.AddStreamIdToUrl(txConfig.StatusEndpoint, ps.stream.StreamConfiguration.Id)
+			ps.statusUrl = goSsfUtils.AddStreamIdToUrl(txConfig.StatusEndpoint, remoteId)
 			return ps.statusUrl
 		}
 	}

--- a/internal/server/api_receiver.go
+++ b/internal/server/api_receiver.go
@@ -20,6 +20,7 @@ import (
 	"github.com/i2-open/i2goSignals/pkg/goSetPush"
 	"github.com/i2-open/i2goSignals/pkg/goSsfUtils"
 	"github.com/i2-open/i2goSignals/pkg/oauthClient"
+	"github.com/i2-open/i2goSignals/pkg/services"
 	model "github.com/i2-open/i2goSignals/pkg/ssfModels"
 	"github.com/i2-open/i2goSignals/pkg/tlsSupport"
 	"github.com/i2-open/i2goSignals/pkg/wellKnownSupport"
@@ -32,10 +33,12 @@ type ClientPollStream struct {
 	stream    *model.StreamStateRecord
 	ctx       context.Context
 	cancel    context.CancelFunc
-	active    bool // false once Close() or a terminal error asked the receiver to stop
-	running   bool // true while the polling goroutine is alive (set on launch, cleared on goroutine exit)
-	done      chan struct{} // closed by the polling goroutine when it exits; lets StopGracefully wait for an in-flight poll to drain
-	statusUrl string
+	active          bool          // false once Close() or a terminal error asked the receiver to stop
+	running         bool          // true while the polling goroutine is alive (set on launch, cleared on goroutine exit)
+	done            chan struct{} // closed by the polling goroutine when it exits; lets StopGracefully wait for an in-flight poll to drain
+	statusUrl       string
+	verifyUrl       string // cached transmitter verification endpoint
+	verifyRequested bool   // true once a verification has been requested for this goroutine (one-shot on stream establishment)
 }
 
 type ReceiverPushStream struct {
@@ -555,8 +558,14 @@ func (rps *ReceiverPushStream) initiateVerification() {
 	rps.verifyState = state
 	rps.mu.Unlock()
 
+	// The transmitter identifies the stream by its own (remote) stream_id.
+	remoteId := rps.stream.StreamConfiguration.Id
+	if rid := rps.stream.StreamConfiguration.RemoteStreamId; rid != nil && *rid != "" {
+		remoteId = *rid
+	}
 	params := model.VerificationParameters{
-		State: state,
+		StreamId: remoteId,
+		State:    state,
 	}
 
 	client, _, closeClient, err := rps.sa.getHTTPClientForStream(rps.ctx, rps.stream)
@@ -902,6 +911,100 @@ func (ps *ClientPollStream) getStatusEndpoint() string {
 	return ""
 }
 
+// getVerifyEndpoint resolves (and caches) the transmitter's verification endpoint
+// for this polling receiver. Unlike the status endpoint the stream_id is NOT put
+// in the URL — SSF 1.0 §8.1.4.2 carries it in the request body — so the bare
+// endpoint is cached. Resolution mirrors getStatusEndpoint: a registered TxAlias
+// server's discovered config first, else well-known discovery, else a fallback
+// derived from the status endpoint by swapping the trailing /status for /verify.
+func (ps *ClientPollStream) getVerifyEndpoint() string {
+	ps.mu.RLock()
+	if ps.verifyUrl != "" {
+		ps.mu.RUnlock()
+		return ps.verifyUrl
+	}
+	ps.mu.RUnlock()
+
+	// Resolve WITHOUT holding ps.mu: the helpers below (getServerForStream,
+	// well-known discovery, getStatusEndpoint) manage their own state/locks, and
+	// getStatusEndpoint takes ps.mu itself — holding it here would deadlock.
+	resolved := ""
+	if server, _ := ps.sa.getServerForStream(ps.ctx, ps.stream); server != nil {
+		client := ps.sa.getHTTPClientForWellKnownEndpoint(ps.ctx, ps.stream)
+		if endpoint, err := goSsfUtils.GetVerificationEndpoint(ps.ctx, client, server); err == nil && endpoint != "" {
+			resolved = endpoint
+		}
+	}
+
+	if resolved == "" && ps.stream.StreamConfiguration.TxWellKnownUrl != nil && *ps.stream.StreamConfiguration.TxWellKnownUrl != "" {
+		client := ps.sa.getHTTPClientForWellKnownEndpoint(ps.ctx, ps.stream)
+		txConfig, err := wellKnownSupport.FetchSSFConfiguration(ps.ctx, client, *ps.stream.StreamConfiguration.TxWellKnownUrl)
+		if err == nil && txConfig.VerificationEndpoint != "" {
+			resolved = txConfig.VerificationEndpoint
+		}
+	}
+
+	// Fallback: derive /verify from the resolved status endpoint, dropping the
+	// stream_id query the status URL carries (it belongs in the verify body).
+	if resolved == "" {
+		if statusUrl := ps.getStatusEndpoint(); statusUrl != "" {
+			if u, err := url.Parse(statusUrl); err == nil && strings.Contains(u.Path, "/status") {
+				u.Path = strings.Replace(u.Path, "/status", "/verify", 1)
+				u.RawQuery = ""
+				resolved = u.String()
+			}
+		}
+	}
+
+	ps.mu.Lock()
+	if ps.verifyUrl == "" {
+		ps.verifyUrl = resolved
+	}
+	v := ps.verifyUrl
+	ps.mu.Unlock()
+	return v
+}
+
+// initiateVerification asks the transmitter to emit a verification event for this
+// stream (SSF 1.0 §8.1.4.2). The resulting SET is delivered on a subsequent poll
+// and handled by the normal inbound path. Best-effort: failures are logged and do
+// not stop polling. Run once per goroutine, after the stream is confirmed enabled.
+func (ps *ClientPollStream) initiateVerification() {
+	if !services.RcvVerifyOnEstablishEnabled() {
+		return
+	}
+	sid := ps.stream.StreamConfiguration.Id
+
+	// The transmitter identifies the stream by its own (remote) stream_id.
+	remoteId := sid
+	if rid := ps.stream.StreamConfiguration.RemoteStreamId; rid != nil && *rid != "" {
+		remoteId = *rid
+	}
+
+	verifyUrl := ps.getVerifyEndpoint()
+	if verifyUrl == "" {
+		serverLog.Warn("POLL-RCV: Could not determine verification endpoint", "sid", sid)
+		return
+	}
+
+	client, _, closeClient, err := ps.sa.getHTTPClientForStream(ps.ctx, ps.stream)
+	if err != nil {
+		serverLog.Warn("POLL-RCV: Failed to get client for verification request", "sid", sid, "error", err)
+		return
+	}
+	defer closeClient()
+
+	params := model.VerificationParameters{
+		StreamId: remoteId,
+		State:    ksuid.New().String(),
+	}
+	if err := goSsfUtils.PostVerification(ps.ctx, client, verifyUrl, params); err != nil {
+		serverLog.Warn("POLL-RCV: Verification request failed", "sid", sid, "error", err)
+		return
+	}
+	serverLog.Info("POLL-RCV: Verification requested", "sid", sid, "remote", remoteId)
+}
+
 func (ps *ClientPollStream) checkTransmitterStatus(ctx context.Context) (*model.StreamStatus, error) {
 	server, _ := ps.sa.getServerForStream(ctx, ps.stream)
 	client, _, closeClient, err := ps.sa.getHTTPClientForStream(ctx, ps.stream)
@@ -1100,6 +1203,20 @@ func (ps *ClientPollStream) runPollLoop(resource string) {
 	// Initial status check upon lease acquisition - verify that the transmitter is active
 	if ok, _ := ps.handleTransmitterStatus(heartbeatCtx, statusCheckInterval); !ok {
 		return
+	}
+
+	// Once the stream is established, optionally request a verification event from
+	// the transmitter (SSF 1.0 §8.1.4.2) so the receiver confirms end-to-end
+	// delivery. Gated by I2SIG_RCV_VERIFY_ON_ESTABLISH (off by default; the gate
+	// lives in initiateVerification). One-shot per goroutine; the verification SET
+	// arrives on a later poll and is processed by the normal inbound path.
+	// Best-effort — never blocks polling.
+	ps.mu.Lock()
+	shouldVerify := !ps.verifyRequested
+	ps.verifyRequested = true
+	ps.mu.Unlock()
+	if shouldVerify {
+		ps.initiateVerification()
 	}
 
 	retryCount := 0

--- a/internal/server/api_receiver.go
+++ b/internal/server/api_receiver.go
@@ -34,6 +34,7 @@ type ClientPollStream struct {
 	cancel    context.CancelFunc
 	active    bool // false once Close() or a terminal error asked the receiver to stop
 	running   bool // true while the polling goroutine is alive (set on launch, cleared on goroutine exit)
+	done      chan struct{} // closed by the polling goroutine when it exits; lets StopGracefully wait for an in-flight poll to drain
 	statusUrl string
 }
 
@@ -143,6 +144,36 @@ func (sa *SignalsApplication) CloseReceiver(sid string) {
 		delete(sa.pushReceivers, sid)
 	}
 
+}
+
+// DrainReceiver gracefully stops a polling receiver and waits for its in-flight
+// poll to complete, so no poll request to the transmitter overlaps a subsequent
+// delete cascade. It does not remove the client (CloseReceiver still does the
+// final cleanup); it only stops the long-poll loop without tearing the current
+// request. Push receivers issue no long-poll, so they are left for CloseReceiver.
+// Best-effort: a drain timeout just means CloseReceiver will force-cancel next.
+func (sa *SignalsApplication) DrainReceiver(sid string) {
+	sa.mu.Lock()
+	ps, ok := sa.pollClients[sid]
+	sa.mu.Unlock()
+	if !ok {
+		return
+	}
+
+	// Bound the wait by the poll's own long-poll timeout plus slack so the DELETE
+	// stays responsive; the in-flight poll returns within that window.
+	timeout := 12 * time.Second
+	ps.mu.RLock()
+	if rm := ps.stream.Delivery.PollReceiveMethod; rm != nil && rm.PollConfig != nil && rm.PollConfig.TimeoutSecs > 0 {
+		timeout = time.Duration(rm.PollConfig.TimeoutSecs+2) * time.Second
+	}
+	ps.mu.RUnlock()
+
+	if drained := ps.StopGracefully(timeout); !drained {
+		serverLog.Warn("RCV: poll drain timed out before delete; forcing close", "sid", sid, "timeout", timeout)
+	} else {
+		serverLog.Debug("RCV: poll drained before delete cascade", "sid", sid)
+	}
 }
 
 // getHTTPClientForWellKnownEndpoint returns an HTTP client for fetching well-known configuration endpoints
@@ -330,6 +361,7 @@ func (sa *SignalsApplication) handleClientPollReceiver(streamState *model.Stream
 			running: true,
 			ctx:     ctx,
 			cancel:  cancel,
+			done:    make(chan struct{}),
 		}
 		sa.pollClients[streamState.StreamConfiguration.Id] = ps
 		pollUrl := streamState.Delivery.PollReceiveMethod.EndpointUrl
@@ -356,6 +388,7 @@ func (sa *SignalsApplication) handleClientPollReceiver(streamState *model.Stream
 		ps.cancel = cancel
 		ps.active = true
 		ps.running = true
+		ps.done = make(chan struct{}) // fresh drain signal for the revived goroutine
 	}
 	ps.mu.Unlock()
 
@@ -707,6 +740,36 @@ func (ps *ClientPollStream) Close() {
 	}
 }
 
+// StopGracefully asks the polling goroutine to stop WITHOUT cancelling its
+// context, then waits up to timeout for it to exit. Because the context is left
+// intact, an in-flight long-poll completes naturally instead of being torn
+// mid-request — the loop only re-checks active between polls, so it exits once
+// the current poll returns. This is used before a delete cascade so the receiver
+// is not issuing a poll to the transmitter at the same moment the cascade hits
+// it (a single-threaded transmitter would otherwise race the two requests).
+// Returns true if the goroutine exited within the window; on timeout the caller
+// should fall back to Close() to force-cancel.
+func (ps *ClientPollStream) StopGracefully(timeout time.Duration) bool {
+	ps.mu.Lock()
+	if !ps.running {
+		ps.mu.Unlock()
+		return true
+	}
+	ps.active = false // stop issuing new polls; do NOT cancel so the in-flight poll drains
+	done := ps.done
+	ps.mu.Unlock()
+
+	if done == nil {
+		return false
+	}
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
 // isConnectionError returns true if the error is related to connection failure
 // and we should consider the server offline.
 func isConnectionError(err error) bool {
@@ -923,6 +986,9 @@ func (ps *ClientPollStream) pollEventsReceiver() {
 	defer func() {
 		ps.mu.Lock()
 		ps.running = false
+		if ps.done != nil {
+			close(ps.done) // wake any StopGracefully waiter: the in-flight poll has fully drained
+		}
 		ps.mu.Unlock()
 	}()
 

--- a/internal/server/api_receiver.go
+++ b/internal/server/api_receiver.go
@@ -235,6 +235,72 @@ func (sa *SignalsApplication) getHTTPClientForStream(ctx context.Context, stream
 	return client, "", noop, nil
 }
 
+// CascadeReceiverStreamDelete deletes the corresponding stream on the FOREIGN
+// transmitter when a locally-auto-registered receiver stream is removed
+// (SSF 1.0 §8.1.1.5). It is best-effort: any failure is logged and swallowed so
+// local deletion always succeeds (mirroring the SSTP peer-cascade contract). A
+// no-op unless the stream is a receiver stream carrying a remote_stream_id.
+func (sa *SignalsApplication) CascadeReceiverStreamDelete(ctx context.Context, state *model.StreamStateRecord) {
+	conf := state.StreamConfiguration
+	if !(state.GetType() == model.ReceivePoll || state.GetType() == model.ReceivePush) {
+		return
+	}
+	if conf.RemoteStreamId == nil || *conf.RemoteStreamId == "" {
+		return
+	}
+
+	// Resolve the transmitter's configuration_endpoint: prefer a registered
+	// TxAlias server's cached metadata, else discover it from the well-known URL.
+	configEndpoint := ""
+	if server, _ := sa.getServerForStream(ctx, state); server != nil && server.ServerConfiguration != nil {
+		configEndpoint = server.ServerConfiguration.ConfigurationEndpoint
+	}
+	if configEndpoint == "" && conf.TxWellKnownUrl != nil && *conf.TxWellKnownUrl != "" {
+		wkClient := sa.getHTTPClientForWellKnownEndpoint(ctx, state)
+		txConfig, err := wellKnownSupport.FetchSSFConfiguration(ctx, wkClient, *conf.TxWellKnownUrl)
+		if err != nil {
+			serverLog.Warn("RCV: delete cascade skipped — failed to discover transmitter config", "sid", conf.Id, "error", err)
+			return
+		}
+		configEndpoint = txConfig.ConfigurationEndpoint
+	}
+	if configEndpoint == "" {
+		serverLog.Warn("RCV: delete cascade skipped — no transmitter configuration_endpoint", "sid", conf.Id)
+		return
+	}
+
+	delURL := goSsfUtils.AddStreamIdToUrl(configEndpoint, *conf.RemoteStreamId)
+	client, auth, closeClient, err := sa.getHTTPClientForStream(ctx, state)
+	if err != nil {
+		serverLog.Warn("RCV: delete cascade skipped — client error", "sid", conf.Id, "error", err)
+		return
+	}
+	defer closeClient()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, delURL, nil)
+	if err != nil {
+		serverLog.Warn("RCV: delete cascade skipped — request build error", "sid", conf.Id, "error", err)
+		return
+	}
+	if auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		serverLog.Warn("RCV: delete cascade to transmitter failed", "sid", conf.Id, "remote", *conf.RemoteStreamId, "error", err)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// 204/200 = deleted; 404 = already gone (also acceptable per §8.1.1.5).
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotFound {
+		serverLog.Warn("RCV: delete cascade — unexpected transmitter status", "sid", conf.Id, "status", resp.StatusCode)
+		return
+	}
+	serverLog.Info("RCV: delete cascaded to transmitter", "sid", conf.Id, "remote", *conf.RemoteStreamId, "status", resp.StatusCode)
+}
+
 /*
 HandleReceiver checks if a stream is already defined and updates the configuration returning the ClientPollStream.
 Otherwise, if new, a new receiver is started and its handle is returned. Transmitter streams are ignored automatically.

--- a/internal/server/api_stream_management.go
+++ b/internal/server/api_stream_management.go
@@ -313,17 +313,22 @@ func StreamDeleteHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *h
 	state.Status = model.StreamStateDisable
 	sa.GetEventRouter().UpdateStreamState(state)
 
-	// Stop all the inbound traffic if Polling. Done BEFORE the remote-delete
-	// cascade so the poll goroutine is no longer issuing its own requests to the
-	// transmitter while the cascade discovers/deletes — concurrent calls would
-	// otherwise race (and some transmitters serialize per-stream requests).
-	sa.CloseReceiver(authContext.StreamId)
+	// Gracefully stop a polling receiver and wait for its in-flight poll to drain
+	// BEFORE the remote-delete cascade, so the receiver is not mid-poll against the
+	// transmitter while the cascade discovers/deletes the same stream — concurrent
+	// calls would otherwise race (and some transmitters serialize per-stream
+	// requests). Unlike CloseReceiver this does not tear the current poll request.
+	sa.DrainReceiver(authContext.StreamId)
 
 	// For a receiver stream auto-registered against a foreign transmitter, delete
 	// the remote stream too (SSF §8.1.1.5). Best-effort: the stream's transmitter
 	// credentials/TLS settings are still available on `state`; a remote failure is
 	// logged but never blocks local deletion.
 	sa.CascadeReceiverStreamDelete(r.Context(), state)
+
+	// Final teardown of the (now-drained) receiver and its bookkeeping. The
+	// context-cancel here is a no-op when the poll goroutine already exited.
+	sa.CloseReceiver(authContext.StreamId)
 
 	// Stop any outbound activity
 	sa.GetEventRouter().RemoveStream(authContext.StreamId)

--- a/internal/server/api_stream_management.go
+++ b/internal/server/api_stream_management.go
@@ -709,10 +709,20 @@ func StreamUpdateHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *h
 		return
 	}
 
-	// Because the PUT/PATCH request does not have a stream id parameter, we extract from payload and re-check.
+	// SSF identifies the target stream by the stream_id query parameter, surfaced
+	// here as authCtx.StreamId. PUT/PATCH instead carry the full StreamConfiguration
+	// in the body, where stream_id is a field, so receivers that omit the query
+	// parameter (e.g. the OpenID conformance suite) leave authCtx.StreamId empty.
+	// Fall back to the body's stream_id in that case. Earlier SSF drafts encoded
+	// the stream id in the token, which is why authCtx.StreamId exists at all.
+	streamId := authCtx.StreamId
+	if streamId == "" {
+		streamId = jsonRequest.StreamConfiguration.Id
+	}
+
 	// Use IsAuthorizedForStream (not a bare Eat check) so local tokens keep their stream-id binding while
 	// OAuth/STS callers — who carry no per-stream binding — are still validated against the granted scope set.
-	if !authCtx.IsAuthorizedForStream(jsonRequest.StreamConfiguration.Id, authSupport.ScopeStreamMgmt, authSupport.ScopeStreamAdmin) {
+	if !authCtx.IsAuthorizedForStream(streamId, authSupport.ScopeStreamMgmt, authSupport.ScopeStreamAdmin) {
 		http.Error(w, "Stream identifier not authorized", http.StatusForbidden)
 		return
 	}
@@ -722,7 +732,7 @@ func StreamUpdateHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *h
 	jsonRequest.ResetDate = nil
 	jsonRequest.ResetJti = ""
 
-	configResp, err := sa.GetStreamService().UpdateStream(r.Context(), authCtx.StreamId, authCtx.ProjectId, jsonRequest)
+	configResp, err := sa.GetStreamService().UpdateStream(r.Context(), streamId, authCtx.ProjectId, jsonRequest)
 	if err != nil || configResp == nil {
 		if err != nil && err.Error() == mongo_provider.ErrorInvalidProject {
 			http.Error(w, "Streamid invalid for authorization", http.StatusUnauthorized)
@@ -737,13 +747,13 @@ func StreamUpdateHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *h
 		return
 	}
 
-	streamState, err := sa.GetStreamService().GetStreamState(r.Context(), authCtx.StreamId)
+	streamState, err := sa.GetStreamService().GetStreamState(r.Context(), streamId)
 	if err != nil {
-		serverLog.Error("Error getting stream state after update", "id", authCtx.StreamId, "error", err)
+		serverLog.Error("Error getting stream state after update", "id", streamId, "error", err)
 	}
 	if resetDate != nil || resetJti != "" {
 		// reset the stream to a particular date
-		err := sa.GetEventService().ResetEventStream(r.Context(), authCtx.StreamId, resetJti, resetDate, func(eventRecord *model.AgEventRecord) bool {
+		err := sa.GetEventService().ResetEventStream(r.Context(), streamId, resetJti, resetDate, func(eventRecord *model.AgEventRecord) bool {
 			// Operational events (verify, stream-updated) are point-to-point and excluded from replay.
 			if eventRecord.Operational {
 				return false
@@ -762,17 +772,17 @@ func StreamUpdateHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *h
 	}
 
 	// Update the event router
-	state, err := sa.GetStreamService().GetStreamState(r.Context(), authCtx.StreamId)
+	state, err := sa.GetStreamService().GetStreamState(r.Context(), streamId)
 	if err != nil {
-		serverLog.Error("Error getting stream state for event router update", "id", authCtx.StreamId, "error", err)
+		serverLog.Error("Error getting stream state for event router update", "id", streamId, "error", err)
 	}
 	if resetDate != nil || resetJti != "" {
-		sa.GetEventRouter().RemoveStream(authCtx.StreamId)
+		sa.GetEventRouter().RemoveStream(streamId)
 	}
 	sa.GetEventRouter().UpdateStreamState(state)
 	sa.HandleReceiver(state)
 
-	serverLog.Info(fmt.Sprintf("Stream %s UPDATED", authCtx.StreamId))
+	serverLog.Info(fmt.Sprintf("Stream %s UPDATED", streamId))
 
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	respBytes, err := json.MarshalIndent(adjustBaseUrl(sa, *configResp), "", "  ")

--- a/internal/server/api_stream_management.go
+++ b/internal/server/api_stream_management.go
@@ -331,7 +331,9 @@ func StreamDeleteHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *h
 		return
 	}
 	// sa.EventRouter.RemoveStream(authContext)
-	w.WriteHeader(http.StatusOK)
+	// SSF 1.0 §8.1.5 Stream Configuration Delete: a successful delete answers
+	// 204 No Content (the response carries no body).
+	w.WriteHeader(http.StatusNoContent)
 	serverLog.Info(fmt.Sprintf("Stream %s inactivated and deleted.", authContext.StreamId))
 }
 

--- a/internal/server/api_stream_management.go
+++ b/internal/server/api_stream_management.go
@@ -313,8 +313,17 @@ func StreamDeleteHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *h
 	state.Status = model.StreamStateDisable
 	sa.GetEventRouter().UpdateStreamState(state)
 
-	// Stop all the inbound traffic if Polling
+	// Stop all the inbound traffic if Polling. Done BEFORE the remote-delete
+	// cascade so the poll goroutine is no longer issuing its own requests to the
+	// transmitter while the cascade discovers/deletes — concurrent calls would
+	// otherwise race (and some transmitters serialize per-stream requests).
 	sa.CloseReceiver(authContext.StreamId)
+
+	// For a receiver stream auto-registered against a foreign transmitter, delete
+	// the remote stream too (SSF §8.1.1.5). Best-effort: the stream's transmitter
+	// credentials/TLS settings are still available on `state`; a remote failure is
+	// logged but never blocks local deletion.
+	sa.CascadeReceiverStreamDelete(r.Context(), state)
 
 	// Stop any outbound activity
 	sa.GetEventRouter().RemoveStream(authContext.StreamId)

--- a/internal/server/application.go
+++ b/internal/server/application.go
@@ -38,6 +38,7 @@ type SsfApplicationInterface interface {
 	GetDefIssuer() string
 	Name() string
 	CloseReceiver(sid string)
+	CascadeReceiverStreamDelete(ctx context.Context, state *model.StreamStateRecord)
 	HandleReceiver(streamState *model.StreamStateRecord) *ClientPollStream
 
 	// Service accessors. Handlers depend on these directly.

--- a/internal/server/application.go
+++ b/internal/server/application.go
@@ -38,6 +38,7 @@ type SsfApplicationInterface interface {
 	GetDefIssuer() string
 	Name() string
 	CloseReceiver(sid string)
+	DrainReceiver(sid string)
 	CascadeReceiverStreamDelete(ctx context.Context, state *model.StreamStateRecord)
 	HandleReceiver(streamState *model.StreamStateRecord) *ClientPollStream
 

--- a/internal/server/test/server_test.go
+++ b/internal/server/test/server_test.go
@@ -237,7 +237,7 @@ func (suite *ServerSuite) Test3_StreamConfig() {
 	req.Header.Set("Authorization", "Bearer "+suite.servers[0].streamMgmtToken)
 	resp, err = suite.servers[0].client.Do(req)
 	assert.NoError(suite.T(), err, "Stream should be successfully deleted")
-	assert.Equal(suite.T(), http.StatusOK, resp.StatusCode, "Should be OK status")
+	assert.Equal(suite.T(), http.StatusNoContent, resp.StatusCode, "Should be 204 No Content")
 
 	// Step 4.
 
@@ -292,7 +292,7 @@ func (suite *ServerSuite) Test3_StreamConfig() {
 	req.Header.Set("Authorization", "Bearer "+suite.servers[0].streamMgmtToken)
 	resp, err = suite.servers[0].client.Do(req)
 	assert.NoError(suite.T(), err, "Stream delete request ok")
-	assert.Equal(suite.T(), http.StatusOK, resp.StatusCode, "Delete return status 200")
+	assert.Equal(suite.T(), http.StatusNoContent, resp.StatusCode, "Delete return status 204")
 }
 
 // Test4_StreamUpdate checks the stream configuration update functionality via HTTP PUT.
@@ -357,7 +357,7 @@ func (suite *ServerSuite) Test4_StreamUpdate() {
 	if err != nil {
 		return
 	}
-	assert.Equal(suite.T(), http.StatusOK, resp.StatusCode, "Check delete ok")
+	assert.Equal(suite.T(), http.StatusNoContent, resp.StatusCode, "Check delete ok")
 }
 
 // Test5_PollStreamDelivery sets up a polling delivery stream between SSF1 and SSF2 and tests an event can be transferred

--- a/internal/server/test/stream_aud_default_test.go
+++ b/internal/server/test/stream_aud_default_test.go
@@ -1,0 +1,81 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/i2-open/i2goSignals/pkg/authSupport"
+	"github.com/i2-open/i2goSignals/pkg/ssfModels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pollStreamConfig returns a minimal transmitter POLL stream config with no aud,
+// so CreateStream exercises the transmitter-side default-aud resolution.
+func pollStreamConfig() model.StreamConfiguration {
+	return model.StreamConfiguration{
+		EventsRequested: []string{"*"},
+		Delivery: &model.OneOfStreamConfigurationDelivery{
+			PollTransmitMethod: &model.PollTransmitMethod{
+				Method: model.DeliveryPoll,
+			},
+		},
+	}
+}
+
+// TestCreateStreamDefaultsAudToClientId pins the transmitter contract: when the
+// receiver asserts no aud, the transmitter populates it from the most specific
+// stable receiver identity available — the registered client_id of a locally
+// issued token. aud is Read-Only / transmitter-asserted (SSF 1.0 §7.1.1) and is
+// echoed into every SET, so it must never be empty.
+func TestCreateStreamDefaultsAudToClientId(t *testing.T) {
+	instance, err := createServer(t, "stream_aud_default_clientid_test", true)
+	require.NoError(t, err)
+	defer instance.app.Shutdown()
+
+	authCtx := &authSupport.AuthContext{
+		ProjectId: instance.projectId,
+		Eat:       &authSupport.EventAuthToken{ClientId: "client-abc123", ProjectId: instance.projectId},
+	}
+
+	created, err := instance.CreateStream(pollStreamConfig(), authCtx)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"client-abc123"}, created.Aud,
+		"a locally issued token's client_id must become the default aud")
+}
+
+// TestCreateStreamDefaultsAudToProjectIdFloor pins the floor: an OAuth/STS caller
+// carries no local EAT (and therefore no client_id), so the default aud falls back
+// to the project id, which is always present.
+func TestCreateStreamDefaultsAudToProjectIdFloor(t *testing.T) {
+	instance, err := createServer(t, "stream_aud_default_projectid_test", true)
+	require.NoError(t, err)
+	defer instance.app.Shutdown()
+
+	// ConvertProject yields an AuthContext with ProjectId set and no Eat — the
+	// shape of an OAuth/STS-validated caller.
+	created, err := instance.CreateStream(pollStreamConfig(), authSupport.ConvertProject(instance.projectId))
+	require.NoError(t, err)
+	assert.Equal(t, []string{instance.projectId}, created.Aud,
+		"with no client_id the default aud must fall back to the project id")
+}
+
+// TestCreateStreamHonorsRequestedAud pins that a receiver-asserted aud (e.g. a
+// domain) is never overwritten by the default — the request wins.
+func TestCreateStreamHonorsRequestedAud(t *testing.T) {
+	instance, err := createServer(t, "stream_aud_honor_request_test", true)
+	require.NoError(t, err)
+	defer instance.app.Shutdown()
+
+	cfg := pollStreamConfig()
+	cfg.Aud = []string{"https://rp.example.com"}
+
+	authCtx := &authSupport.AuthContext{
+		ProjectId: instance.projectId,
+		Eat:       &authSupport.EventAuthToken{ClientId: "client-abc123", ProjectId: instance.projectId},
+	}
+
+	created, err := instance.CreateStream(cfg, authCtx)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"https://rp.example.com"}, created.Aud,
+		"a receiver-asserted aud must be preserved, not replaced by the default")
+}

--- a/internal/server/test/stream_update_bodyid_test.go
+++ b/internal/server/test/stream_update_bodyid_test.go
@@ -1,0 +1,72 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/i2-open/i2goSignals/pkg/authSupport"
+	"github.com/i2-open/i2goSignals/pkg/ssfModels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// updateStreamNoQueryParam PATCHes/PUTs the /stream endpoint with NO stream_id
+// query parameter, identifying the target only via the stream_id field in the
+// body — the way SSF PUT/PATCH carry the full StreamConfiguration, and the way
+// the OpenID conformance suite sends update/replace. Returns the HTTP response.
+func updateStreamNoQueryParam(t *testing.T, instance *ssfInstance, method string, cfg model.StreamConfiguration) *http.Response {
+	t.Helper()
+	body, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	// Note: no "?stream_id=" — the only stream identifier is cfg.Id in the body.
+	req, err := http.NewRequest(method, instance.ts.URL+"/stream", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+instance.streamMgmtToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := instance.client.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// TestStreamUpdateResolvesStreamIdFromBody pins the fix for the PUT/PATCH 404:
+// when the request omits the stream_id query parameter and supplies it only in
+// the StreamConfiguration body, the handler must still locate and update the
+// stream (it previously used authCtx.StreamId, which is populated only from the
+// query parameter, and 404'd).
+func TestStreamUpdateResolvesStreamIdFromBody(t *testing.T) {
+	instance, err := createServer(t, "stream_update_bodyid_test", true)
+	require.NoError(t, err)
+	defer instance.app.Shutdown()
+
+	created, err := instance.CreateStream(pollStreamConfig(), authSupport.ConvertProject(instance.projectId))
+	require.NoError(t, err)
+	require.NotEmpty(t, created.Id)
+
+	// PATCH with stream_id only in the body.
+	patchCfg := model.StreamConfiguration{
+		Id:              created.Id,
+		Description:     "patched via body stream_id",
+		EventsRequested: created.EventsSupported,
+	}
+	resp := updateStreamNoQueryParam(t, instance, http.MethodPatch, patchCfg)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "PATCH with body-only stream_id must succeed (200), not 404")
+
+	var patched model.StreamConfiguration
+	body, _ := io.ReadAll(resp.Body)
+	require.NoError(t, json.Unmarshal(body, &patched))
+	assert.Equal(t, created.Id, patched.Id, "response must echo the same stream")
+
+	// PUT (replace) the same way.
+	putCfg := model.StreamConfiguration{
+		Id:              created.Id,
+		Description:     "replaced via body stream_id",
+		EventsRequested: created.EventsSupported,
+	}
+	resp2 := updateStreamNoQueryParam(t, instance, http.MethodPut, putCfg)
+	defer resp2.Body.Close()
+	assert.Equal(t, http.StatusOK, resp2.StatusCode, "PUT with body-only stream_id must succeed (200), not 404")
+}

--- a/pkg/goSet/jwks_loader.go
+++ b/pkg/goSet/jwks_loader.go
@@ -11,6 +11,16 @@ import (
 )
 
 func GetJwks(jwksUrl string) (*keyfunc.JWKS, error) {
+	return GetJwksWithClient(jwksUrl, nil)
+}
+
+// GetJwksWithClient is like GetJwks but uses the supplied http.Client when
+// non-nil. Receiver streams pass a client whose TLS config honors the stream's
+// transmitter TLS settings (tx_tls_skip_verify / tx_tls_certificate) so the
+// issuer JWKS can be fetched from a transmitter presenting a self-signed
+// certificate. When client is nil, behavior is unchanged (SPIFFE transport when
+// enabled, otherwise keyfunc's default client).
+func GetJwksWithClient(jwksUrl string, client *http.Client) (*keyfunc.JWKS, error) {
 	keyOptions := keyfunc.Options{
 		Ctx: context.Background(),
 		RefreshErrorHandler: func(err error) {
@@ -22,9 +32,11 @@ func GetJwks(jwksUrl string) (*keyfunc.JWKS, error) {
 		RefreshUnknownKID: true,
 	}
 
-	// If SPIFFE is enabled, we use the Resilient transport to allow fetching
-	// JWKS from both internal SPIFFE nodes and external HTTPS endpoints.
-	if tlsSupport.SpiffeEnabled() {
+	if client != nil {
+		keyOptions.Client = client
+	} else if tlsSupport.SpiffeEnabled() {
+		// If SPIFFE is enabled, we use the Resilient transport to allow fetching
+		// JWKS from both internal SPIFFE nodes and external HTTPS endpoints.
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		x509Source, err := tlsSupport.NewX509Source(ctx)

--- a/pkg/goSetPush/push.go
+++ b/pkg/goSetPush/push.go
@@ -72,6 +72,12 @@ type TransmitterConfig struct {
 	// HTTPClient is an optional custom HTTP client. If nil, a default with 60s timeout is used.
 	HTTPClient *http.Client
 
+	// InsecureSkipVerify, when true and HTTPClient is nil, builds the default
+	// client with TLS certificate verification disabled. It carries the stream's
+	// tx_tls_skip_verify flag for receivers that present a self-signed or
+	// otherwise unverifiable TLS cert. Ignored when HTTPClient is supplied.
+	InsecureSkipVerify bool
+
 	// Logger is an optional structured logger. If nil, a default is used.
 	Logger *slog.Logger
 }

--- a/pkg/goSetPush/push_test.go
+++ b/pkg/goSetPush/push_test.go
@@ -218,6 +218,33 @@ func TestPushSET_Accepted(t *testing.T) {
 	assert.NoError(t, result.Err)
 }
 
+// TestPushSET_InsecureSkipVerify pins the tx_tls_skip_verify wiring: a receiver
+// presenting a self-signed TLS cert (httptest.NewTLSServer) is rejected by the
+// default verifying client, but accepted when InsecureSkipVerify is set.
+func TestPushSET_InsecureSkipVerify(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	// Default (verify): the self-signed cert is untrusted, so the push fails at
+	// the TLS layer with no HTTP response.
+	verifyResult := PushSET(context.Background(), "test-token-string", TransmitterConfig{
+		EndpointURL: server.URL,
+	})
+	require.Error(t, verifyResult.Err, "default client must reject the self-signed receiver cert")
+	assert.False(t, verifyResult.Accepted)
+
+	// InsecureSkipVerify: TLS verification is skipped and the push is accepted.
+	skipResult := PushSET(context.Background(), "test-token-string", TransmitterConfig{
+		EndpointURL:        server.URL,
+		InsecureSkipVerify: true,
+	})
+	assert.NoError(t, skipResult.Err, "InsecureSkipVerify must accept the self-signed receiver cert")
+	assert.True(t, skipResult.Accepted)
+	assert.Equal(t, http.StatusAccepted, skipResult.StatusCode)
+}
+
 func TestPushSET_BadRequest(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		errBody := DeliveryErr{

--- a/pkg/goSetPush/transmitter.go
+++ b/pkg/goSetPush/transmitter.go
@@ -2,6 +2,7 @@ package goSetPush
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -21,7 +22,16 @@ func PushSET(ctx context.Context, tokenString string, config TransmitterConfig) 
 	client := config.HTTPClient
 	if client == nil {
 		client = &http.Client{Timeout: 60 * time.Second}
-		tlsSupport.CheckCaInstalled(client)
+		if config.InsecureSkipVerify {
+			// Honor the stream's tx_tls_skip_verify: skip receiver cert
+			// verification entirely (dev / self-signed receivers). CheckCaInstalled
+			// is intentionally not called — verification is being disabled.
+			client.Transport = &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // per-stream tx_tls_skip_verify opt-in
+			}
+		} else {
+			tlsSupport.CheckCaInstalled(client)
+		}
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, config.EndpointURL, strings.NewReader(tokenString))

--- a/pkg/goSsfServer/ssf-application.go
+++ b/pkg/goSsfServer/ssf-application.go
@@ -90,6 +90,10 @@ func (sa *SsfApplication) CloseReceiver(_ string) {
 	// SSF-only server does not implement receivers
 }
 
+func (sa *SsfApplication) DrainReceiver(_ string) {
+	// SSF-only server does not implement receivers
+}
+
 func (sa *SsfApplication) CascadeReceiverStreamDelete(_ context.Context, _ *model.StreamStateRecord) {
 	// SSF-only server does not implement receivers
 }

--- a/pkg/goSsfServer/ssf-application.go
+++ b/pkg/goSsfServer/ssf-application.go
@@ -90,6 +90,10 @@ func (sa *SsfApplication) CloseReceiver(_ string) {
 	// SSF-only server does not implement receivers
 }
 
+func (sa *SsfApplication) CascadeReceiverStreamDelete(_ context.Context, _ *model.StreamStateRecord) {
+	// SSF-only server does not implement receivers
+}
+
 func (sa *SsfApplication) HandleReceiver(_ *model.StreamStateRecord) *server.ClientPollStream {
 	// SSF-only server does not implement receivers
 	return nil

--- a/pkg/services/rcv_management.go
+++ b/pkg/services/rcv_management.go
@@ -1,0 +1,28 @@
+package services
+
+import (
+	"os"
+	"strings"
+)
+
+// rcvManagementExerciseEnvVar opts a receiver into a one-shot self-exercise of
+// the transmitter's stream-management API (read, update, replace, status-update)
+// once a stream is established. It exists purely for conformance/interop testing:
+// a real receiver does not spontaneously PATCH/PUT/POST-status its own stream, so
+// this stays off by default. The OpenID SSF receiver conformance plan
+// (happypath, stream-status-update modules) requires the suite to observe these
+// receiver-initiated management calls, which this flag drives.
+const rcvManagementExerciseEnvVar = "I2SIG_RCV_MANAGEMENT_EXERCISE"
+
+// RcvManagementExerciseEnabled reports whether receivers should perform the
+// one-shot management self-exercise against the transmitter on stream
+// establishment. True only when I2SIG_RCV_MANAGEMENT_EXERCISE is a truthy value
+// (true/1/enabled/yes, case-insensitive); unset or anything else means false.
+func RcvManagementExerciseEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(rcvManagementExerciseEnvVar))) {
+	case "true", "1", "enabled", "yes":
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/services/rcv_verification.go
+++ b/pkg/services/rcv_verification.go
@@ -1,0 +1,27 @@
+package services
+
+import (
+	"os"
+	"strings"
+)
+
+// rcvVerifyOnEstablishEnvVar opts a polling receiver into requesting a stream
+// verification event from the transmitter once a stream is established (SSF 1.0
+// §8.1.4.2). A receiver-initiated verification is legitimate behaviour, but it
+// adds an outbound request (and retries when the transmitter rejects it), so it
+// stays off by default and is enabled explicitly — e.g. by the OpenID SSF
+// receiver conformance plan, which waits to observe the verification request.
+const rcvVerifyOnEstablishEnvVar = "I2SIG_RCV_VERIFY_ON_ESTABLISH"
+
+// RcvVerifyOnEstablishEnabled reports whether a polling receiver should request a
+// verification event from the transmitter on stream establishment. True only when
+// I2SIG_RCV_VERIFY_ON_ESTABLISH is a truthy value (true/1/enabled/yes,
+// case-insensitive); unset or anything else means false.
+func RcvVerifyOnEstablishEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(rcvVerifyOnEstablishEnvVar))) {
+	case "true", "1", "enabled", "yes":
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/services/stream_service.go
+++ b/pkg/services/stream_service.go
@@ -612,6 +612,17 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamSt
 	defaultSubjects := request.DefaultSubjects
 	if !SubjectFilteringEnabled() {
 		defaultSubjects = ""
+	} else if defaultSubjects == "" && request.SubjectFilterMode != model.SubjectFilterModePassthru {
+		// SSF §8.1.3 Add/Remove-Subject is an optional narrowing of an existing
+		// event subscription: a stream that filters locally but subscribes to event
+		// types without an explicit baseline must deliver every matching event. The
+		// local baseline must be ALL or NONE (never ""), but a create request rarely
+		// carries default_subjects, so default the empty case to ALL. Without this,
+		// entryDelivers only delivers under an ALL baseline when no per-subject entry
+		// exists, so enabling the feature server-wide would silently blackhole every
+		// stream's events. PASSTHRU streams are excluded: they filter nothing locally
+		// (subject management is relayed upstream), so they carry no local baseline.
+		defaultSubjects = model.DefaultSubjectsAll
 	}
 
 	streamRec := &model.StreamStateRecord{

--- a/pkg/services/stream_service.go
+++ b/pkg/services/stream_service.go
@@ -508,7 +508,12 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamSt
 			}
 
 			var txStreamResp model.StreamConfiguration
-			if err := json.NewDecoder(resp.Body).Decode(&txStreamResp); err != nil {
+			respBody, readErr := io.ReadAll(resp.Body)
+			if readErr != nil {
+				return model.StreamConfiguration{}, fmt.Errorf("failed to read transmitter registration response: %v", readErr)
+			}
+			// Tolerate a string-valued aud (RFC 7519 §4.1.3) from the transmitter.
+			if err := model.UnmarshalStreamConfigurationJSON(respBody, &txStreamResp); err != nil {
 				return model.StreamConfiguration{}, fmt.Errorf("failed to decode transmitter registration response: %v", err)
 			}
 
@@ -758,7 +763,15 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamSt
 		}
 
 		var txStreamResp model.StreamConfiguration
-		if err := json.NewDecoder(resp.Body).Decode(&txStreamResp); err != nil {
+		respBody, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			if cleanupErr := s.DeleteStream(ctx, config.Id); cleanupErr != nil {
+				ssLog.Error("failed to delete stream during cleanup", "id", config.Id, "error", cleanupErr)
+			}
+			return model.StreamConfiguration{}, fmt.Errorf("failed to read transmitter registration response: %v", readErr)
+		}
+		// Tolerate a string-valued aud (RFC 7519 §4.1.3) from the transmitter.
+		if err := model.UnmarshalStreamConfigurationJSON(respBody, &txStreamResp); err != nil {
 			if cleanupErr := s.DeleteStream(ctx, config.Id); cleanupErr != nil {
 				ssLog.Error("failed to delete stream during cleanup", "id", config.Id, "error", cleanupErr)
 			}

--- a/pkg/services/stream_service.go
+++ b/pkg/services/stream_service.go
@@ -542,10 +542,17 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamSt
 
 			if txStreamResp.Delivery != nil && txStreamResp.Delivery.PollTransmitMethod != nil {
 
-				// Copy the authorization header for use at the Status and management endpoints
-				txToken := txStreamResp.Delivery.PollTransmitMethod.AuthorizationHeader
-				config.TxToken = &txToken // Use for status and verification endpoints
-				config.Delivery.PollReceiveMethod.AuthorizationHeader = txStreamResp.Delivery.PollTransmitMethod.AuthorizationHeader
+				// Copy the transmitter-issued poll authorization header for the status,
+				// management, poll and delete calls. RFC 8936 permits the transmitter to
+				// omit it, in which case the receiver keeps using the credential it
+				// registered with — otherwise we'd blank out the token and lose access to
+				// every subsequent call (the push path guards this the same way).
+				if hdr := txStreamResp.Delivery.PollTransmitMethod.AuthorizationHeader; hdr != "" {
+					config.TxToken = &hdr // Use for status and verification endpoints
+					config.Delivery.PollReceiveMethod.AuthorizationHeader = hdr
+				} else {
+					config.TxToken = request.TxToken
+				}
 				config.Delivery.PollReceiveMethod.EndpointUrl = txStreamResp.Delivery.PollTransmitMethod.EndpointUrl
 				config.Delivery.PollReceiveMethod.PollConfig = txStreamResp.Delivery.PollTransmitMethod.PollConfig // follow the Transmitters poll config if asserted
 				if transmitAlias != "" {

--- a/pkg/services/stream_service.go
+++ b/pkg/services/stream_service.go
@@ -1357,7 +1357,20 @@ func (s *StreamService) fetchReceiverJwks(ctx context.Context, sid, iss, jwksUrl
 	}
 
 	ssLog.Debug("Loading JWKS key", "url", jwksUrl)
-	jwks, err = goSet.GetJwks(jwksUrl)
+	// Honor the stream's transmitter TLS settings so the issuer JWKS can be
+	// fetched even when the transmitter presents a self-signed certificate;
+	// otherwise the load fails TLS verification and retries indefinitely.
+	var jwksClient *http.Client
+	if disableRec != nil {
+		skip := disableRec.TxTLSSkipVerify || TxTLSSkipVerifyDefault()
+		if skip || disableRec.TxTLSCertificate != "" {
+			jwksClient = oauthClient.GetBaseHTTPClientForServer(&model.Server{
+				TLSSkipVerify:  skip,
+				TLSCertificate: disableRec.TxTLSCertificate,
+			})
+		}
+	}
+	jwks, err = goSet.GetJwksWithClient(jwksUrl, jwksClient)
 	if err != nil {
 		msg := fmt.Sprintf("Error retrieving issuer JWKS public key: %s", err.Error())
 		if isPermanentJwksError(err) {

--- a/pkg/services/stream_service.go
+++ b/pkg/services/stream_service.go
@@ -573,6 +573,14 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamSt
 	config.InactivityTimeout = int32(s.maxInactivityTimeout)
 	config.MinVerificationInterval = int32(s.minVerificationInterval)
 
+	// TxTLSSkipVerify (goSignals extension): the transmitter skips receiver TLS
+	// certificate verification when delivering pushes. Honor an explicit per-stream
+	// request value (e.g. set by goSignalsAdmin) and allow a deployment-wide default
+	// via I2SIG_TX_TLS_SKIP_VERIFY for receivers that present a self-signed / SAN-less
+	// cert (dev, conformance). The field is built field-by-field here, so without
+	// this copy the request value would be silently dropped.
+	config.TxTLSSkipVerify = request.TxTLSSkipVerify || TxTLSSkipVerifyDefault()
+
 	// It is not SSF compliant, but goSignals will accept these settings on stream creation
 	if request.InactivityTimeout > 0 {
 		config.InactivityTimeout = request.InactivityTimeout

--- a/pkg/services/stream_service.go
+++ b/pkg/services/stream_service.go
@@ -354,9 +354,16 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamSt
 		if txServer == nil {
 			selectedTxServerParam = false
 			// In static token mode, we don't necessarily have a pre-defined server. Create one so we can use the new http client / credential handler
+			// Carry the receiver's transmitter-TLS settings onto the synthesized
+			// server so discovery and stream registration honor a self-signed or
+			// hostname-mismatched transmitter cert (tx_tls_certificate /
+			// tx_tls_skip_verify). Without this the inline static path always
+			// verified against the system roots regardless of the request fields.
 			txServer = &model.Server{
-				Host:        *request.TxWellKnownUrl,
-				ClientToken: request.TxToken,
+				Host:           *request.TxWellKnownUrl,
+				ClientToken:    request.TxToken,
+				TLSCertificate: request.TxTLSCertificate,
+				TLSSkipVerify:  request.TxTLSSkipVerify || TxTLSSkipVerifyDefault(),
 			}
 		}
 		client := oauthClient.GetBaseHTTPClientForServer(txServer)

--- a/pkg/services/stream_service.go
+++ b/pkg/services/stream_service.go
@@ -303,8 +303,8 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamSt
 	// (ADR 0007). Passing it as the issuing session sets Parent without altering
 	// the delivery token's other claims (an empty-ID session leaves Parent empty).
 	var deliveryParent *authSupport.AuthContext
-	if ctx.Value("authCtx") != nil {
-		authCtx := ctx.Value("authCtx").(*authSupport.AuthContext)
+	authCtx, _ := ctx.Value(authSupport.AuthContextKey).(*authSupport.AuthContext)
+	if authCtx != nil {
 		isOAuth = authCtx.IsOAuthClient
 		if authCtx.Eat != nil {
 			deliveryParent = &authSupport.AuthContext{Eat: &authSupport.EventAuthToken{}}
@@ -314,6 +314,20 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamSt
 
 	config.Id = mid.Hex()
 	config.Aud = request.Aud
+	// aud identifies the Event Receiver(s); it is Read-Only / transmitter-asserted
+	// (SSF 1.0 §7.1.1) and is echoed into every SET's aud claim, so the transmitter
+	// must populate it even when the receiver asserts none. Resolve the most specific
+	// stable receiver identity available: the registered client_id for a locally
+	// issued token, falling back to the project id — always present, and the only
+	// identity an OAuth/STS caller carries (it has no local EAT). A receiver that
+	// needs a specific audience (e.g. a domain) sets it in the request.
+	if len(config.Aud) == 0 {
+		if authCtx != nil && authCtx.Eat != nil && authCtx.Eat.ClientId != "" {
+			config.Aud = []string{authCtx.Eat.ClientId}
+		} else if projectID != "" {
+			config.Aud = []string{projectID}
+		}
+	}
 
 	config.EventsSupported = model.GetSupportedEvents()
 
@@ -500,6 +514,14 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamSt
 
 			// from the response, update config.EventsDelivered with the transmitters response EventsDelivered
 			config.EventsDelivered = txStreamResp.EventsDelivered
+			// aud/iss are transmitter-asserted, Read-Only (SSF 1.0 §7.1.1): accept the
+			// values the transmitter returns, overriding what we requested.
+			if len(txStreamResp.Aud) > 0 {
+				config.Aud = txStreamResp.Aud
+			}
+			if txStreamResp.Iss != "" {
+				config.Iss = txStreamResp.Iss
+			}
 			config.TxWellKnownUrl = request.TxWellKnownUrl
 			txId := txStreamResp.Id
 
@@ -726,6 +748,14 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamSt
 
 		// from the response, update config with the transmitters response values
 		config.EventsDelivered = txStreamResp.EventsDelivered
+		// aud/iss are transmitter-asserted, Read-Only (SSF 1.0 §7.1.1): accept the
+		// values the transmitter returns, overriding what we requested.
+		if len(txStreamResp.Aud) > 0 {
+			config.Aud = txStreamResp.Aud
+		}
+		if txStreamResp.Iss != "" {
+			config.Iss = txStreamResp.Iss
+		}
 		config.EventsRequested = request.EventsRequested
 		config.Description = request.Description
 		config.TxWellKnownUrl = request.TxWellKnownUrl

--- a/pkg/services/stream_service_subject_filter_test.go
+++ b/pkg/services/stream_service_subject_filter_test.go
@@ -10,6 +10,7 @@ import (
 
     interfaces "github.com/i2-open/i2goSignals/pkg/dao"
     "github.com/i2-open/i2goSignals/pkg/dao/memory"
+    "github.com/i2-open/i2goSignals/pkg/goSet"
     "github.com/i2-open/i2goSignals/pkg/ssfModels"
     "github.com/stretchr/testify/assert"
     "github.com/stretchr/testify/require"
@@ -520,4 +521,57 @@ func TestStreamService_DefaultSubjectsUnchangedKeepsFilter(t *testing.T) {
 
     _, getErr := filterDAO.Get(ctx, created.Id, "email:alice@example.com")
     require.NoError(t, getErr, "an unchanged defaultSubjects must leave the filter intact")
+}
+
+// TestStreamService_DefaultSubjectsDefaultsToAllWhenEnabled pins the fix for the
+// deny-all blackhole: a stream created while subject filtering is enabled but
+// without an explicit default_subjects (the common create/register case — the
+// OpenID conformance suite never sends the field) must default its baseline to
+// ALL. The baseline must be ALL or NONE (never ""); an empty baseline denies
+// every subject for which there is no per-subject entry, so without this default
+// enabling the feature server-wide silently blackholes every stream's events.
+func TestStreamService_DefaultSubjectsDefaultsToAllWhenEnabled(t *testing.T) {
+    t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+    svc := newSubjectFilterTestService()
+    ctx := context.Background()
+
+    // pushTransmitterRequest() carries no DefaultSubjects.
+    created, err := svc.CreateStream(ctx, pushTransmitterRequest(), "test-project", nil)
+    require.NoError(t, err)
+
+    state, err := svc.GetStreamState(ctx, created.Id)
+    require.NoError(t, err)
+    assert.Equal(t, model.DefaultSubjectsAll, state.DefaultSubjects,
+        "a filtering-enabled stream created without default_subjects must default to ALL so it delivers events")
+}
+
+// TestStreamService_DefaultAllStreamDeliversUnfilteredEvent verifies the
+// delivery consequence of the fix end-to-end through SubjectFilterService.Allows:
+// a non-operational (security) event whose subject is in no per-subject filter
+// entry must still be delivered, because the stream's baseline defaulted to ALL.
+// This is the exact path that POLL/PUSH delivery consults at send time; before
+// the fix the "" baseline returned false here and the event was discarded.
+func TestStreamService_DefaultAllStreamDeliversUnfilteredEvent(t *testing.T) {
+    t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+    ctx := context.Background()
+
+    svc := newSubjectFilterTestService()
+    filterDAO := memory.NewSubjectFilterDAO()
+    sfs := NewSubjectFilterService(filterDAO)
+    svc.SetSubjectFilterService(sfs)
+
+    created, err := svc.CreateStream(ctx, pushTransmitterRequest(), "test-project", nil)
+    require.NoError(t, err)
+    state, err := svc.GetStreamState(ctx, created.Id)
+    require.NoError(t, err)
+    require.Equal(t, model.DefaultSubjectsAll, state.DefaultSubjects)
+
+    // A non-operational event whose subject matches no filter entry.
+    ev := &model.AgEventRecord{Operational: false}
+    ev.Event.SubjectId = &goSet.SubjectIdentifier{Format: "opaque"}
+    ev.Event.SubjectId.Id = "user-with-no-filter-entry"
+
+    assert.True(t, sfs.Allows(ctx, state, ev),
+        "with the baseline defaulted to ALL, a non-operational event must be delivered "+
+            "even when no per-subject filter entry exists")
 }

--- a/pkg/services/stream_service_tx_tls_test.go
+++ b/pkg/services/stream_service_tx_tls_test.go
@@ -1,0 +1,61 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStreamService_TxTLSSkipVerifyFromRequest verifies an explicit
+// tx_tls_skip_verify on the create request is persisted onto the stream — the
+// field is assembled field-by-field in CreateStream, so without the copy the
+// request value would be silently dropped (the original dead-field regression).
+func TestStreamService_TxTLSSkipVerifyFromRequest(t *testing.T) {
+	svc := newSubjectFilterTestService()
+	ctx := context.Background()
+
+	req := pushTransmitterRequest()
+	req.StreamConfiguration.TxTLSSkipVerify = true
+
+	created, err := svc.CreateStream(ctx, req, "test-project", nil)
+	require.NoError(t, err)
+
+	state, err := svc.GetStreamState(ctx, created.Id)
+	require.NoError(t, err)
+	assert.True(t, state.StreamConfiguration.TxTLSSkipVerify,
+		"an explicit tx_tls_skip_verify on the request must persist onto the stream")
+}
+
+// TestStreamService_TxTLSSkipVerifyFromEnv verifies the deployment-wide default:
+// with I2SIG_TX_TLS_SKIP_VERIFY truthy, a stream created without the field set
+// defaults to skipping receiver TLS verification (dev / conformance receivers).
+func TestStreamService_TxTLSSkipVerifyFromEnv(t *testing.T) {
+	t.Setenv("I2SIG_TX_TLS_SKIP_VERIFY", "true")
+	svc := newSubjectFilterTestService()
+	ctx := context.Background()
+
+	created, err := svc.CreateStream(ctx, pushTransmitterRequest(), "test-project", nil)
+	require.NoError(t, err)
+
+	state, err := svc.GetStreamState(ctx, created.Id)
+	require.NoError(t, err)
+	assert.True(t, state.StreamConfiguration.TxTLSSkipVerify,
+		"I2SIG_TX_TLS_SKIP_VERIFY must default new streams to skip receiver TLS verification")
+}
+
+// TestStreamService_TxTLSSkipVerifyDefaultsOff verifies the safe default: with
+// no env and no request value, verification stays on (flag false).
+func TestStreamService_TxTLSSkipVerifyDefaultsOff(t *testing.T) {
+	svc := newSubjectFilterTestService()
+	ctx := context.Background()
+
+	created, err := svc.CreateStream(ctx, pushTransmitterRequest(), "test-project", nil)
+	require.NoError(t, err)
+
+	state, err := svc.GetStreamState(ctx, created.Id)
+	require.NoError(t, err)
+	assert.False(t, state.StreamConfiguration.TxTLSSkipVerify,
+		"tx_tls_skip_verify must default to false (verify) absent an env or request value")
+}

--- a/pkg/services/tx_tls.go
+++ b/pkg/services/tx_tls.go
@@ -1,0 +1,27 @@
+package services
+
+import (
+	"os"
+	"strings"
+)
+
+// txTLSSkipVerifyEnvVar is a server-wide default for new transmitter streams'
+// tx_tls_skip_verify flag. It exists for deployments where the receiver presents
+// a self-signed or otherwise unverifiable TLS cert — dev stacks, and the OpenID
+// conformance suite (whose nginx serves a SAN-less self-signed cert, so Go's push
+// client rejects it). A per-stream value set explicitly on the create request
+// still applies; this only supplies the default when the request leaves it false.
+const txTLSSkipVerifyEnvVar = "I2SIG_TX_TLS_SKIP_VERIFY"
+
+// TxTLSSkipVerifyDefault reports whether new transmitter streams should default
+// to skipping receiver TLS certificate verification. True only when
+// I2SIG_TX_TLS_SKIP_VERIFY is a truthy value (true/1/enabled/yes,
+// case-insensitive); unset or any other value means false (verify, the default).
+func TxTLSSkipVerifyDefault() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(txTLSSkipVerifyEnvVar))) {
+	case "true", "1", "enabled", "yes":
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/ssfModels/model_stream_configuration.go
+++ b/pkg/ssfModels/model_stream_configuration.go
@@ -4,7 +4,11 @@ import "time"
 
 // StreamConfiguration is a JSON Object describing and Event Stream's configuration [Spec](https://openid.net/specs/openid-sse-framework-1_0.html#stream-config)\"
 type StreamConfiguration struct {
-	Id string `json:"stream_id" bson:"id"`
+	// stream_id is Read-Only / transmitter-assigned (SSF 1.0 §7.1.1). omitempty so
+	// a receiver's stream-registration request (which reuses this struct) does not
+	// send an empty stream_id — strict transmitters reject transmitter-supplied
+	// properties in a create body. Real responses always carry a non-empty Id.
+	Id string `json:"stream_id,omitempty" bson:"id"`
 
 	// Read-Only. A URL using the https scheme with no query or fragment component that the Transmitter asserts as its Issuer Identifier. This MUST be identical to the iss Claim value in Security Event Tokens issued from this Transmitter.
 	Iss string `json:"iss,omitempty" bson:"iss,omitempty"`

--- a/pkg/ssfModels/model_verification_parameters.go
+++ b/pkg/ssfModels/model_verification_parameters.go
@@ -9,6 +9,11 @@
 package model
 
 type VerificationParameters struct {
+	// REQUIRED. The stream_id identifying the Event Stream for which a verification
+	// event is requested (SSF 1.0 §8.1.4.2). When the receiver registered against a
+	// foreign transmitter this is the transmitter-assigned (remote) stream_id.
+	StreamId string `json:"stream_id,omitempty"`
+
 	// OPTIONAL. An arbitrary string that the Event Transmitter MUST echo back to the Event Receiver in the verification event’s payload. Event Receivers MAY use the value of this parameter to correlate a verification event with a verification request. If the verification event is initiated by the transmitter then this parameter MUST not be set.
 	State string `json:"state,omitempty"`
 }

--- a/pkg/ssfModels/stream_configuration_decode.go
+++ b/pkg/ssfModels/stream_configuration_decode.go
@@ -1,0 +1,50 @@
+package model
+
+import "encoding/json"
+
+// UnmarshalStreamConfigurationJSON decodes an SSF stream-configuration document
+// into cfg while tolerating an "aud" value delivered as a single JSON string.
+//
+// RFC 7519 §4.1.3 — which SSF inherits via JWT semantics — permits aud to be
+// either a single StringOrURI or an array of StringOrURI. goSignals models aud
+// as []string, so a string-valued aud returned by a FOREIGN transmitter (during
+// receiver auto-registration) would otherwise fail to decode with
+// "cannot unmarshal string into Go struct field StreamConfiguration.aud".
+//
+// A string aud is normalized to a single-element slice; an array aud (or any
+// other shape) is passed through unchanged. Use this anywhere goSignals parses a
+// stream configuration it did not author, i.e. responses from remote
+// transmitters whose on-wire aud shape we do not control.
+func UnmarshalStreamConfigurationJSON(data []byte, cfg *StreamConfiguration) error {
+	return json.Unmarshal(normalizeAudToArray(data), cfg)
+}
+
+// normalizeAudToArray rewrites a top-level "aud" string into a one-element JSON
+// array, leaving every other field byte-for-byte intact (they are preserved as
+// json.RawMessage, so nested custom unmarshalers such as the delivery oneOf are
+// unaffected). If aud is absent, already an array, or the document is not a JSON
+// object, the input is returned unchanged.
+func normalizeAudToArray(data []byte) []byte {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		return data
+	}
+	raw, ok := m["aud"]
+	if !ok {
+		return data
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return data // aud is already an array (or some other shape) — leave as-is
+	}
+	arr, err := json.Marshal([]string{s})
+	if err != nil {
+		return data
+	}
+	m["aud"] = arr
+	out, err := json.Marshal(m)
+	if err != nil {
+		return data
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Brings goSignalsServer into conformance with the OpenID Shared Signals Framework (SSF) 1.0 Final, verified against the OpenID conformance suite acting as both transmitter (goSignals as receiver) and receiver (goSignals as transmitter). Adds a reproducible conformance harness and the spec/interop fixes that running it surfaced.

All SSF conformance modules pass: transmitter plan plus the six receiver modules (happypath, stream-status-update, stream-create-delete, stream-verification, unsolicited-stream-verification, supported-events).

## What's included (20 atomic commits)

**Conformance harness**
- SSF conformance test harness for goSignalsServer (docker-compose, env, suite-configs)
- Enable subject filtering, PUSH delivery, and receiver management self-exercise for the relevant plans

**Transmitter-side spec compliance**
- Default stream `aud` to a stable receiver identity (§7.1.1)
- Return `204 No Content` on stream delete (§8.1.5)
- Resolve PUT/PATCH stream target from the body's `stream_id` (§8.1.1.3)
- Default an enabled stream's subject baseline to ALL on create

**Receiver-side spec compliance & interop**
- Tolerate string-valued `aud` in transmitter stream responses
- Omit empty `stream_id` from stream-registration request
- Honor per-stream transmitter TLS on outbound clients; fetch issuer JWKS with the same settings
- Retain registration token when the transmitter omits a poll auth header
- Resolve transmitter endpoints via insertion-form well-known + remote `stream_id`
- Cascade stream deletion to the transmitter (§8.1.1.5), draining in-flight poll first
- Request stream verification from the transmitter on POLL (§8.1.4.2), gated behind `I2SIG_RCV_VERIFY_ON_ESTABLISH`
- Exercise the transmitter stream-management API (read/update/replace/status-update), gated behind `I2SIG_RCV_MANAGEMENT_EXERCISE`

**PUSH delivery fixes**
- Wire `TxTLSSkipVerify` so the transmitter honors `tx_tls_skip_verify`
- Make the receiver status-poll optional (`I2SIG_PUSH_DISABLE_RECEIVER_STATUS`)

## Testing

Each commit builds independently (`go build ./...`, unit tests green). Full SSF conformance plan run end-to-end against the suite with goSignals as the SUT — all modules pass; the conformance-only behaviors (verification-on-establish, management self-exercise, receiver status-poll suppression, TLS-skip) are env-gated and off by default.

The drain-in-flight-poll-before-delete change made `TestGoSignalsTool` wait on each poll-stream delete for the in-flight long-poll to return (~10s default, two deletes in one subtest ≈ 20s). The test now caps the in-process long-poll to 1s via `I2SIG_POLL_DEFAULT_TIMEOUT` / `I2SIG_POLL_MAX_TIMEOUT` (test-only; production poll timeouts unchanged), bringing the suite from ~43s back to ~6s with event delivery still verified.
