### PR TITLE
feat(server): export pkg/goSignalsServer admin-route surface for REST coexistence (#215)

### DIFF
--- a/docs/adr/0027-pkg-admin-route-surface.md
+++ b/docs/adr/0027-pkg-admin-route-surface.md
@@ -1,0 +1,166 @@
+<!-- gosignals-brand-hero -->
+<picture><source media="(prefers-color-scheme: dark)" srcset="../../brand/logo/gosignals-hero-primary.svg"><img src="../../brand/logo/gosignals-hero-on-light.svg" alt="goSignals" height="77"></picture>
+
+# 27. A pkg/-importable admin-route surface for enterprise REST coexistence
+
+Date: 2026-06-24
+
+## Status
+
+Accepted (GH #215).
+Builds on ADR 0021 (lift `internal/services` to `pkg/services` — the public service
+handles this surface is assembled from) and is a sibling of the delivery seam
+(ADR 0010 provider decomposition / the `PushDelivery` seam): both expose a narrow,
+caller-owned injection point so an out-of-tree consumer can reuse the gateway's
+behavior without dragging the cluster/storage runtime in.
+
+## Context
+
+The community goSignals strategic gateway (`cmd/goSignalsServer`, the
+`internal/server` handler tree behind `*SignalsApplication` + `routers.go`) owns
+the REST admin surface: stream / server / key / issuer CRUD plus the
+subject-management family. That surface lives entirely under `internal/`, so an
+external Go module cannot mount it.
+
+The enterprise REST-coexistence binary (`I2SIG_REST_ADMIN=on`, enterprise #76,
+PRD `i2goSignalsAdmin#164`) must register the **community** REST admin handler
+families and omit them (route-not-registered 404) when off — and per enterprise
+ADR 0009/0042 it must **reuse** the community handlers, not re-implement them.
+Re-implementation would fork the admin contract: two copies of stream-create
+validation, subject-filter relay, rotate-on-GET, drifting over time exactly as
+the receiver-stream predicate drifted between DAO adapters before PRD #39.
+
+ADR 0021 already lifted the service layer to `pkg/services`, so the building
+blocks an admin handler needs (`StreamService`, `KeyService`, `ServerService`,
+`TokenService`, `SubjectFilterService`, `SubjectRelayService`, the
+`authSupport.AuthIssuer`) are public. What was still trapped under `internal/`
+was the *binding* of those services to the admin HTTP handlers and the route
+table. The handlers also reach two collaborators an external mount cannot supply
+from public inputs: the `eventRouter.EventRouter` (the stream-mutation handlers
+call `UpdateStreamState`/`RemoveStream`; `handleSubjectChange` additionally calls
+`NotifySubjectFilterChange`) and — for HYBRID/PASSTHRU subject relay — the
+already-public `*services.SubjectRelayService`. The full peer/event/cluster plane
+(`/.well-known/*`, `/health`, OAuth, event delivery, bootstrap) needs the
+event/cluster/storage seam and is out of scope; enterprise serves its own.
+
+## Decision
+
+Add a community `pkg/goSignalsServer` wrapper that exposes the admin-route subset
+as a `pkg/`-importable handler set an external module mounts on its own
+`*mux.Router`. The handler bodies stay in `internal/server` and are reused
+byte-identically; only the way the application they run against is constructed
+changes.
+
+1. **Admin/peer route split** (`internal/server/routers.go`). `getRoutes()` is
+   partitioned into `peerRoutes()` (the always-on Q16 exclusion list) and
+   `adminRoutes()` (the 22-route admin family), with `getRoutes()` their pure
+   union. `(*SignalsApplication).AdminRouteTable()` returns the admin Routes bound
+   to a given application's handler methods. Membership is pinned by
+   `internal/server/routers_split_test.go#TestAdminRoutesMembership`, so a future
+   edit cannot silently reclassify a route across the seam.
+
+2. **A reduced admin application** (`internal/server/admin_surface.go`).
+   `NewAdminApplication(AdminAppDeps)` assembles a `*SignalsApplication` from
+   PUBLIC service handles only — no `dbProviders.Persistence`, no background sync,
+   no cluster server, no live receivers. The receiver-bookkeeping maps are
+   initialized so the StreamDelete cascade is safe (no live receivers ⇒ inert).
+
+3. **A 3-method `StreamStateSink`** (`UpdateStreamState`, `RemoveStream`,
+   `NotifySubjectFilterChange`) — the exact router surface the admin family
+   touches, audited against the handler call sites. The wrapper injects a
+   caller-supplied sink via `adminRouterAdapter`, which adapts the 3 methods up to
+   the full `eventRouter.EventRouter` interface and panics on the other ~17
+   methods (a guardrail: they belong to the peer/event plane and can only be
+   reached if a non-admin route were ever bound onto an admin application by
+   mistake). The in-binary gateway passes its real `*eventRouter.EventRouter`,
+   which already satisfies the narrow sink — so wiring through the sink does not
+   change gateway behavior.
+
+4. **`*services.SubjectRelayService` injected directly**, not folded into the
+   sink: the subject-management handler drives HYBRID/PASSTHRU upstream relay
+   through it, and it is already `pkg/`-public (ADR 0021), so no new lift.
+
+5. **The public wrapper** (`pkg/goSignalsServer/admin_surface.go`):
+   `NewAdminSurface(AdminSurfaceConfig) *AdminSurface` taking only `pkg/`-exported
+   handles, and `(*AdminSurface).AdminRoutes() Routes`. An external caller builds
+   the public services (`pkg/services` over `pkg/dao`), supplies a
+   `StreamStateSink`, and mounts `AdminRoutes()`; omitting them leaves the paths
+   unregistered (404) — the registration toggle the enterprise REST-admin flag
+   relies on. The caller wraps the handlers for auth/audit; the surface itself
+   does not impose middleware (each handler validates the bearer inline against
+   the injected `AuthIssuer`).
+
+The contract names — `pkg/goSignalsServer`, `NewAdminSurface`,
+`AdminSurfaceConfig`, `StreamStateSink`, `AdminRoutes() Routes`, the 22-route
+admin family — are pinned; neither side renames them unilaterally (the #215 ⇄ #76
+contract handshake).
+
+## Considered alternatives
+
+- **Full lift of the `internal/server` admin handlers into `pkg/` (option A).**
+  Cleaner long-term, but a large mechanical move with broad blast radius across
+  the handler tree, and it would have to lift or re-home the application object
+  too. Deferred; this wrapper keeps the handlers in place and reuses them.
+- **Stub the full 20-method `eventRouter.EventRouter` for the caller to
+  implement.** Forces every external consumer to implement (or no-op) 17 methods
+  that the admin family never calls — noise that also hides which methods the
+  admin surface actually depends on. Rejected in favor of the narrow 3-method
+  sink the route audit proved sufficient.
+- **Re-implement the admin handlers in enterprise.** Forks the admin contract
+  (validation, relay, rotate-on-GET) into two drifting copies — exactly what
+  enterprise ADR 0009/0042 says to avoid. Rejected.
+- **Expose the surface through `pkg/goSsfServer`.** That package is the test-only
+  SSF simulator, not the strategic gateway; reusing its name would also collide
+  with the `i2goSignalsAdmin` project. A dedicated `pkg/goSignalsServer` follows
+  the same `internal/server`-import-within-the-module precedent without the name
+  clash.
+
+## Consequences
+
+**Positive**
+
+- The enterprise REST-coexistence binary mounts the community admin routes from
+  public inputs, behind one flag, with byte-identical handler behavior — reuse,
+  not re-implementation. No `internal/` import is required of the external caller
+  (proven by `pkg/goSignalsServer/admin_surface_test.go`, an external
+  `goSignalsServer_test` package importing only `pkg/...`).
+- The admin/peer split is a pure partition guarded by tests, so the seam cannot
+  silently drift.
+- The 3-method sink documents, and the route-audit test pins, exactly which
+  router transitions the admin family emits; the caller forwards just those into
+  its own control-stream/event state.
+- The peer/event/cluster plane stays out of the public surface — enterprise
+  serves it itself, flag-independently — so the export does not leak the
+  storage/cluster seam.
+
+**Negative / accepted trade-offs**
+
+- `pkg/goSignalsServer` imports `internal/server` within the module (the
+  `pkg/goSsfServer` precedent) — a deliberate, scoped `pkg → internal` edge that
+  the ADR 0021 CI boundary gate does not cover (the gate is scoped to
+  `pkg/services`, `pkg/dao`, `pkg/authSupport`). The external *caller* still needs
+  no `internal/` import; the edge is internal to the wrapper.
+- The reduced admin application is a second construction path for
+  `*SignalsApplication` alongside `NewApplication`; the `adminRouterAdapter`'s
+  panic-on-unsupported guardrail is the safety net that keeps a mis-bound
+  non-admin route from silently no-oping.
+
+## Related
+
+- GH #215 — this surface (community side); enterprise #76 — the consumer.
+- PRD `i2goSignalsAdmin#164` — the admin-UI / REST-coexistence parent.
+- ADR 0021 — lift `internal/services` to `pkg/services` (the public handles this
+  surface is built from).
+- ADR 0010 — provider decomposition / the `PushDelivery` seam (sibling
+  caller-owned injection point).
+- ADR 0009 (enterprise) / ADR 0042 (enterprise) — REST coexistence must reuse
+  community handlers and pin the community module by SHA/tag.
+- `internal/server/routers.go` — `peerRoutes()` / `adminRoutes()` /
+  `AdminRouteTable()`.
+- `internal/server/admin_surface.go` — `NewAdminApplication`,
+  `AdminStreamStateSink`, `adminRouterAdapter`.
+- `pkg/goSignalsServer/admin_surface.go` — `NewAdminSurface`,
+  `AdminSurfaceConfig`, `StreamStateSink`, `AdminRoutes`.
+- `internal/server/routers_split_test.go`,
+  `pkg/goSignalsServer/admin_surface_test.go` — the partition and external-consumer
+  pins.

--- a/internal/server/admin_surface.go
+++ b/internal/server/admin_surface.go
@@ -1,0 +1,196 @@
+package server
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/i2-open/i2goSignals/internal/eventRouter"
+	"github.com/i2-open/i2goSignals/pkg/authSupport"
+	"github.com/i2-open/i2goSignals/pkg/goSet"
+	"github.com/i2-open/i2goSignals/pkg/goSetSstp"
+	"github.com/i2-open/i2goSignals/pkg/services"
+	model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+)
+
+// admin_surface.go is the issue #215 seam: it lets the pkg/goSignalsServer
+// admin-surface wrapper build a *SignalsApplication from PUBLIC service handles
+// plus a narrow stream-state sink, without standing up the full clustered
+// runtime (no backgroundSync, no internal cluster server, no live receivers).
+// The admin handler bodies are reused verbatim — this only changes how the
+// application they run against is constructed, so the admin REST behavior is
+// byte-identical to the in-binary gateway.
+
+// AdminStreamStateSink is the narrow router surface the admin mutation handlers
+// drive. The full gateway passes its real *eventRouter.EventRouter (which has
+// all three methods, so it satisfies this interface directly); the wrapper
+// passes a caller-supplied sink so an external consumer can observe the same
+// state transitions the in-binary router would apply. The pkg/goSignalsServer
+// StreamStateSink has the identical method set and is adapted onto this.
+//
+// Audited against issue #215 Scope §1: the admin family touches the router only
+// through these three methods — UpdateStreamState/RemoveStream from the four
+// stream-mutation handlers (StreamCreate/Update/Delete, UpdateStatus, plus the
+// SSTP-pair helpers) and NotifySubjectFilterChange additionally from
+// handleSubjectChange (/add-subject, /remove-subject).
+type AdminStreamStateSink interface {
+	UpdateStreamState(stream *model.StreamStateRecord)
+	RemoveStream(sid string)
+	NotifySubjectFilterChange(sid string)
+}
+
+// AdminAppDeps carries the public handles the admin surface is built from. Every
+// field is a pkg/-exported type, so the wrapper (and, transitively, an external
+// consumer) needs no internal/ import to assemble them.
+type AdminAppDeps struct {
+	StreamService        *services.StreamService
+	KeyService           *services.KeyService
+	ServerService        *services.ServerService
+	TokenService         *services.TokenService
+	SubjectFilterService *services.SubjectFilterService
+	SubjectRelayService  *services.SubjectRelayService
+	Auth                 *authSupport.AuthIssuer
+	DefIssuer            string
+	BaseUrl              *url.URL
+	// Sink receives the stream-state transitions the admin mutation handlers
+	// emit. Required; nil is treated as a no-op sink so a read-only mount does
+	// not panic.
+	Sink AdminStreamStateSink
+}
+
+// NewAdminApplication assembles a *SignalsApplication wired for the admin-route
+// surface only (issue #215). It deliberately does NOT start the cluster
+// background sync, the internal cluster server, or live receivers, and does NOT
+// build the full router — the caller (pkg/goSignalsServer) mounts only
+// AdminRouteTable() on its own mux. The receiver-bookkeeping maps ARE
+// initialized so the StreamDelete cascade (DrainReceiver/CloseReceiver/
+// HandleReceiver) runs without panicking on a nil map; with no live receivers
+// those calls are inert no-ops.
+func NewAdminApplication(deps AdminAppDeps) *SignalsApplication {
+	sink := deps.Sink
+	if sink == nil {
+		sink = noopStreamStateSink{}
+	}
+
+	sa := &SignalsApplication{
+		StreamService:        deps.StreamService,
+		KeyService:           deps.KeyService,
+		ServerService:        deps.ServerService,
+		TokenService:         deps.TokenService,
+		SubjectFilterService: deps.SubjectFilterService,
+		SubjectRelayService:  deps.SubjectRelayService,
+		Auth:                 deps.Auth,
+		DefIssuer:            deps.DefIssuer,
+		BaseUrl:              deps.BaseUrl,
+		AdminRole:            "ADMIN",
+		// Receiver bookkeeping maps so the StreamDelete cascade is safe with no
+		// live receivers (writes to a nil map would panic).
+		pollClients:   map[string]*ClientPollStream{},
+		pushClients:   map[string]*ReceiverPushStream{},
+		pushReceivers: map[string]model.StreamStateRecord{},
+		// EventRouter is the sink adapter: the three admin-driven methods forward
+		// to the supplied sink; the other 17 EventRouter methods are unreachable
+		// from the admin family and panic loudly if ever wired into an admin
+		// route (a guardrail, not an expected path).
+		EventRouter: &adminRouterAdapter{sink: sink},
+	}
+	return sa
+}
+
+// noopStreamStateSink absorbs stream-state transitions when the caller supplies
+// no sink (a read-only admin mount).
+type noopStreamStateSink struct{}
+
+func (noopStreamStateSink) UpdateStreamState(*model.StreamStateRecord) {}
+func (noopStreamStateSink) RemoveStream(string)                        {}
+func (noopStreamStateSink) NotifySubjectFilterChange(string)           {}
+
+// adminRouterAdapter adapts a 3-method AdminStreamStateSink up to the full
+// eventRouter.EventRouter interface that SsfApplicationInterface.GetEventRouter
+// returns. Only the three methods the admin handlers call are wired; the rest
+// belong to the event/cluster/storage plane the admin surface does not serve
+// (issue #215 out-of-scope) and panic if reached, which can only happen if a
+// non-admin route were ever bound onto an admin application by mistake.
+type adminRouterAdapter struct {
+	sink AdminStreamStateSink
+}
+
+func (a *adminRouterAdapter) UpdateStreamState(stream *model.StreamStateRecord) {
+	a.sink.UpdateStreamState(stream)
+}
+func (a *adminRouterAdapter) RemoveStream(sid string) { a.sink.RemoveStream(sid) }
+func (a *adminRouterAdapter) NotifySubjectFilterChange(sid string) {
+	a.sink.NotifySubjectFilterChange(sid)
+}
+
+func (a *adminRouterAdapter) unsupported(method string) {
+	panic("goSignalsServer admin surface: eventRouter." + method +
+		" is not served by the admin-route surface (issue #215 peer/event plane is out of scope)")
+}
+
+func (a *adminRouterAdapter) HandleEvent(*goSet.SecurityEventToken, string, string) error {
+	a.unsupported("HandleEvent")
+	return nil
+}
+
+func (a *adminRouterAdapter) SubmitOperationalEvent(string, *goSet.SecurityEventToken, string) (*model.EventRecord, error) {
+	a.unsupported("SubmitOperationalEvent")
+	return nil, nil
+}
+
+func (a *adminRouterAdapter) GenerateVerifyEvent(string, string) (*model.EventRecord, error) {
+	a.unsupported("GenerateVerifyEvent")
+	return nil, nil
+}
+
+func (a *adminRouterAdapter) PollStreamHandler(string, model.PollParameters) (map[string]string, bool, int) {
+	a.unsupported("PollStreamHandler")
+	return nil, false, 0
+}
+
+func (a *adminRouterAdapter) SstpServerHandler(context.Context, string, goSetSstp.Message, []eventRouter.SstpInboundSet) (goSetSstp.Message, int) {
+	a.unsupported("SstpServerHandler")
+	return goSetSstp.Message{}, 0
+}
+
+func (a *adminRouterAdapter) Shutdown() { a.unsupported("Shutdown") }
+
+func (a *adminRouterAdapter) SetEventCounter(*prometheus.CounterVec, *prometheus.CounterVec) {
+	a.unsupported("SetEventCounter")
+}
+
+func (a *adminRouterAdapter) PreInitializeCounter(*model.StreamStateRecord) {
+	a.unsupported("PreInitializeCounter")
+}
+
+func (a *adminRouterAdapter) GetPushStreamCnt() float64 {
+	a.unsupported("GetPushStreamCnt")
+	return 0
+}
+
+func (a *adminRouterAdapter) GetPollStreamCnt() float64 {
+	a.unsupported("GetPollStreamCnt")
+	return 0
+}
+
+func (a *adminRouterAdapter) IncrementCounter(*model.StreamStateRecord, *goSet.SecurityEventToken, bool) {
+	a.unsupported("IncrementCounter")
+}
+
+func (a *adminRouterAdapter) SetStatsHandler(interface{}) { a.unsupported("SetStatsHandler") }
+
+func (a *adminRouterAdapter) ResetStream(string) { a.unsupported("ResetStream") }
+
+func (a *adminRouterAdapter) WakeTransmitter(string, string) { a.unsupported("WakeTransmitter") }
+
+func (a *adminRouterAdapter) WakeSstpClient(string) { a.unsupported("WakeSstpClient") }
+
+func (a *adminRouterAdapter) WakeSstpServer(string) { a.unsupported("WakeSstpServer") }
+
+// Compile-time assertions: the adapter satisfies the full EventRouter
+// interface, and the real *eventRouter.EventRouter satisfies the narrow sink so
+// the in-binary gateway can pass its router directly with byte-identical
+// behavior.
+var _ eventRouter.EventRouter = (*adminRouterAdapter)(nil)
+var _ AdminStreamStateSink = (eventRouter.EventRouter)(nil)

--- a/internal/server/routers.go
+++ b/internal/server/routers.go
@@ -90,8 +90,25 @@ func (sa *SignalsApplication) Index(w http.ResponseWriter, r *http.Request) {
 	_, _ = fmt.Fprintf(w, "Hello %s", test)
 }
 
+// getRoutes returns the full gateway route table: the always-on peer set
+// followed by the admin families. The split into peerRoutes()/adminRoutes() is
+// the issue #215 enabler — the pkg/goSignalsServer admin-surface wrapper mounts
+// only the admin subset, while an enterprise REST-coexistence binary registers
+// the admin families conditionally and always serves the peer set (PRD #164,
+// enterprise ADR 0009). This concatenation must stay a pure partition: every
+// route is in exactly one subset and getRoutes() is their union.
 func (h *HttpRouter) getRoutes() Routes {
-	routes := Routes{
+	return append(h.peerRoutes(), h.adminRoutes()...)
+}
+
+// peerRoutes is the always-on, peer-facing route set (issue #215 Q16 exclusion
+// list): discovery (/.well-known/*), health, OAuth (/introspect, /revoke,
+// /token), event delivery (/poll, /events, /verification), JWKS serving, SSTP
+// transport, cluster wake-ups, and bootstrap (/iat, /register). These are NOT
+// mounted by the pkg/goSignalsServer admin-surface wrapper and are unaffected by
+// the enterprise REST-admin flag — they always register.
+func (h *HttpRouter) peerRoutes() Routes {
+	return Routes{
 		Route{
 			"Index",
 			"GET",
@@ -139,6 +156,175 @@ func (h *HttpRouter) getRoutes() Routes {
 			false,
 		},
 
+		Route{
+			"VerificationRequest",
+			http.MethodPost,
+			"/verification",
+			h.sa.VerificationRequest,
+			false,
+		},
+
+		Route{
+			"VerificationRequestSSF",
+			http.MethodPost,
+			"/verify",
+			h.sa.VerificationRequest,
+			false,
+		},
+
+		Route{
+			"WellKnownSsfConfigurationGet",
+			http.MethodGet,
+			"/.well-known/ssf-configuration",
+			h.sa.WellKnownSsfConfigurationGet,
+			false,
+		},
+
+		// ADR 0023: capture a multi-segment issuer path so a local issuer carrying
+		// a path component (e.g. /tenants/acme) resolves, not just a single segment.
+		Route{
+			"WellKnownSsfConfigurationIssuerGet",
+			http.MethodGet,
+			"/.well-known/ssf-configuration/{issuer:.+}",
+			h.sa.WellKnownSsfConfigurationIssuerGet,
+			false,
+		},
+
+		Route{
+			"JwksJson",
+			http.MethodGet,
+			"/jwks.json",
+			h.sa.JwksJson,
+			false,
+		},
+
+		// ADR 0023: multi-segment keyName so a local issuer's clean jwks_uri
+		// (baseURL + /jwks/<path>) resolves. The {keyName:.+} pattern requires the
+		// /jwks/ prefix and so does not shadow the literal GET /jwks.json (no
+		// trailing slash) above; it is GET-only and so does not shadow the
+		// POST /jwks/{keyName} create route either.
+		Route{
+			"JwksJsonTenant",
+			http.MethodGet,
+			"/jwks/{keyName:.+}",
+			h.sa.JwksJsonIssuer,
+			false,
+		},
+
+		Route{
+			"PollEvents",
+			http.MethodPost,
+			"/poll/{id}",
+			h.sa.PollEvents,
+			false,
+		},
+
+		// SSTP is registered without a method restriction so that any non-POST
+		// method on /sstp/{id} reaches the handler and returns an explicit 405
+		// (gorilla/mux otherwise 404s an unmatched method on a method-pinned
+		// route). The handler enforces POST-only (PRD #154 Q19, Q21.a).
+		Route{
+			"ReceiveSstpEvent",
+			"",
+			"/sstp/{id}",
+			h.sa.ReceiveSstpEvent,
+			false,
+		},
+
+		Route{
+			"WakeTransmitter",
+			http.MethodPost,
+			"/_cluster/wake-transmitter",
+			h.sa.WakeTransmitter,
+			false,
+		},
+
+		// SSTP cluster wake-up routes (PRD #154 Q11.1, Q11.2, #167). Kept separate
+		// from wake-transmitter for telemetry separation; same SPIFFE/HMAC auth.
+		Route{
+			"WakeSstpClient",
+			http.MethodPost,
+			"/_cluster/wake-sstp-client",
+			h.sa.WakeSstpClient,
+			false,
+		},
+		Route{
+			"WakeSstpServer",
+			http.MethodPost,
+			"/_cluster/wake-sstp-server",
+			h.sa.WakeSstpServer,
+			false,
+		},
+
+		Route{
+			"ProtectedResourceMetadata",
+			http.MethodGet,
+			"/.well-known/oauth-protected-resource",
+			h.sa.ProtectedResourceMetadata,
+			false,
+		},
+
+		// RFC 8414 OAuth 2.0 Authorization Server Metadata. The bare endpoint
+		// describes the default issuer; the {issuer:.+} variant captures a
+		// multi-segment local issuer path (ADR 0023) and resolves it the same
+		// local-rooted-then-bare way ssf-configuration/JWKS do (GH #209). When an
+		// external authorization server is configured the handler reflects its
+		// metadata verbatim (a discovery proxy).
+		Route{
+			"WellKnownOAuthAuthorizationServer",
+			http.MethodGet,
+			"/.well-known/oauth-authorization-server",
+			h.sa.WellKnownOAuthAuthorizationServer,
+			false,
+		},
+		Route{
+			"WellKnownOAuthAuthorizationServerIssuer",
+			http.MethodGet,
+			"/.well-known/oauth-authorization-server/{issuer:.+}",
+			h.sa.WellKnownOAuthAuthorizationServer,
+			false,
+		},
+		Route{
+			"Introspect",
+			http.MethodPost,
+			"/introspect",
+			h.sa.IntrospectHandler,
+			false,
+		},
+		Route{
+			"Revoke",
+			http.MethodPost,
+			"/revoke",
+			h.sa.RevokeHandler,
+			false,
+		},
+		Route{
+			"TokenRevoke",
+			http.MethodDelete,
+			"/token/{jti}",
+			h.sa.TokenRevokeHandler,
+			false,
+		},
+		Route{
+			"TokenList",
+			http.MethodGet,
+			"/token",
+			h.sa.TokenListHandler,
+			false,
+		},
+	}
+}
+
+// adminRoutes is the admin-family route set (issue #215 Scope §1): stream /
+// server / key / issuer CRUD plus the subject-management family (/add-subject,
+// /remove-subject, /subject-filter/review, /status, /states, /state). These are
+// the routes the pkg/goSignalsServer wrapper binds and mounts, and the routes an
+// enterprise REST-coexistence binary registers only when its admin flag is on
+// (PRD #164). The set is bound directly to a *SignalsApplication's handler
+// methods, so it is reusable both here (full in-binary gateway) and from the
+// wrapper's AdminRouteTable.
+func (h *HttpRouter) adminRoutes() Routes {
+	return Routes{
 		Route{
 			"AddSubject",
 			http.MethodPost,
@@ -268,39 +454,6 @@ func (h *HttpRouter) getRoutes() Routes {
 		},
 
 		Route{
-			"VerificationRequest",
-			http.MethodPost,
-			"/verification",
-			h.sa.VerificationRequest,
-			false,
-		},
-
-		Route{
-			"VerificationRequestSSF",
-			http.MethodPost,
-			"/verify",
-			h.sa.VerificationRequest,
-			false,
-		},
-
-		Route{
-			"WellKnownSsfConfigurationGet",
-			http.MethodGet,
-			"/.well-known/ssf-configuration",
-			h.sa.WellKnownSsfConfigurationGet,
-			false,
-		},
-
-		// ADR 0023: capture a multi-segment issuer path so a local issuer carrying
-		// a path component (e.g. /tenants/acme) resolves, not just a single segment.
-		Route{
-			"WellKnownSsfConfigurationIssuerGet",
-			http.MethodGet,
-			"/.well-known/ssf-configuration/{issuer:.+}",
-			h.sa.WellKnownSsfConfigurationIssuerGet,
-			false,
-		},
-		Route{
 			"CreateKey",
 			http.MethodPost,
 			"/key/{keyName}",
@@ -324,14 +477,6 @@ func (h *HttpRouter) getRoutes() Routes {
 		},
 
 		Route{
-			"JwksJson",
-			http.MethodGet,
-			"/jwks.json",
-			h.sa.JwksJson,
-			false,
-		},
-
-		Route{
 			"JwksIssuers",
 			http.MethodGet,
 			"/issuers",
@@ -346,121 +491,16 @@ func (h *HttpRouter) getRoutes() Routes {
 			HandlerFunc: h.sa.GetSummaries,
 			IsIdQuery:   false,
 		},
-
-		// ADR 0023: multi-segment keyName so a local issuer's clean jwks_uri
-		// (baseURL + /jwks/<path>) resolves. The {keyName:.+} pattern requires the
-		// /jwks/ prefix and so does not shadow the literal GET /jwks.json (no
-		// trailing slash) above; it is GET-only and so does not shadow the
-		// POST /jwks/{keyName} create route either.
-		Route{
-			"JwksJsonTenant",
-			http.MethodGet,
-			"/jwks/{keyName:.+}",
-			h.sa.JwksJsonIssuer,
-			false,
-		},
-
-		Route{
-			"PollEvents",
-			http.MethodPost,
-			"/poll/{id}",
-			h.sa.PollEvents,
-			false,
-		},
-
-		// SSTP is registered without a method restriction so that any non-POST
-		// method on /sstp/{id} reaches the handler and returns an explicit 405
-		// (gorilla/mux otherwise 404s an unmatched method on a method-pinned
-		// route). The handler enforces POST-only (PRD #154 Q19, Q21.a).
-		Route{
-			"ReceiveSstpEvent",
-			"",
-			"/sstp/{id}",
-			h.sa.ReceiveSstpEvent,
-			false,
-		},
-
-		Route{
-			"WakeTransmitter",
-			http.MethodPost,
-			"/_cluster/wake-transmitter",
-			h.sa.WakeTransmitter,
-			false,
-		},
-
-		// SSTP cluster wake-up routes (PRD #154 Q11.1, Q11.2, #167). Kept separate
-		// from wake-transmitter for telemetry separation; same SPIFFE/HMAC auth.
-		Route{
-			"WakeSstpClient",
-			http.MethodPost,
-			"/_cluster/wake-sstp-client",
-			h.sa.WakeSstpClient,
-			false,
-		},
-		Route{
-			"WakeSstpServer",
-			http.MethodPost,
-			"/_cluster/wake-sstp-server",
-			h.sa.WakeSstpServer,
-			false,
-		},
-
-		Route{
-			"ProtectedResourceMetadata",
-			http.MethodGet,
-			"/.well-known/oauth-protected-resource",
-			h.sa.ProtectedResourceMetadata,
-			false,
-		},
-
-		// RFC 8414 OAuth 2.0 Authorization Server Metadata. The bare endpoint
-		// describes the default issuer; the {issuer:.+} variant captures a
-		// multi-segment local issuer path (ADR 0023) and resolves it the same
-		// local-rooted-then-bare way ssf-configuration/JWKS do (GH #209). When an
-		// external authorization server is configured the handler reflects its
-		// metadata verbatim (a discovery proxy).
-		Route{
-			"WellKnownOAuthAuthorizationServer",
-			http.MethodGet,
-			"/.well-known/oauth-authorization-server",
-			h.sa.WellKnownOAuthAuthorizationServer,
-			false,
-		},
-		Route{
-			"WellKnownOAuthAuthorizationServerIssuer",
-			http.MethodGet,
-			"/.well-known/oauth-authorization-server/{issuer:.+}",
-			h.sa.WellKnownOAuthAuthorizationServer,
-			false,
-		},
-		Route{
-			"Introspect",
-			http.MethodPost,
-			"/introspect",
-			h.sa.IntrospectHandler,
-			false,
-		},
-		Route{
-			"Revoke",
-			http.MethodPost,
-			"/revoke",
-			h.sa.RevokeHandler,
-			false,
-		},
-		Route{
-			"TokenRevoke",
-			http.MethodDelete,
-			"/token/{jti}",
-			h.sa.TokenRevokeHandler,
-			false,
-		},
-		Route{
-			"TokenList",
-			http.MethodGet,
-			"/token",
-			h.sa.TokenListHandler,
-			false,
-		},
 	}
-	return routes
+}
+
+// AdminRouteTable returns the admin-family Routes (issue #215 Scope §1) bound to
+// this application's handler methods. It is the seam the pkg/goSignalsServer
+// admin-surface wrapper mounts: the wrapper builds a *SignalsApplication from
+// public service handles (NewAdminApplication) and asks for its admin routes,
+// reusing the exact handler bodies the full gateway runs (byte-identical
+// behavior, no re-implementation). Peer routes are deliberately excluded.
+func (sa *SignalsApplication) AdminRouteTable() Routes {
+	h := &HttpRouter{sa: sa}
+	return h.adminRoutes()
 }

--- a/internal/server/routers_split_test.go
+++ b/internal/server/routers_split_test.go
@@ -1,0 +1,125 @@
+package server
+
+import (
+	"sort"
+	"testing"
+)
+
+// nameSet returns the set of route Names in the slice.
+func nameSet(routes Routes) map[string]int {
+	m := make(map[string]int, len(routes))
+	for _, r := range routes {
+		m[r.Name]++
+	}
+	return m
+}
+
+// TestRouteSplitPartitionsFullSet asserts the admin/peer split (issue #215) is a
+// pure partition of getRoutes(): peerRoutes() and adminRoutes() are disjoint and
+// their union is exactly getRoutes(). This guards the refactor from silently
+// dropping, duplicating, or reclassifying a route.
+func TestRouteSplitPartitionsFullSet(t *testing.T) {
+	h := &HttpRouter{sa: &SignalsApplication{}}
+
+	full := h.getRoutes()
+	peer := h.peerRoutes()
+	admin := h.adminRoutes()
+
+	if len(peer)+len(admin) != len(full) {
+		t.Fatalf("partition size mismatch: peer(%d)+admin(%d) != full(%d)",
+			len(peer), len(admin), len(full))
+	}
+
+	peerNames := nameSet(peer)
+	adminNames := nameSet(admin)
+
+	// Disjoint: no route name appears in both subsets.
+	for name := range peerNames {
+		if _, dup := adminNames[name]; dup {
+			t.Errorf("route %q appears in BOTH peer and admin subsets", name)
+		}
+	}
+
+	// Union equals full: every full route is in exactly one subset, and each
+	// subset only contains full routes.
+	union := make(map[string]int)
+	for name, c := range peerNames {
+		union[name] += c
+	}
+	for name, c := range adminNames {
+		union[name] += c
+	}
+	fullNames := nameSet(full)
+	for name, c := range fullNames {
+		if union[name] != c {
+			t.Errorf("route %q: union count %d != full count %d", name, union[name], c)
+		}
+	}
+	for name := range union {
+		if _, ok := fullNames[name]; !ok {
+			t.Errorf("route %q in a subset but not in getRoutes()", name)
+		}
+	}
+}
+
+// TestAdminRoutesMembership pins the exact admin-family membership against issue
+// #215 Scope §1 so a future edit cannot quietly move an admin route into the
+// always-on peer set (which the pkg/goSignalsServer wrapper would then fail to
+// mount) or vice versa.
+func TestAdminRoutesMembership(t *testing.T) {
+	h := &HttpRouter{sa: &SignalsApplication{}}
+
+	wantAdmin := []string{
+		"StreamDelete", "ListStreamStates", "GetStreamState", "StreamGet",
+		"StreamCreate", "CreateServer", "ServerList", "ServerGet", "ServerUpdate",
+		"ServerDelete", "StreamReplace", "StreamPatch", "UpdateStatus", "GetStatus",
+		"AddSubject", "RemoveSubject", "ReviewSubjectFilter", "CreateKey",
+		"CreateKeyLegacy", "KeyDelete", "JwksIssuers", "JwksSummaries",
+	}
+	sort.Strings(wantAdmin)
+
+	got := make([]string, 0)
+	for name := range nameSet(h.adminRoutes()) {
+		got = append(got, name)
+	}
+	sort.Strings(got)
+
+	if len(got) != len(wantAdmin) {
+		t.Fatalf("admin route count = %d, want %d\n got=%v\nwant=%v",
+			len(got), len(wantAdmin), got, wantAdmin)
+	}
+	for i := range wantAdmin {
+		if got[i] != wantAdmin[i] {
+			t.Errorf("admin route mismatch at %d: got %q want %q", i, got[i], wantAdmin[i])
+		}
+	}
+}
+
+// TestPeerRoutesExcludeAdmin asserts the Q16 peer-set exclusion list (issue
+// #215): the peer subset must contain the always-on routes and must NOT contain
+// any admin route.
+func TestPeerRoutesExcludeAdmin(t *testing.T) {
+	h := &HttpRouter{sa: &SignalsApplication{}}
+	peerNames := nameSet(h.peerRoutes())
+
+	mustBePeer := []string{
+		"Health", "GenerateIat", "RegisterClient", "PollEvents",
+		"ReceivePushEvent", "VerificationRequest", "Introspect", "Revoke",
+		"WellKnownSsfConfigurationGet", "ReceiveSstpEvent", "JwksJson",
+	}
+	for _, n := range mustBePeer {
+		if _, ok := peerNames[n]; !ok {
+			t.Errorf("peer route %q missing from peerRoutes()", n)
+		}
+	}
+
+	mustNotBePeer := []string{
+		"StreamCreate", "StreamDelete", "CreateServer", "CreateKey", "UpdateStatus",
+		"AddSubject", "RemoveSubject", "ReviewSubjectFilter",
+	}
+	for _, n := range mustNotBePeer {
+		if _, ok := peerNames[n]; ok {
+			t.Errorf("admin route %q must NOT be in peerRoutes()", n)
+		}
+	}
+}

--- a/pkg/goSignalsServer/README.md
+++ b/pkg/goSignalsServer/README.md
@@ -1,0 +1,34 @@
+<!-- gosignals-brand-hero -->
+<picture><source media="(prefers-color-scheme: dark)" srcset="../../brand/logo/gosignals-hero-primary.svg"><img src="../../brand/logo/gosignals-hero-on-light.svg" alt="goSignals" height="77"></picture>
+
+# goSignalsServer
+
+This package exposes the community goSignals strategic gateway's REST **admin**
+route surface (stream / server / key / issuer CRUD plus subject management) as a
+`pkg/`-importable handler set that an external Go module can mount onto its own
+`*mux.Router`.
+
+It is the community-side enabler for the enterprise REST-coexistence binary
+(GH #215, PRD i2goSignalsAdmin#164): the enterprise admin REUSES the community
+admin handlers — byte-identical behavior — rather than re-implementing them, and
+toggles their registration behind a runtime flag.
+
+Usage:
+* Build the public services (`pkg/services` over `pkg/dao`) — no `internal/`
+  import is required of the caller.
+* Implement a `StreamStateSink` (`UpdateStreamState` / `RemoveStream` /
+  `NotifySubjectFilterChange`) and construct (or inject) a
+  `*services.SubjectRelayService`.
+* Call `NewAdminSurface(AdminSurfaceConfig{...})` and mount `AdminRoutes()`;
+  omitting them leaves the paths unregistered (route-not-registered 404) — the
+  flag-off behavior.
+
+This package does NOT export the always-on peer plane (`/.well-known/*`,
+`/health`, OAuth, event delivery, bootstrap): those require the
+event/cluster/storage seam and are served by the binary directly. See
+[`docs/adr/0027-pkg-admin-route-surface.md`](../../docs/adr/0027-pkg-admin-route-surface.md).
+
+---
+
+<!-- gosignals-brand-footer -->
+<p align="center"><sub>(C)2026 Independent Identity Inc.</sub></p>

--- a/pkg/goSignalsServer/admin_surface.go
+++ b/pkg/goSignalsServer/admin_surface.go
@@ -1,0 +1,149 @@
+// Package goSignalsServer exposes the community goSignals strategic gateway's
+// REST admin-route surface (stream/server/key/issuer CRUD plus subject
+// management) as a pkg/-importable handler set that an external Go module can
+// mount onto its own *mux.Router. It is the community-side enabler for the
+// enterprise REST-coexistence binary (issue #215, PRD i2goSignalsAdmin#164):
+// the enterprise admin must REUSE the community admin handlers rather than
+// re-implement them, and toggle their registration behind a runtime flag.
+//
+// The wrapper follows the pkg/goSsfServer precedent — it imports internal/server
+// within this module to bind the existing handler bodies (so admin behavior is
+// byte-identical to the in-binary gateway) — but the EXTERNAL caller needs only
+// pkg/ imports: it builds the public services (pkg/services over pkg/dao),
+// supplies a StreamStateSink, calls NewAdminSurface, and mounts AdminRoutes().
+//
+// Out of scope (issue #215): the always-on peer routes (/.well-known/*, /health,
+// OAuth, event delivery, bootstrap) are NOT exposed here — they require the
+// event/cluster/storage seam and are served by the binary directly.
+package goSignalsServer
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/i2-open/i2goSignals/internal/server"
+	"github.com/i2-open/i2goSignals/pkg/authSupport"
+	"github.com/i2-open/i2goSignals/pkg/services"
+	ssfModels "github.com/i2-open/i2goSignals/pkg/ssfModels"
+)
+
+// Route describes one bound admin HTTP route. It mirrors the internal gateway's
+// route shape so a caller can register it on a gorilla/mux router exactly as the
+// in-binary server does. IsIdQuery marks the legacy `?stream_id=` query-binding
+// routes; none of the current admin routes set it, but it is surfaced for
+// registration parity.
+type Route struct {
+	Name        string
+	Method      string
+	Pattern     string
+	HandlerFunc http.HandlerFunc
+	IsIdQuery   bool
+}
+
+// Routes is an ordered admin route set.
+type Routes []Route
+
+// StreamStateSink is the narrow router surface the admin mutation handlers
+// drive. The wrapper supplies it to the bound handlers so an external consumer
+// observes the same three stream-state transitions the in-binary EventRouter
+// would apply:
+//
+//   - UpdateStreamState / RemoveStream — emitted by the four stream-mutation
+//     handlers (StreamCreate/Update/Delete, UpdateStatus) and the SSTP-pair
+//     helpers as a stream is created, reconfigured, or torn down.
+//   - NotifySubjectFilterChange — emitted additionally by the subject-management
+//     handler (/add-subject, /remove-subject) so the stream's PUSH lease owner
+//     invalidates its match-result cache (issue #94).
+//
+// The in-binary gateway passes its real *eventRouter.EventRouter here (it has
+// the identical method set), so wiring through this sink does not change gateway
+// behavior. HYBRID subject-change upstream relay is NOT part of this sink — it
+// is driven through the injected *services.SubjectRelayService instead.
+type StreamStateSink interface {
+	UpdateStreamState(stream *ssfModels.StreamStateRecord)
+	RemoveStream(sid string)
+	NotifySubjectFilterChange(sid string)
+}
+
+// AdminSurfaceConfig holds the PUBLIC handles the admin surface is built from.
+// Every field is a pkg/-exported type, so an external module assembles them
+// without importing anything under internal/. SubjectRelayService is injected
+// directly (it is already pkg/-public) because the subject-management handler
+// drives HYBRID/PASSTHRU upstream relay through it; it is deliberately NOT part
+// of the StreamStateSink.
+type AdminSurfaceConfig struct {
+	StreamService        *services.StreamService
+	KeyService           *services.KeyService
+	ServerService        *services.ServerService
+	TokenService         *services.TokenService
+	SubjectFilterService *services.SubjectFilterService
+	SubjectRelayService  *services.SubjectRelayService
+	Auth                 *authSupport.AuthIssuer
+	DefaultIssuer        string
+	BaseURL              *url.URL
+	// Sink observes stream-state transitions emitted by the admin mutation
+	// handlers. Optional; nil is treated as a no-op sink (a read-only mount).
+	Sink StreamStateSink
+}
+
+// AdminSurface is a bound admin-route surface. Construct it with NewAdminSurface
+// and mount AdminRoutes() onto your own router.
+type AdminSurface struct {
+	app *server.SignalsApplication
+}
+
+// NewAdminSurface binds the community admin handlers against the supplied public
+// services and sink. The returned surface's AdminRoutes() yields the admin route
+// set ready to mount; the peer routes are intentionally absent.
+func NewAdminSurface(cfg AdminSurfaceConfig) *AdminSurface {
+	var sink server.AdminStreamStateSink
+	if cfg.Sink != nil {
+		sink = sinkAdapter{cfg.Sink}
+	}
+	app := server.NewAdminApplication(server.AdminAppDeps{
+		StreamService:        cfg.StreamService,
+		KeyService:           cfg.KeyService,
+		ServerService:        cfg.ServerService,
+		TokenService:         cfg.TokenService,
+		SubjectFilterService: cfg.SubjectFilterService,
+		SubjectRelayService:  cfg.SubjectRelayService,
+		Auth:                 cfg.Auth,
+		DefIssuer:            cfg.DefaultIssuer,
+		BaseUrl:              cfg.BaseURL,
+		Sink:                 sink,
+	})
+	return &AdminSurface{app: app}
+}
+
+// AdminRoutes returns the admin-family route set (issue #215 Scope §1) bound to
+// the surface's handlers. Mount each Route on your own *mux.Router; when a
+// deployment omits them, those paths are simply not registered and resolve to
+// the router's 404 (route-not-registered) — the registration toggle the
+// enterprise REST-admin flag relies on.
+func (a *AdminSurface) AdminRoutes() Routes {
+	internal := a.app.AdminRouteTable()
+	out := make(Routes, 0, len(internal))
+	for _, r := range internal {
+		out = append(out, Route{
+			Name:        r.Name,
+			Method:      r.Method,
+			Pattern:     r.Pattern,
+			HandlerFunc: r.HandlerFunc,
+			IsIdQuery:   r.IsIdQuery,
+		})
+	}
+	return out
+}
+
+// sinkAdapter bridges the pkg StreamStateSink to the internal server sink
+// interface. The two have identical method sets; this adapter exists only to
+// keep the internal interface internal while the public one is pkg/-typed.
+type sinkAdapter struct {
+	s StreamStateSink
+}
+
+func (a sinkAdapter) UpdateStreamState(stream *ssfModels.StreamStateRecord) {
+	a.s.UpdateStreamState(stream)
+}
+func (a sinkAdapter) RemoveStream(sid string)              { a.s.RemoveStream(sid) }
+func (a sinkAdapter) NotifySubjectFilterChange(sid string) { a.s.NotifySubjectFilterChange(sid) }

--- a/pkg/goSignalsServer/admin_surface_test.go
+++ b/pkg/goSignalsServer/admin_surface_test.go
@@ -1,0 +1,412 @@
+// Package goSignalsServer_test is an EXTERNAL test package (package
+// goSignalsServer_test, not goSignalsServer). Its import list is the load-bearing
+// acceptance criterion of issue #215: it imports ONLY pkg/... packages plus the
+// goSignalsServer package itself and never anything under internal/. The test
+// thereby proves that an out-of-tree consumer (the enterprise REST-coexistence
+// binary) can build the community admin handler set from public services, mount
+// it behind a runtime flag, and observe the stream/subject-filter state
+// transitions — all without an internal/ import.
+package goSignalsServer_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/i2-open/i2goSignals/pkg/authSupport"
+	"github.com/i2-open/i2goSignals/pkg/dao/memory"
+	"github.com/i2-open/i2goSignals/pkg/goSet"
+	"github.com/i2-open/i2goSignals/pkg/goSignalsServer"
+	"github.com/i2-open/i2goSignals/pkg/services"
+	model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+)
+
+const testDefaultIssuer = "DEFAULT"
+
+// recordingSink is a test StreamStateSink (the 3-method seam the caller
+// implements per the #215 contract) that records every transition the admin
+// mutation handlers emit, so the test can assert which ones fired.
+type recordingSink struct {
+	mu             sync.Mutex
+	updated        []*model.StreamStateRecord
+	removed        []string
+	filterNotified []string
+}
+
+func (s *recordingSink) UpdateStreamState(stream *model.StreamStateRecord) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.updated = append(s.updated, stream)
+}
+
+func (s *recordingSink) RemoveStream(sid string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.removed = append(s.removed, sid)
+}
+
+func (s *recordingSink) NotifySubjectFilterChange(sid string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.filterNotified = append(s.filterNotified, sid)
+}
+
+func (s *recordingSink) updateCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.updated)
+}
+
+func (s *recordingSink) removeCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.removed)
+}
+
+func (s *recordingSink) filterCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.filterNotified)
+}
+
+var _ goSignalsServer.StreamStateSink = (*recordingSink)(nil)
+
+// adminFixture bundles the public services, the constructed admin surface, the
+// recording sink, and a flag recording whether the injected SubjectRelayService's
+// resolve closure fired (i.e. whether a HYBRID upstream relay was attempted).
+type adminFixture struct {
+	surface  *goSignalsServer.AdminSurface
+	sink     *recordingSink
+	auth     *authSupport.AuthIssuer
+	relayHit *relayProbe
+}
+
+// relayProbe records whether the injected *services.SubjectRelayService was
+// driven into its upstream-relay branch. RelayHybrid only reaches resolve() when
+// the handler resolved a HYBRID downstream against a NONE upstream — so a fired
+// resolve closure proves the subject change relayed through the injected relay
+// service (the AC: "HYBRID subject change relays through the injected
+// *services.SubjectRelayService").
+type relayProbe struct {
+	mu       sync.Mutex
+	resolved int
+}
+
+func (p *relayProbe) hit() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.resolved++
+}
+
+func (p *relayProbe) count() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.resolved
+}
+
+// newAdminFixture builds the public services over the in-memory DAO and
+// constructs an AdminSurface from them. It uses ONLY pkg/ constructors:
+// pkg/dao/memory DAOs, pkg/services service constructors, and the AuthIssuer the
+// KeyService exposes — the same pattern pkg/services' own tests use. No
+// dbProviders.OpenPersistence (which is internal/) is involved.
+func newAdminFixture(t *testing.T) *adminFixture {
+	t.Helper()
+	ctx := context.Background()
+
+	// KeyService with a real signing key so the AuthIssuer can both mint and
+	// validate the admin bearer the handlers gate on.
+	keyService := services.NewKeyService(memory.NewKeyDAO(), testDefaultIssuer, nil, nil)
+	if err := keyService.InitializeTokenKey(ctx, testDefaultIssuer); err != nil {
+		t.Fatalf("InitializeTokenKey: %v", err)
+	}
+	auth := keyService.GetAuthIssuer()
+
+	streamService := services.NewStreamService(
+		memory.NewStreamDAO(), keyService, testDefaultIssuer, services.StreamServiceConfig{})
+	serverService := services.NewServerService(memory.NewServerDAO())
+	tokenService := services.NewTokenService(memory.NewTokenDAO())
+	subjectFilterService := services.NewSubjectFilterService(memory.NewSubjectFilterDAO())
+
+	probe := &relayProbe{}
+	// A SubjectRelayService whose closures resolve a NONE upstream receiver
+	// matching the created HYBRID stream's issuer. The resolve closure records
+	// that it ran (the observation point) and returns a benign UpstreamConn; the
+	// handler tolerates a relay that does not reach a live upstream, so no HTTP
+	// server is needed to observe the relay being driven.
+	relayService := services.NewSubjectRelayService(
+		// listReceivers: one NONE upstream whose Iss matches the created stream's
+		// Iss (DefIssuer), so ResolveRelayTarget finds exactly one target.
+		func(context.Context) ([]model.StreamStateRecord, error) {
+			rx := model.StreamStateRecord{DefaultSubjects: model.DefaultSubjectsNone}
+			rx.StreamConfiguration.Id = "upstream-receiver"
+			rx.StreamConfiguration.Iss = testDefaultIssuer
+			remote := "remote-stream-id"
+			rx.RemoteStreamId = &remote
+			return []model.StreamStateRecord{rx}, nil
+		},
+		// listTransmitters: empty interested-set siblings, so a fresh add is a
+		// 0->1 transition and RelayHybrid engages.
+		func(context.Context) ([]model.StreamStateRecord, error) {
+			return nil, nil
+		},
+		// interested: no sibling is interested (0->1 transition).
+		func(context.Context, *model.StreamStateRecord, *goSet.SubjectIdentifier) bool {
+			return false
+		},
+		// resolve: the observation point. Firing this proves the handler drove
+		// RelayHybrid into its upstream-relay branch.
+		func(context.Context, *model.StreamStateRecord) (*services.UpstreamConn, error) {
+			probe.hit()
+			return &services.UpstreamConn{
+				Config:     &model.TransmitterConfiguration{},
+				HttpClient: http.DefaultClient,
+			}, nil
+		},
+	)
+
+	base, _ := url.Parse("https://gateway.example")
+	sink := &recordingSink{}
+	surface := goSignalsServer.NewAdminSurface(goSignalsServer.AdminSurfaceConfig{
+		StreamService:        streamService,
+		KeyService:           keyService,
+		ServerService:        serverService,
+		TokenService:         tokenService,
+		SubjectFilterService: subjectFilterService,
+		SubjectRelayService:  relayService,
+		Auth:                 auth,
+		DefaultIssuer:        testDefaultIssuer,
+		BaseURL:              base,
+		Sink:                 sink,
+	})
+
+	return &adminFixture{surface: surface, sink: sink, auth: auth, relayHit: probe}
+}
+
+// adminBearer mints an admin-scoped bearer (Roles ["admin","stream"]) the admin
+// handlers accept, using only the public AuthIssuer.IssueStreamClientToken.
+func (f *adminFixture) adminBearer(t *testing.T, projectId string) string {
+	t.Helper()
+	client := model.SsfClient{Id: bson.NewObjectID(), ProjectIds: []string{projectId}}
+	tok, err := f.auth.IssueStreamClientToken(client, projectId, true, "")
+	if err != nil {
+		t.Fatalf("IssueStreamClientToken: %v", err)
+	}
+	return tok
+}
+
+// mountAdmin registers the admin routes onto a fresh gorilla/mux router, exactly
+// as an enterprise REST-coexistence binary would when its admin flag is on.
+func mountAdmin(surface *goSignalsServer.AdminSurface) *mux.Router {
+	router := mux.NewRouter().StrictSlash(true).UseEncodedPath()
+	for _, rt := range surface.AdminRoutes() {
+		r := router.NewRoute().Name(rt.Name).Path(rt.Pattern).HandlerFunc(rt.HandlerFunc)
+		if rt.Method != "" {
+			r.Methods(rt.Method)
+		}
+	}
+	return router
+}
+
+// doJSON drives one request with the given admin bearer and returns the response
+// recorder.
+func doJSON(t *testing.T, router *mux.Router, method, target, bearer string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	var rdr *bytes.Reader
+	if body != nil {
+		rdr = bytes.NewReader(body)
+	} else {
+		rdr = bytes.NewReader(nil)
+	}
+	req := httptest.NewRequest(method, target, rdr)
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	return rr
+}
+
+// TestAdminRoutesResolveAndOmittedRoute404 is AC#1 (the headline criterion): an
+// admin route RESOLVES when mounted, and the same path on a router that did NOT
+// mount the admin routes returns route-not-registered 404 — the enterprise
+// REST-admin flag's on/off behavior ("omitting => route-not-registered 404").
+func TestAdminRoutesResolveAndOmittedRoute404(t *testing.T) {
+	f := newAdminFixture(t)
+	bearer := f.adminBearer(t, "proj-1")
+
+	// Mounted: GET /states resolves to a handler (anything other than the
+	// router's own 404 proves the route is registered). With a valid admin
+	// bearer this read-only route returns 200.
+	mounted := mountAdmin(f.surface)
+	rr := doJSON(t, mounted, http.MethodGet, "/states", bearer, nil)
+	if rr.Code == http.StatusNotFound {
+		t.Fatalf("mounted /states should resolve to the admin handler, got 404 (route not registered)")
+	}
+	if rr.Code != http.StatusOK {
+		t.Fatalf("mounted /states: expected 200, got %d (body=%q)", rr.Code, rr.Body.String())
+	}
+
+	// Omitted: a router with NO admin routes mounted returns 404 for the same
+	// path — the route is simply not registered (the flag-off behavior).
+	empty := mux.NewRouter().StrictSlash(true).UseEncodedPath()
+	rr = doJSON(t, empty, http.MethodGet, "/states", bearer, nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("omitted /states: expected 404 (route-not-registered), got %d", rr.Code)
+	}
+}
+
+// TestAdminAuthGate confirms the mounted admin handlers gate on the admin
+// authorization context: a request with no bearer is rejected (not 200), and the
+// minted admin bearer is accepted — proving the test drives a VALID admin
+// authorization context through public inputs only.
+func TestAdminAuthGate(t *testing.T) {
+	f := newAdminFixture(t)
+	mounted := mountAdmin(f.surface)
+
+	// No bearer: the handler's inline ValidateAuthorizationAny rejects it.
+	rr := doJSON(t, mounted, http.MethodGet, "/states", "", nil)
+	if rr.Code == http.StatusOK {
+		t.Fatalf("unauthenticated /states must not be authorized, got 200")
+	}
+
+	// Admin bearer: accepted.
+	bearer := f.adminBearer(t, "proj-1")
+	rr = doJSON(t, mounted, http.MethodGet, "/states", bearer, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("admin /states: expected 200, got %d (body=%q)", rr.Code, rr.Body.String())
+	}
+}
+
+// TestStreamMutationDrivesSink drives a stream create and delete through the
+// admin routes and asserts the sink's UpdateStreamState fired on create and that
+// RemoveStream (and a disabling UpdateStreamState) fired on delete.
+func TestStreamMutationDrivesSink(t *testing.T) {
+	f := newAdminFixture(t)
+	mounted := mountAdmin(f.surface)
+	bearer := f.adminBearer(t, "proj-1")
+
+	// Create a minimal PUSH transmitter stream. After a successful CreateStream
+	// the handler unconditionally calls EventRouter.UpdateStreamState, which the
+	// adminRouterAdapter forwards to our sink.
+	createBody := mustJSON(t, map[string]any{
+		"delivery": map[string]any{
+			"method":       "urn:ietf:rfc:8935",
+			"endpoint_url": "https://receiver.example/events",
+		},
+	})
+	rr := doJSON(t, mounted, http.MethodPost, "/stream", bearer, createBody)
+	if rr.Code != http.StatusOK && rr.Code != http.StatusCreated {
+		t.Fatalf("POST /stream: expected 200/201, got %d (body=%q)", rr.Code, rr.Body.String())
+	}
+	if f.sink.updateCount() == 0 {
+		t.Fatalf("expected UpdateStreamState to fire on stream create, got none")
+	}
+	streamID := streamIDFromCreate(t, rr.Body.Bytes())
+
+	// Delete the stream: addressed via ?stream_id=<id> (which also fills the
+	// auth context's StreamId). The handler disables (UpdateStreamState) then
+	// RemoveStream(sid).
+	updatesBefore := f.sink.updateCount()
+	rr = doJSON(t, mounted, http.MethodDelete, "/stream?stream_id="+url.QueryEscape(streamID), bearer, nil)
+	if rr.Code != http.StatusOK && rr.Code != http.StatusNoContent {
+		t.Fatalf("DELETE /stream: expected 200/204, got %d (body=%q)", rr.Code, rr.Body.String())
+	}
+	if f.sink.removeCount() == 0 {
+		t.Fatalf("expected RemoveStream to fire on stream delete, got none")
+	}
+	if removed := f.sink.removed; removed[len(removed)-1] != streamID {
+		t.Fatalf("RemoveStream(sid): expected %q, got %q", streamID, removed[len(removed)-1])
+	}
+	if f.sink.updateCount() <= updatesBefore {
+		t.Fatalf("expected a disabling UpdateStreamState on delete (before=%d after=%d)",
+			updatesBefore, f.sink.updateCount())
+	}
+}
+
+// TestSubjectChangeDrivesSinkAndRelay drives /add-subject on a HYBRID stream and
+// asserts NotifySubjectFilterChange fired on the sink AND that the change relayed
+// through the injected *services.SubjectRelayService (the resolve probe fired).
+func TestSubjectChangeDrivesSinkAndRelay(t *testing.T) {
+	// /add-subject is gated by the server-wide I2SIG_SUBJECT_FILTERING setting
+	// (read from the environment at request time); enable it for this test.
+	t.Setenv("I2SIG_SUBJECT_FILTERING", "ENABLED")
+
+	f := newAdminFixture(t)
+	mounted := mountAdmin(f.surface)
+	bearer := f.adminBearer(t, "proj-1")
+
+	// Create a HYBRID transmitter stream whose Iss defaults to DefIssuer
+	// (DEFAULT), matching the relay fixture's NONE upstream receiver. The
+	// NONE baseline makes a fresh Add a genuine 0->1 delivery transition, so the
+	// filter service returns RelayDecisionImmediate and the handler relays
+	// upstream (under ALL, an Add is a no-op and never relays).
+	createBody := mustJSON(t, map[string]any{
+		"delivery": map[string]any{
+			"method":       "urn:ietf:rfc:8935",
+			"endpoint_url": "https://receiver.example/events",
+		},
+		"subject_filter_mode": model.SubjectFilterModeHybrid,
+		"default_subjects":    model.DefaultSubjectsNone,
+	})
+	rr := doJSON(t, mounted, http.MethodPost, "/stream", bearer, createBody)
+	if rr.Code != http.StatusOK && rr.Code != http.StatusCreated {
+		t.Fatalf("POST /stream (hybrid): expected 200/201, got %d (body=%q)", rr.Code, rr.Body.String())
+	}
+	streamID := streamIDFromCreate(t, rr.Body.Bytes())
+
+	// Add a subject to the HYBRID stream. The handler applies the local filter,
+	// calls NotifySubjectFilterChange(sid) on the router sink, and (HYBRID +
+	// immediate decision) drives RelayHybrid through the injected relay service.
+	addBody := mustJSON(t, map[string]any{
+		"stream_id": streamID,
+		"subject":   map[string]any{"format": "email", "email": "alice@example.com"},
+		"verified":  true,
+	})
+	rr = doJSON(t, mounted, http.MethodPost, "/add-subject", bearer, addBody)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("POST /add-subject: expected 200, got %d (body=%q)", rr.Code, rr.Body.String())
+	}
+	if f.sink.filterCount() == 0 {
+		t.Fatalf("expected NotifySubjectFilterChange to fire on /add-subject, got none")
+	}
+	if notified := f.sink.filterNotified; notified[len(notified)-1] != streamID {
+		t.Fatalf("NotifySubjectFilterChange(sid): expected %q, got %q", streamID, notified[len(notified)-1])
+	}
+	if f.relayHit.count() == 0 {
+		t.Fatalf("expected the HYBRID subject change to relay through the injected SubjectRelayService, got none")
+	}
+}
+
+// mustJSON marshals v or fails the test.
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// streamIDFromCreate extracts the created stream_id from a POST /stream response.
+func streamIDFromCreate(t *testing.T, body []byte) string {
+	t.Helper()
+	var resp struct {
+		StreamId string `json:"stream_id"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode create response: %v (body=%q)", err, string(body))
+	}
+	if resp.StreamId == "" {
+		t.Fatalf("create response carried no stream_id (body=%q)", string(body))
+	}
+	return resp.StreamId
+}


### PR DESCRIPTION
Closes #215.

## What

Exports the community goSignals admin-route surface as a `pkg/`-importable handler set (`pkg/goSignalsServer`) so the enterprise REST-coexistence binary (`I2SIG_REST_ADMIN=on`, enterprise#76 under PRD admin#164) can **reuse** the community admin handlers rather than re-implement them, toggled behind a runtime flag.

## How

- **`internal/server/routers.go`** — pure partition refactor of `getRoutes()` into `peerRoutes()` (always-on: `.well-known`, health, OAuth, event delivery, bootstrap) and `adminRoutes()` (the 22-route admin family). `getRoutes()` signature and behavior are unchanged; adds `AdminRouteTable()`.
- **`internal/server/admin_surface.go`** — `NewAdminApplication` builds an admin-only `*SignalsApplication` from public service handles plus a narrow 3-method `AdminStreamStateSink` (`UpdateStreamState`/`RemoveStream`/`NotifySubjectFilterChange`), without standing up the cluster runtime. Admin handler bodies are reused verbatim, so REST behavior is byte-identical to the in-binary gateway.
- **`pkg/goSignalsServer/admin_surface.go`** — `NewAdminSurface(AdminSurfaceConfig)` / `AdminRoutes()`. Follows the `pkg/goSsfServer` precedent: imports `internal/server` within this module, but the **external caller needs only `pkg/` imports** (public services over `pkg/dao`, a `StreamStateSink`).

## Scope / impact

- Purely additive — no exported symbol removed or renamed. New package `pkg/goSignalsServer`.
- No impact on the `cmd/goSignals` CLI (only a test-only `internal/server` import; nothing it relies on changed) or on the `i2goSignalsAdmin` repo (separate module, pins an earlier release, imports none of the touched packages).
- Peer/event/cluster plane is deliberately out of scope (issue #215).

## Tests

- `internal/server/routers_split_test.go` — proves peer∪admin is a disjoint partition of `getRoutes()` and pins exact admin-family membership.
- `pkg/goSignalsServer/admin_surface_test.go` — external (`_test` package, zero `internal/` imports): routes resolve + auth gate + sink/relay are driven on stream and subject mutations.
- `go test -race ./...` green; `go vet` clean; `gofmt -l` clean.

See `docs/adr/0027-pkg-admin-route-surface.md` (lineage ADR 0021).
