### PR TITLE
docs: correct logger package path (internal/logger -> pkg/logger)

### DIFF
--- a/.aiassistant/rules/aiguidelines.md
+++ b/.aiassistant/rules/aiguidelines.md
@@ -29,7 +29,7 @@ apply: always
 - **Race**: When testing concurrent code, use `go test -race` to detect potential race conditions, but ensure reasonable timeouts or lock detections to ensure tests finish within 5 minutes.
 
 #### Coding Standards
-- **Logging**: Use the internal logging package (`github.com/i2-open/i2goSignals/internal/logger`) which uses `slog`. Use `logger.Sub("Component")` to create sub-loggers for specific components.
+- **Logging**: Use the logging package (`github.com/i2-open/i2goSignals/pkg/logger`) which uses `slog`. Use `logger.Sub("Component")` to create sub-loggers for specific components.
 - **Database**: When interacting with MongoDB, follow existing patterns in `internal/providers/dbProviders/mongo_provider`.
 - **Go Version**: The project uses Go 1.25. Ensure all code is compatible.
 - **Error Handling**: Use standard Go error handling. Wrap errors with context where appropriate.

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -29,7 +29,7 @@
 - **Implement tests**: Implement reproduction tests when feasible and keep if resonable
 
 #### Coding Standards
-- **Logging**: Use the internal logging package (`github.com/i2-open/i2goSignals/internal/logger`) which uses `slog`. Use `logger.Sub("Component")` to create sub-loggers for specific components.
+- **Logging**: Use the logging package (`github.com/i2-open/i2goSignals/pkg/logger`) which uses `slog`. Use `logger.Sub("Component")` to create sub-loggers for specific components.
 - **Database**: When interacting with MongoDB, follow existing patterns in `internal/providers/dbProviders/mongo_provider`.
 - **Go Version**: The project uses Go 1.25. Ensure all code is compatible.
 - **Error Handling**: Use standard Go error handling. Wrap errors with context where appropriate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Integration tests use `testify/suite`; some (notably under `internal/server`) st
 ## Project conventions
 
 - **Indentation:** Go files are gofmt-canonical **tabs** — run `gofmt -w` on any `.go` file you touch; a commit must leave `gofmt -l` clean. Non-Go files (YAML, Markdown, shell, JSON) use **4 spaces, never tabs**. Do not author Go with 4-space indentation expecting a formatter to fix it.
-- **Logging:** use `internal/logger` (wraps `slog`); create per-component sub-loggers (`var eventLogger = logger.Sub("ROUTER")`). Levels via `LOG_LEVEL`. Log-level policy (WARN vs ERROR discipline) is in `CONTEXT.md`.
+- **Logging:** use `pkg/logger` (wraps `slog`); create per-component sub-loggers (`var eventLogger = logger.Sub("ROUTER")`). Levels via `LOG_LEVEL`. Log-level policy (WARN vs ERROR discipline) is in `CONTEXT.md`.
 - **Package boundary:** `pkg/goSet*` packages must not import anything under `internal/` — they are standalone libraries.
 - **Pre-existing `go vet` warnings** in `internal/model`, `pkg/goScim`, `cmd/goSignals` (duplicate JSON tags, mutex copies) — don't be alarmed, don't add new ones.
 - **Don't commit** `__debug_bin*`, certs under `config/certs/`, or anything matched by `.aiignore` (`.mongo/` + some WiredTiger files). Do not read or modify `.aiignore`-matched files.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -173,7 +173,7 @@ to know two things: the *shape* of each log line, and which fields are
 guaranteed to be there.
 
 When the environment variable `LOG_FORMAT=json` is set, every record
-written by `internal/logger` (which means every package that uses
+written by `pkg/logger` (which means every package that uses
 `logger.Sub(...)`) is emitted as a single line of JSON on stdout. One
 self-contained JSON object per line, separated by newlines — a format
 that every mainstream log collector understands natively.


### PR DESCRIPTION
## What

The logging package moved from `internal/logger` to `pkg/logger` (all 37 imports use `github.com/i2-open/i2goSignals/pkg/logger`; `internal/logger` no longer exists). This updates the four doc/guideline files that still pointed at the old path:

- `CLAUDE.md`
- `.junie/guidelines.md`
- `.aiassistant/rules/aiguidelines.md`
- `docs/observability.md`

## Why

Surfaced by the standards-axis review of PR #213 — the docs told contributors (and AI agents) to import a package that no longer exists at that path.

## Scope

Docs only, +4/−4. No code, no behavior change. The `.idea/workspace.xml` reference is IDE-generated state and was intentionally left alone (it regenerates).

https://claude.ai/code/session_01JZpuTACanwmQEV4ETFsHGM