### PR TITLE
feat(ssf): enforce §7.2.4 issuer↔discovery-location binding (jwks_uri stays free-form)

### DIFF
--- a/cmd/goSignals/add_server_issuer_binding_test.go
+++ b/cmd/goSignals/add_server_issuer_binding_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/i2-open/i2goSignals/pkg/ssfModels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// issuerBindingStub answers the SSF discovery probe with a caller-controlled
+// issuer (read through a pointer so a test can set it to the stub's own URL
+// after construction) and a deliberately FREE-FORM jwks_uri on an unrelated
+// host. Everything else 404s, so the later protected-resource probe is a
+// harmless miss. Used to exercise the §7.2.4 issuer↔discovery-location check in
+// `add server`.
+func issuerBindingStub(t *testing.T, advertisedIssuer *string) *httptest.Server {
+	t.Helper()
+	const wk = "/.well-known/ssf-configuration"
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == wk || strings.HasPrefix(r.URL.Path, wk+"/") {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(model.TransmitterConfiguration{
+				Issuer:  *advertisedIssuer,
+				JwksUri: "https://keys.elsewhere.example/jwks.json",
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+}
+
+// TestAddServer_StrictIssuerMismatch_Fails: a server added with --strict-ssf
+// whose discovery doc advertises an issuer different from the location it was
+// fetched from must FAIL the §7.2.4 binding and must NOT be recorded.
+func TestAddServer_StrictIssuerMismatch_Fails(t *testing.T) {
+	issuer := "https://impersonator.example.com"
+	stub := issuerBindingStub(t, &issuer)
+	defer stub.Close()
+
+	cli := newTestCLI(t)
+	cmd := &AddServerCmd{Alias: "strict-bad", Host: stub.URL, StrictSsf: true}
+	err := cmd.Run(cli)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "issuer binding")
+	_, exists := cli.Data.Servers["strict-bad"]
+	assert.False(t, exists, "a strict server failing the issuer binding must not be recorded")
+}
+
+// TestAddServer_FlexibleIssuerMismatch_WarnsAndRecords: the default (non-strict)
+// posture warns on a mismatch but still records the server and returns no error.
+func TestAddServer_FlexibleIssuerMismatch_WarnsAndRecords(t *testing.T) {
+	issuer := "https://different.example.com"
+	stub := issuerBindingStub(t, &issuer)
+	defer stub.Close()
+
+	cli := newTestCLI(t)
+	cmd := &AddServerCmd{Alias: "flex-mismatch", Host: stub.URL}
+	out := captureStdout(t, func() {
+		require.NoError(t, cmd.Run(cli))
+	})
+	_, exists := cli.Data.Servers["flex-mismatch"]
+	assert.True(t, exists, "a flexible server with an issuer mismatch is still recorded")
+	assert.Contains(t, out, "issuer binding", "a warning must be surfaced to the operator")
+}
+
+// TestAddServer_StrictIssuerMatch_Succeeds: a strict server whose advertised
+// issuer equals the discovery location is recorded with no error — and the
+// free-form jwks_uri (a different host) does not affect the outcome.
+func TestAddServer_StrictIssuerMatch_Succeeds(t *testing.T) {
+	var issuer string
+	stub := issuerBindingStub(t, &issuer)
+	defer stub.Close()
+	issuer = stub.URL // issuer == discovery location
+
+	cli := newTestCLI(t)
+	cmd := &AddServerCmd{Alias: "strict-good", Host: stub.URL, StrictSsf: true}
+	require.NoError(t, cmd.Run(cli))
+	_, exists := cli.Data.Servers["strict-good"]
+	assert.True(t, exists, "a strict server with a consistent issuer binding is recorded")
+}

--- a/cmd/goSignals/commands.go
+++ b/cmd/goSignals/commands.go
@@ -184,6 +184,18 @@ func (as *AddServerCmd) Run(c *CLI) error {
 	}
 	server.ServerConfiguration = &transmitterConfiguration
 
+	// SSF §7.2.4 issuer binding: the issuer advertised in the discovery document
+	// must equal the location it was retrieved from (server.Host carries any
+	// HTTP-fallback scheme change). jwks_uri is free-form and not checked. A
+	// strict-spec transmitter (--strict-ssf) must bind exactly or the add aborts;
+	// a flexible peer only warns. Keyed off the per-server StrictSsf posture, NOT
+	// the goSsfServer-only I2SIG_STRICT_SSF env flag.
+	if warn, berr := wellKnownSupport.EvaluateIssuerBinding(transmitterConfiguration.Issuer, server.Host, as.StrictSsf); berr != nil {
+		return berr
+	} else if warn != "" {
+		fmt.Println("Warning: " + warn)
+	}
+
 	// `add server` is connect-only: it performs SSF discovery and records the
 	// server without minting any credential. Interactive auth happens later via
 	// `login <alias>` (PKCE). The --iat/--token/--client-secret/--bootstrap

--- a/pkg/goSet/jwks_loader_test.go
+++ b/pkg/goSet/jwks_loader_test.go
@@ -1,0 +1,71 @@
+package goSet
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// rsaPublicJWKS renders a minimal, standards-valid JWKS document for the public
+// half of an RSA key under the given kid.
+func rsaPublicJWKS(t *testing.T, kid string, pub *rsa.PublicKey) []byte {
+	t.Helper()
+	n := base64.RawURLEncoding.EncodeToString(pub.N.Bytes())
+	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes())
+	doc := map[string]any{
+		"keys": []map[string]any{
+			{"kty": "RSA", "use": "sig", "alg": "RS256", "kid": kid, "n": n, "e": e},
+		},
+	}
+	b, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal jwks: %v", err)
+	}
+	return b
+}
+
+// TestGetJwksWithClient_FetchesFreeFormUrlVerbatim locks in SSF §7.2.4's
+// free-form jwks_uri rule: the JWKS loader fetches whatever URL it is handed —
+// here a path that bears no relationship to any issuer identifier — and never
+// derives the location from `iss`/`issuer`. A regression that coupled
+// iss==jwks_uri would have to change this call site and would fail here.
+func TestGetJwksWithClient_FetchesFreeFormUrlVerbatim(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	const kid = "free-form-key-1"
+	jwksJSON := rsaPublicJWKS(t, kid, &key.PublicKey)
+
+	// Serve the JWKS at a path deliberately unrelated to any issuer identifier.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/keys/over-here.json" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jwksJSON)
+	}))
+	defer srv.Close()
+
+	jwks, err := GetJwksWithClient(srv.URL+"/keys/over-here.json", srv.Client())
+	if err != nil {
+		t.Fatalf("GetJwksWithClient on a free-form jwks_uri must succeed: %v", err)
+	}
+
+	found := false
+	for _, k := range jwks.KIDs() {
+		if k == kid {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("kid %q from the free-form jwks_uri was not loaded; got KIDs=%v", kid, jwks.KIDs())
+	}
+}

--- a/pkg/services/stream_service.go
+++ b/pkg/services/stream_service.go
@@ -413,6 +413,19 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamSt
 		if txConfig.ConfigurationEndpoint == "" {
 			return model.StreamConfiguration{}, errors.New("transmitter configuration missing configuration_endpoint")
 		}
+		// SSF §7.2.4 issuer binding: the transmitter's advertised issuer must
+		// equal the location its discovery document was retrieved from
+		// (txServer.Host). jwks_uri stays free-form and is not part of this
+		// check. A strict peer (txServer.StrictSsf — the per-peer posture, NOT
+		// the goSsfServer-only I2SIG_STRICT_SSF env flag) aborts on a mismatch;
+		// a flexible peer only warns. The inline static TxWellKnownUrl path
+		// synthesizes txServer without StrictSsf, so it defaults to the flexible
+		// warn-and-continue branch.
+		if warn, berr := wellKnownSupport.EvaluateIssuerBinding(txConfig.Issuer, txServer.Host, txServer.StrictSsf); berr != nil {
+			return model.StreamConfiguration{}, berr
+		} else if warn != "" {
+			ssLog.Warn(warn, "tx-host", txServer.Host, "advertised-issuer", txConfig.Issuer)
+		}
 		defaultTxJwksUrl = txConfig.JwksUri
 	}
 

--- a/pkg/services/stream_service_issuer_binding_test.go
+++ b/pkg/services/stream_service_issuer_binding_test.go
@@ -1,0 +1,106 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/i2-open/i2goSignals/pkg/ssfModels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockBindingTransmitter stands up an SSF transmitter whose discovery document
+// advertises issuerOverride as its `issuer` (or, when issuerOverride == "", the
+// server's own URL — a consistent binding). jwks_uri is FREE-FORM on an
+// unrelated host. It drives the §7.2.4 issuer↔discovery-location check on the
+// receiver-side CreateStream path off the per-peer StrictSsf posture.
+func mockBindingTransmitter(t *testing.T, strict bool, issuerOverride string) (*model.Server, func()) {
+	t.Helper()
+
+	cfg := model.TransmitterConfiguration{
+		JwksUri: "https://keys.elsewhere.example/jwks.json",
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/ssf-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(cfg)
+	})
+	mux.HandleFunc("/streams", func(w http.ResponseWriter, r *http.Request) {
+		var req model.StreamConfiguration
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		req.Id = "remote-binding-stream"
+		if req.Delivery != nil && req.Delivery.PollTransmitMethod != nil {
+			req.Delivery.PollTransmitMethod.EndpointUrl = "http://transmitter.com/poll/x"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(req)
+	})
+
+	ts := httptest.NewServer(mux)
+	cfg.ConfigurationEndpoint = ts.URL + "/streams"
+	if issuerOverride != "" {
+		cfg.Issuer = issuerOverride
+	} else {
+		cfg.Issuer = ts.URL // issuer == discovery location
+	}
+
+	token := "test-token"
+	server := &model.Server{
+		Alias:       "binding-tx",
+		Host:        ts.URL,
+		ClientToken: &token,
+		ProjectId:   "test-project",
+		StrictSsf:   strict,
+	}
+	return server, ts.Close
+}
+
+func bindingReceiveRequest() model.StreamStateRecord {
+	return model.StreamStateRecord{StreamConfiguration: model.StreamConfiguration{
+		EventsRequested: []string{"urn:ietf:params:sse:event-type:risc:account-enabled"},
+		Delivery: &model.OneOfStreamConfigurationDelivery{
+			PollReceiveMethod: &model.PollReceiveMethod{Method: model.ReceivePoll},
+		},
+	}}
+}
+
+// TestCreateStream_StrictIssuerMismatch_Fails: the receiver-side create against
+// a strict transmitter whose advertised issuer != its discovery location must
+// abort the registration (SSF §7.2.4).
+func TestCreateStream_StrictIssuerMismatch_Fails(t *testing.T) {
+	server, closeFn := mockBindingTransmitter(t, true, "https://impersonator.example.com")
+	defer closeFn()
+
+	svc := newStrictTestStreamService(t)
+	_, err := svc.CreateStream(context.Background(), bindingReceiveRequest(), "test-project", server)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "issuer binding")
+}
+
+// TestCreateStream_FlexibleIssuerMismatch_Succeeds: a flexible transmitter with
+// a mismatched issuer only warns; the stream is still created.
+func TestCreateStream_FlexibleIssuerMismatch_Succeeds(t *testing.T) {
+	server, closeFn := mockBindingTransmitter(t, false, "https://different.example.com")
+	defer closeFn()
+
+	svc := newStrictTestStreamService(t)
+	cfg, err := svc.CreateStream(context.Background(), bindingReceiveRequest(), "test-project", server)
+	require.NoError(t, err)
+	assert.NotEmpty(t, cfg.Id)
+}
+
+// TestCreateStream_StrictIssuerMatch_Succeeds: a strict transmitter advertising
+// issuer == its discovery location binds cleanly; the free-form jwks_uri on a
+// different host is irrelevant to the check.
+func TestCreateStream_StrictIssuerMatch_Succeeds(t *testing.T) {
+	server, closeFn := mockBindingTransmitter(t, true, "") // issuer == discovery location
+	defer closeFn()
+
+	svc := newStrictTestStreamService(t)
+	cfg, err := svc.CreateStream(context.Background(), bindingReceiveRequest(), "test-project", server)
+	require.NoError(t, err)
+	assert.NotEmpty(t, cfg.Id)
+}

--- a/pkg/services/stream_service_jwks_freeform_e2e_test.go
+++ b/pkg/services/stream_service_jwks_freeform_e2e_test.go
@@ -1,0 +1,127 @@
+package services
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/i2-open/i2goSignals/pkg/goSet"
+	"github.com/i2-open/i2goSignals/pkg/ssfModels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rsaPublicJWKSBytes renders a minimal, standards-valid JWKS document for the
+// public half of an RSA key under the given kid.
+func rsaPublicJWKSBytes(t *testing.T, kid string, pub *rsa.PublicKey) []byte {
+	t.Helper()
+	n := base64.RawURLEncoding.EncodeToString(pub.N.Bytes())
+	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes())
+	doc := map[string]any{
+		"keys": []map[string]any{
+			{"kty": "RSA", "use": "sig", "alg": "RS256", "kid": kid, "n": n, "e": e},
+		},
+	}
+	b, err := json.Marshal(doc)
+	require.NoError(t, err)
+	return b
+}
+
+// TestCreateStream_FreeFormJwksUri_EndToEnd is the SSF §7.2.4 regression guard the
+// issue (#207 Scope A) requires: a transmitter whose jwks_uri lives on an entirely
+// different host AND path from its iss must be honored end to end —
+// registration → key fetch → SET verify — with nothing silently coupling iss to
+// jwks_uri. Earlier coverage proved each leg in isolation; this connects them so
+// the property can't regress through a gap between the layers.
+//
+//   - registration: the real receiver CreateStream runs the §7.2.4 issuer-binding
+//     check (issuer == discovery location, so it binds even under strict) and
+//     carries the free-form jwks_uri verbatim into the stored stream config — it is
+//     never derived from iss.
+//   - key fetch: the JWKS loads from that free-form URL (a different host from iss).
+//   - SET verify: a SET signed under iss (NOT the jwks host) verifies against the
+//     keys fetched from the free-form jwks_uri.
+//
+// If anyone "fixes" the code to require iss == jwks_uri, one of these legs breaks.
+func TestCreateStream_FreeFormJwksUri_EndToEnd(t *testing.T) {
+	// A transmitter signing key whose public JWKS is served on a SEPARATE host.
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	const kid = "free-form-e2e-key"
+
+	// JWKS host: a second server at a path deliberately unrelated to any issuer.
+	jwksMux := http.NewServeMux()
+	jwksMux.HandleFunc("/keys/not-the-issuer.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(rsaPublicJWKSBytes(t, kid, &key.PublicKey))
+	})
+	jwksServer := httptest.NewServer(jwksMux)
+	defer jwksServer.Close()
+	freeFormJwksUri := jwksServer.URL + "/keys/not-the-issuer.json"
+
+	// Transmitter host: issuer == discovery location (binds), jwks_uri elsewhere.
+	cfg := model.TransmitterConfiguration{JwksUri: freeFormJwksUri}
+	txMux := http.NewServeMux()
+	txMux.HandleFunc("/.well-known/ssf-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(cfg)
+	})
+	txMux.HandleFunc("/streams", func(w http.ResponseWriter, r *http.Request) {
+		var req model.StreamConfiguration
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		req.Id = "remote-freeform-stream"
+		if req.Delivery != nil && req.Delivery.PollTransmitMethod != nil {
+			req.Delivery.PollTransmitMethod.EndpointUrl = "http://transmitter.com/poll/x"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(req)
+	})
+	txServer := httptest.NewServer(txMux)
+	defer txServer.Close()
+	cfg.ConfigurationEndpoint = txServer.URL + "/streams"
+	cfg.Issuer = txServer.URL // issuer == discovery location → clean §7.2.4 binding
+
+	// The jwks_uri must genuinely be a different host than iss for this to mean
+	// anything (httptest assigns each server a distinct host:port).
+	require.NotEqual(t, txServer.URL, jwksServer.URL, "jwks_uri must be served on a different host than iss")
+
+	token := "test-token"
+	server := &model.Server{
+		Alias:       "freeform-tx",
+		Host:        txServer.URL,
+		ClientToken: &token,
+		ProjectId:   "test-project",
+		StrictSsf:   true, // enforce the binding: a clean binding must pass even under strict
+	}
+
+	// --- registration: the real receiver CreateStream path ---
+	svc := newStrictTestStreamService(t)
+	streamCfg, err := svc.CreateStream(context.Background(), bindingReceiveRequest(), "test-project", server)
+	require.NoError(t, err, "a clean issuer binding with a free-form jwks_uri must register even under strict")
+	require.Equal(t, freeFormJwksUri, streamCfg.IssuerJWKSUrl,
+		"registration must carry the free-form jwks_uri verbatim, never derive it from iss")
+
+	// --- key fetch: load the JWKS from the registered free-form jwks_uri ---
+	jwks, err := goSet.GetJwksWithClient(streamCfg.IssuerJWKSUrl, jwksServer.Client())
+	require.NoError(t, err, "keys must load from the free-form jwks_uri (a different host from iss)")
+
+	// --- SET verify: a SET issued under iss (different host from jwks) verifies ---
+	set := goSet.CreateSet(nil, txServer.URL, []string{"https://receiver.example/"})
+	set.Kid = kid
+	set.AddEventPayload("https://schemas.openid.net/secevent/risc/event-type/account-enabled", map[string]any{})
+	signed, err := set.JWS(jwt.SigningMethodRS256, key)
+	require.NoError(t, err)
+
+	parsed, err := goSet.Parse(signed, jwks)
+	require.NoError(t, err,
+		"a SET whose iss differs from the jwks_uri host must verify against keys fetched from that free-form jwks_uri")
+	assert.Equal(t, txServer.URL, parsed.Issuer)
+	assert.NotEqual(t, jwksServer.URL, parsed.Issuer, "iss is the transmitter, never the jwks host")
+}

--- a/pkg/services/stream_service_strict_ssf_test.go
+++ b/pkg/services/stream_service_strict_ssf_test.go
@@ -47,6 +47,10 @@ func mockStrictTransmitter(t *testing.T, strict bool, captured *model.StreamConf
 
 	ts := httptest.NewServer(mux)
 	transmitterConfig.ConfigurationEndpoint = ts.URL + "/streams"
+	// A properly-administered strict transmitter advertises issuer == the
+	// location its discovery document is served from (SSF §7.2.4); bind it so
+	// this stripping-focused test isn't tripped by the issuer-binding check.
+	transmitterConfig.Issuer = ts.URL
 
 	token := "test-token"
 	server := &model.Server{

--- a/pkg/wellKnownSupport/issuer_binding_test.go
+++ b/pkg/wellKnownSupport/issuer_binding_test.go
@@ -1,6 +1,9 @@
 package wellKnownSupport
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestEvaluateIssuerBinding pins the SSF §7.2.4 issuer↔discovery-location
 // decision table that both the CLI `add server` and the server-side receiver
@@ -62,6 +65,68 @@ func TestEvaluateIssuerBinding(t *testing.T) {
 				t.Fatalf("expected no warning for a consistent binding, got %q", warn)
 			}
 		})
+	}
+}
+
+// TestIssuerMatchesLocation pins the policy-free primitive the visibility-only
+// admin discover probe (i2goSignalsAdmin#241) consumes directly: it reports the
+// bare §7.2.4 fact with no warn/fail decision attached. Same normalization
+// contract as EvaluateIssuerBinding, but a pure bool — no strict argument, so a
+// consumer with no committed StrictSsf posture never has to pass a meaningless
+// strict=false to dodge an error branch.
+func TestIssuerMatchesLocation(t *testing.T) {
+	const loc = "https://tr.example.com/issuer1"
+
+	tests := []struct {
+		name     string
+		issuer   string
+		location string
+		want     bool
+	}{
+		{"identical", loc, loc, true},
+		{"trailing-slash-on-issuer", "https://tr.example.com/issuer1/", loc, true},
+		{"trailing-slash-on-location", loc, "https://tr.example.com/issuer1/", true},
+		{"host-case-insensitive", "https://TR.Example.COM/issuer1", loc, true},
+		{"scheme-case-insensitive", "HTTPS://tr.example.com/issuer1", loc, true},
+		{"host-only", "https://tr.example.com", "https://tr.example.com", true},
+		{"different-host", "https://evil.example.com/issuer1", loc, false},
+		{"different-path", "https://tr.example.com/issuer2", loc, false},
+		{"path-case-differs", "https://tr.example.com/Issuer1", loc, false},
+		{"empty-issuer", "", loc, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IssuerMatchesLocation(tc.issuer, tc.location); got != tc.want {
+				t.Fatalf("IssuerMatchesLocation(%q,%q) = %v, want %v", tc.issuer, tc.location, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIssuerBindingDetail verifies the policy-free message helper: it returns ""
+// exactly on a consistent binding and a non-empty description on a mismatch,
+// without ever deciding warn-vs-fail. EvaluateIssuerBinding is built on top of
+// it, so this also guards the message the enforcement callers surface.
+func TestIssuerBindingDetail(t *testing.T) {
+	const loc = "https://tr.example.com/issuer1"
+
+	if d := IssuerBindingDetail(loc, loc); d != "" {
+		t.Fatalf("consistent binding must yield empty detail, got %q", d)
+	}
+	// A mismatch describes both sides and stays policy-free (no warn/fail verb).
+	d := IssuerBindingDetail("https://evil.example.com/issuer1", loc)
+	if d == "" {
+		t.Fatal("mismatch must yield a non-empty detail string")
+	}
+	for _, want := range []string{"evil.example.com", "tr.example.com", "jwks_uri is free-form"} {
+		if !strings.Contains(d, want) {
+			t.Fatalf("detail %q missing expected substring %q", d, want)
+		}
+	}
+	// An empty advertised issuer is itself a §7.2.4 violation; detail must say so.
+	if d := IssuerBindingDetail("", loc); !strings.Contains(d, "(none advertised)") {
+		t.Fatalf("empty-issuer detail must note none advertised, got %q", d)
 	}
 }
 

--- a/pkg/wellKnownSupport/issuer_binding_test.go
+++ b/pkg/wellKnownSupport/issuer_binding_test.go
@@ -1,0 +1,85 @@
+package wellKnownSupport
+
+import "testing"
+
+// TestEvaluateIssuerBinding pins the SSF §7.2.4 issuer↔discovery-location
+// decision table that both the CLI `add server` and the server-side receiver
+// create-stream path key off. The binding compares the metadata `issuer` to the
+// location the discovery document was retrieved from; jwks_uri is FREE-FORM and
+// is deliberately not an input here. On a mismatch the behavior is keyed off the
+// peer's operator-declared strict posture: strict → error, flexible → warning.
+func TestEvaluateIssuerBinding(t *testing.T) {
+	const loc = "https://tr.example.com/issuer1"
+
+	tests := []struct {
+		name     string
+		issuer   string
+		location string
+		strict   bool
+		wantWarn bool // expect a non-empty warning string
+		wantErr  bool
+	}{
+		// --- consistent bindings: no warn, no err, regardless of strict ---
+		{"identical/flexible", loc, loc, false, false, false},
+		{"identical/strict", loc, loc, true, false, false},
+		{"trailing-slash-on-issuer", "https://tr.example.com/issuer1/", loc, true, false, false},
+		{"trailing-slash-on-location", loc, "https://tr.example.com/issuer1/", true, false, false},
+		{"host-case-insensitive", "https://TR.Example.COM/issuer1", loc, true, false, false},
+		{"scheme-case-insensitive", "HTTPS://tr.example.com/issuer1", loc, true, false, false},
+		{"host-only-issuer", "https://tr.example.com", "https://tr.example.com", true, false, false},
+
+		// --- mismatches: warn when flexible, fail when strict ---
+		{"different-host/flexible", "https://evil.example.com/issuer1", loc, false, true, false},
+		{"different-host/strict", "https://evil.example.com/issuer1", loc, true, false, true},
+		{"different-path/flexible", "https://tr.example.com/issuer2", loc, false, true, false},
+		{"different-path/strict", "https://tr.example.com/issuer2", loc, true, false, true},
+		{"empty-issuer/flexible", "", loc, false, true, false},
+		{"empty-issuer/strict", "", loc, true, false, true},
+
+		// --- path case IS significant (RFC 3986): a path-case difference is a mismatch ---
+		{"path-case-differs/strict", "https://tr.example.com/Issuer1", loc, true, false, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			warn, err := EvaluateIssuerBinding(tc.issuer, tc.location, tc.strict)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for strict mismatch, got nil (warn=%q)", warn)
+				}
+				if warn != "" {
+					t.Fatalf("strict mismatch must not return a warning string, got %q", warn)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantWarn && warn == "" {
+				t.Fatalf("expected a non-empty warning for flexible mismatch, got empty")
+			}
+			if !tc.wantWarn && warn != "" {
+				t.Fatalf("expected no warning for a consistent binding, got %q", warn)
+			}
+		})
+	}
+}
+
+// TestEvaluateIssuerBinding_JwksUriIsFreeForm locks in the regression guard: the
+// binding is purely iss↔issuer↔location. EvaluateIssuerBinding structurally
+// cannot couple jwks_uri (it takes no jwks_uri argument), so a transmitter whose
+// jwks_uri lives on an entirely different host/path than its issuer still passes
+// cleanly as long as issuer == location. Nobody can "fix" this into an
+// iss==jwks_uri requirement without changing this signature and failing here.
+func TestEvaluateIssuerBinding_JwksUriIsFreeForm(t *testing.T) {
+	// issuer == discovery location; jwks_uri (not an argument here) could be
+	// anything — the binding must be clean.
+	warn, err := EvaluateIssuerBinding(
+		"https://tr.example.com/issuer1",
+		"https://tr.example.com/issuer1",
+		true,
+	)
+	if err != nil || warn != "" {
+		t.Fatalf("a transmitter with issuer==location must bind cleanly regardless of jwks_uri; warn=%q err=%v", warn, err)
+	}
+}

--- a/pkg/wellKnownSupport/well_known.go
+++ b/pkg/wellKnownSupport/well_known.go
@@ -132,16 +132,45 @@ func normalizeIssuerURL(raw string) string {
 	return u.String()
 }
 
-// issuerMatchesLocation reports whether a transmitter's advertised metadata
+// IssuerMatchesLocation reports whether a transmitter's advertised metadata
 // issuer is consistent with the location its discovery document was retrieved
-// from. An empty metadataIssuer never matches (the transmitter advertised no
-// issuer, which is itself a §7.2.4 violation).
-func issuerMatchesLocation(metadataIssuer, discoveryLocation string) bool {
+// from — the bare SSF §7.2.4 fact, with NO enforcement policy attached.
+// Comparison is scheme/host case-insensitive and ignores a single trailing
+// slash (the path stays case-sensitive per RFC 3986). An empty metadataIssuer
+// never matches (the transmitter advertised no issuer, which is itself a
+// §7.2.4 violation).
+//
+// This is the policy-free primitive: callers that must only *surface* a
+// mismatch (e.g. a pre-registration discovery probe where no StrictSsf posture
+// is committed yet) use this directly and decide their own warn/render
+// behavior, rather than calling EvaluateIssuerBinding with a meaningless
+// strict=false purely to dodge its error branch. jwks_uri is intentionally not
+// a parameter: it is free-form and must never be coupled to iss/issuer.
+func IssuerMatchesLocation(metadataIssuer, discoveryLocation string) bool {
 	mi := normalizeIssuerURL(metadataIssuer)
 	if mi == "" {
 		return false
 	}
 	return mi == normalizeIssuerURL(discoveryLocation)
+}
+
+// IssuerBindingDetail returns a human-readable description of an SSF §7.2.4
+// issuer↔discovery-location mismatch, WITHOUT deciding warn-vs-fail. It returns
+// "" exactly when IssuerMatchesLocation reports true (a consistent binding has
+// nothing to describe). Like IssuerMatchesLocation this is policy-free: a
+// visibility-only consumer renders this string in its own dialog copy, while
+// the enforcement callers go through EvaluateIssuerBinding.
+func IssuerBindingDetail(metadataIssuer, discoveryLocation string) string {
+	if IssuerMatchesLocation(metadataIssuer, discoveryLocation) {
+		return ""
+	}
+	advertised := metadataIssuer
+	if strings.TrimSpace(advertised) == "" {
+		advertised = "(none advertised)"
+	}
+	return fmt.Sprintf(
+		"SSF §7.2.4 issuer binding mismatch: transmitter discovery document advertises issuer %q but was retrieved from %q; these MUST match to prevent transmitter impersonation (jwks_uri is free-form and is not part of this check)",
+		advertised, discoveryLocation)
 }
 
 // EvaluateIssuerBinding checks the SSF §7.2.4 issuer↔discovery-location binding:
@@ -168,16 +197,10 @@ func issuerMatchesLocation(metadataIssuer, discoveryLocation string) bool {
 //   - strict == false -> (warning, nil): the caller logs the warning and
 //     continues (the flexible default; the binding is advisory).
 func EvaluateIssuerBinding(metadataIssuer, discoveryLocation string, strict bool) (string, error) {
-	if issuerMatchesLocation(metadataIssuer, discoveryLocation) {
+	detail := IssuerBindingDetail(metadataIssuer, discoveryLocation)
+	if detail == "" {
 		return "", nil
 	}
-	advertised := metadataIssuer
-	if strings.TrimSpace(advertised) == "" {
-		advertised = "(none advertised)"
-	}
-	detail := fmt.Sprintf(
-		"SSF §7.2.4 issuer binding mismatch: transmitter discovery document advertises issuer %q but was retrieved from %q; these MUST match to prevent transmitter impersonation (jwks_uri is free-form and is not part of this check)",
-		advertised, discoveryLocation)
 	if strict {
 		return "", errors.New(detail)
 	}

--- a/pkg/wellKnownSupport/well_known.go
+++ b/pkg/wellKnownSupport/well_known.go
@@ -113,6 +113,77 @@ func InsertWellKnownURL(baseURL string, wellKnownPath string) (string, error) {
 	return u.String(), nil
 }
 
+// normalizeIssuerURL canonicalizes an issuer/location URL for the SSF §7.2.4
+// binding comparison: scheme and host are lowercased (RFC 3986 case-insensitive
+// components) and a single trailing slash is trimmed. The path is left
+// case-sensitive. An empty/blank input normalizes to "".
+func normalizeIssuerURL(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return ""
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return strings.ToLower(strings.TrimRight(s, "/"))
+	}
+	u.Scheme = strings.ToLower(u.Scheme)
+	u.Host = strings.ToLower(u.Host)
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String()
+}
+
+// issuerMatchesLocation reports whether a transmitter's advertised metadata
+// issuer is consistent with the location its discovery document was retrieved
+// from. An empty metadataIssuer never matches (the transmitter advertised no
+// issuer, which is itself a §7.2.4 violation).
+func issuerMatchesLocation(metadataIssuer, discoveryLocation string) bool {
+	mi := normalizeIssuerURL(metadataIssuer)
+	if mi == "" {
+		return false
+	}
+	return mi == normalizeIssuerURL(discoveryLocation)
+}
+
+// EvaluateIssuerBinding checks the SSF §7.2.4 issuer↔discovery-location binding:
+// the `issuer` advertised inside a transmitter's discovery document MUST equal
+// the location that document was retrieved from (the host + issuer path the
+// .well-known/ssf-configuration URL was built from), to prevent transmitter
+// impersonation. It is the symmetric counterpart of the OpenID conformance
+// suite's OIDSSFCheckTransmitterMetadataIssuer.
+//
+// jwks_uri is intentionally NOT a parameter: it is free-form (any HTTPS URL
+// serving the issuer's keys) and must never be required to equal iss/issuer.
+// Keeping it out of this signature structurally prevents anyone from coupling
+// the two.
+//
+// Comparison is scheme/host case-insensitive and ignores a single trailing
+// slash (the path stays case-sensitive per RFC 3986). On a consistent binding
+// it returns ("", nil). On a mismatch the behavior is keyed off the peer's
+// operator-declared strict posture (model.Server.StrictSsf / the CLI's
+// --strict-ssf — NOT the goSsfServer-only I2SIG_STRICT_SSF env flag):
+//
+//   - strict == true  -> ("", error): abort. The peer claims to be a strict,
+//     properly-administered SSF transmitter, so a mismatch is an impersonation
+//     or misconfiguration signal that must not be recorded.
+//   - strict == false -> (warning, nil): the caller logs the warning and
+//     continues (the flexible default; the binding is advisory).
+func EvaluateIssuerBinding(metadataIssuer, discoveryLocation string, strict bool) (string, error) {
+	if issuerMatchesLocation(metadataIssuer, discoveryLocation) {
+		return "", nil
+	}
+	advertised := metadataIssuer
+	if strings.TrimSpace(advertised) == "" {
+		advertised = "(none advertised)"
+	}
+	detail := fmt.Sprintf(
+		"SSF §7.2.4 issuer binding mismatch: transmitter discovery document advertises issuer %q but was retrieved from %q; these MUST match to prevent transmitter impersonation (jwks_uri is free-form and is not part of this check)",
+		advertised, discoveryLocation)
+	if strict {
+		return "", errors.New(detail)
+	}
+	return detail, nil
+}
+
 // BuildWellKnownURLs generates candidate URLs for a well-known endpoint.
 // It follows RFC 8414 logic for inserting .well-known and also handles simple appending.
 func BuildWellKnownURLs(baseURL string, wellKnownPath string) ([]string, error) {


### PR DESCRIPTION
Closes #207 (Scope A — CLI / receiver). Scope B (admin passthrough visibility) tracks separately as i2-open/i2goSignalsAdmin#241.

## What this does

Adds the SSF §7.2.4 issuer binding check in both places goSignals fetches transmitter discovery: a transmitter's advertised `issuer` MUST equal the location its `.well-known/ssf-configuration` document was retrieved from — the symmetric counterpart of the OpenID conformance suite's `OIDSSFCheckTransmitterMetadataIssuer`. **`jwks_uri` stays free-form** and is deliberately not part of the check (it isn't even a parameter, so the coupling is structurally impossible to reintroduce).

Behavior is keyed off the **per-peer `StrictSsf` posture** (`SsfServer.StrictSsf` / `model.Server.StrictSsf`), **NOT** the `goSsfServer`-only `I2SIG_STRICT_SSF` env flag — so the backed-out server-side env wiring (ADR 0025) stays deleted:

| Posture | Issuer ≠ discovery-location |
|---|---|
| flexible (default) | **warn** and continue (server/stream still recorded) |
| strict (`--strict-ssf` / `StrictSsf=true`) | **fail** — abort the add / registration |

## Changes

- **`pkg/wellKnownSupport/well_known.go`** — new `EvaluateIssuerBinding(metadataIssuer, discoveryLocation, strict)`. Scheme/host case-insensitive, trailing-slash-tolerant.
- **`cmd/goSignals/commands.go`** — `add server` compares `transmitterConfiguration.Issuer` to `server.Host`.
- **`pkg/services/stream_service.go`** — receiver `CreateStream` compares `txConfig.Issuer` to `txServer.Host`; the inline-static `TxWellKnownUrl` path has no strict flag, so it defaults to warn.

## Tests

- Decision-table unit tests (normalization + every strict/flexible cell).
- CLI + server: strict-mismatch → fail (not recorded), flexible-mismatch → warn + record, strict-match → succeed.
- `pkg/goSet` regression: a free-form `jwks_uri` on an issuer-unrelated path is fetched **verbatim** and its keys load.
- `mockStrictTransmitter` now advertises `issuer == location` so the §8.1.1.1 stripping test models a properly-bound transmitter.

All green incl. `-race` on `pkg/services`; `gofmt` / `go vet` clean. Mongo-gated `internal/server` tests are unaffected (their `StrictSsf` tests are CRUD-only and don't touch this path).

## Notes for the reviewer

- **One deliberate deviation:** the issuer-*mismatch* case gets warn/fail-by-strict; a discovery *fetch* failure keeps its existing hard-fail in both modes (recording a nil-`ServerConfiguration` server/stream is unsafe — downstream commands dereference it).
- **SET `iss` validation** left optional (enforced only when an expected issuer is pinned) — flagged in the issue for a separate decision.
- Audit confirmation: `--strict-ssf` stripping (`StripTransmitterSupplied`) introduces no `iss==jwks_uri` coupling.
- No standalone ADR yet — deferred to avoid a cross-branch 0025 number collision with the prd-196 work; can add as 0026 once that lands here.

Full conclusion recorded at https://github.com/i2-open/i2goSignals/issues/207#issuecomment-4781888190

https://claude.ai/code/session_01PxfusPyuNJ3p1dXeGYBRqF
