### PR TITLE
Slice 4A: export the event router to pkg/ + metering observation hook (#218)

### DIFF
--- a/internal/eventRouter/event_router.go
+++ b/internal/eventRouter/event_router.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -61,6 +62,11 @@ type EventRouter interface {
 	SstpServerHandler(ctx context.Context, pairId string, inbound goSetSstp.Message, parsedIn []SstpInboundSet) (goSetSstp.Message, int)
 	Shutdown()
 	SetEventCounter(inCounter, outCounter *prometheus.CounterVec)
+	// RegisterMeteringObserver installs the subject-carrying metering observer
+	// (issue #218). It is distinct from SetEventCounter — the Prometheus path is
+	// untouched — and fires once per routed event (ingress and each egress) with
+	// the event's {stream_urn, direction, subject}.
+	RegisterMeteringObserver(observer MeteringObserver)
 	PreInitializeCounter(stream *model.StreamStateRecord)
 	GetPushStreamCnt() float64
 	GetPollStreamCnt() float64
@@ -137,7 +143,11 @@ type router struct {
 	pushDelivery         delivery.PushDelivery
 	sstpDelivery         delivery.SstpDelivery
 	eventsIn, eventsOut  *prometheus.CounterVec
-	stats                statsTracker
+	// meteringObserver holds the optional subject-carrying metering observer
+	// (issue #218), read lock-free on the routing path. Distinct from the
+	// Prometheus counters above; nil unless an embedder registers one.
+	meteringObserver atomic.Pointer[meteringObserverHolder]
+	stats            statsTracker
 
 	httpClient          *http.Client
 	clusterSecret       string
@@ -761,6 +771,7 @@ func (r *router) HandleEvent(eventToken *goSet.SecurityEventToken, rawEvent stri
 		return err
 	}
 	r.IncrementCounter(streamState, eventToken, true)
+	r.observeMeteredEvent(streamState.StreamConfiguration.Id, DirectionIngress, eventToken)
 
 	// SSTP-server inbound is terminal: the rx side imports the SET for local
 	// consumption (RouteModeImport). It is not fanned out to RFC8935/RFC8936
@@ -783,6 +794,7 @@ func (r *router) HandleEvent(eventToken *goSet.SecurityEventToken, rawEvent stri
 		if r.eventService.MatchesStream(&stream, event) {
 
 			eventLogger.Info("ROUTER: Selected", "sid", stream.StreamConfiguration.Id, "jti", event.Jti, "mode", "PUSH", "types", event.Types)
+			r.observeMeteredEvent(stream.StreamConfiguration.Id, DirectionEgress, eventToken)
 
 			// The transmitter API will forward or sign/encrypt the event based on route mode at delivery time!
 			err = r.eventService.AddEventToStream(r.ctx, event.Jti, stream.Id.Hex())
@@ -810,6 +822,7 @@ func (r *router) HandleEvent(eventToken *goSet.SecurityEventToken, rawEvent stri
 
 		if r.eventService.MatchesStream(&pollStream, event) {
 			eventLogger.Info("ROUTER: Selected", "sid", pollStream.StreamConfiguration.Id, "jti", event.Jti, "mode", "POLL", "types", event.Types)
+			r.observeMeteredEvent(pollStream.StreamConfiguration.Id, DirectionEgress, eventToken)
 
 			// The transmitter API will forward or sign/encrypt the event based on route mode at delivery time!
 			err = r.eventService.AddEventToStream(r.ctx, event.Jti, pollStream.Id.Hex())
@@ -849,6 +862,7 @@ func (r *router) routeEventToSstpPairsLocked(event *model.EventRecord) {
 		// GetEventIds(txSid) fallback finds nothing and the event is silently lost
 		// (not even backfill-recoverable). AddEvent only Insert()s the token.
 		txSid := pair.StreamConfiguration.Id
+		r.observeMeteredEvent(txSid, DirectionEgress, &event.Event)
 		if err := r.eventService.AddEventToStream(r.ctx, event.Jti, txSid); err != nil {
 			eventLogger.Error("ROUTER: Error adding event to SSTP-client pair", "pairId", pairId, "sid", txSid, "jti", event.Jti, "error", err)
 		}
@@ -872,6 +886,7 @@ func (r *router) routeEventToSstpPairsLocked(event *model.EventRecord) {
 		// server runner's drainSstpOutbound GetEventIds(txSid) fallback finds it. The
 		// server takes no client lease — every node may serve the long-poll — so we do
 		// not gate this on lease ownership.
+		r.observeMeteredEvent(txSid, DirectionEgress, &event.Event)
 		if err := r.eventService.AddEventToStream(r.ctx, event.Jti, txSid); err != nil {
 			eventLogger.Error("ROUTER: Error adding event to SSTP-server pair", "sid", txSid, "jti", event.Jti, "error", err)
 		}

--- a/internal/eventRouter/metering.go
+++ b/internal/eventRouter/metering.go
@@ -1,0 +1,83 @@
+package eventRouter
+
+import (
+	"github.com/i2-open/i2goSignals/pkg/goSet"
+)
+
+// Direction labels a metering observation as an inbound (ingress) or outbound
+// (egress) routed event. It mirrors the In/Out axis of the Prometheus event
+// counters (IncrementCounter) but is kept deliberately separate from them: the
+// metering observer is a distinct, subject-carrying seam (issue #218).
+type Direction string
+
+const (
+	// DirectionIngress marks an event accepted into the router on an inbound
+	// stream — the point HandleEvent has persisted-and-counted it.
+	DirectionIngress Direction = "ingress"
+	// DirectionEgress marks an event routed out to a matching transmitter
+	// (business) stream during fan-out.
+	DirectionEgress Direction = "egress"
+)
+
+// MeteringObservation is the per-routed-event record handed to a
+// MeteringObserver. Unlike the Prometheus counter hook (SetEventCounter) it
+// carries the event Subject, which distinct-set metering (MAS) requires and a
+// counter cannot express.
+type MeteringObservation struct {
+	// StreamURN identifies the business stream the event was routed on: the
+	// inbound stream id for DirectionIngress, the matched transmitter stream
+	// id for DirectionEgress.
+	StreamURN string
+	// Direction is ingress or egress.
+	Direction Direction
+	// Subject is the event's RFC9493 subject identifier (the SET sub_id
+	// claim), or nil when the event carries no subject (e.g. some operational
+	// events). It is read from the same field the subject filter selects on.
+	Subject *goSet.SubjectIdentifier
+}
+
+// MeteringObserver receives one MeteringObservation per routed event. It is the
+// subject-carrying metering seam the enterprise superset registers to aggregate
+// business-stream usage; community itself registers none, so /metrics and the
+// Prometheus path are unaffected (issue #218).
+type MeteringObserver interface {
+	ObserveEvent(observation MeteringObservation)
+}
+
+// meteringObserverHolder boxes a MeteringObserver so it can live in an
+// atomic.Pointer — a lock-free read on the hot routing path with no extra
+// mutex contention against the router's RWMutex.
+type meteringObserverHolder struct {
+	observer MeteringObserver
+}
+
+// RegisterMeteringObserver installs (or replaces) the metering observer. It is
+// safe to call after construction and concurrently with routing; a nil observer
+// clears it. The read side is lock-free, so HandleEvent's fan-out pays only an
+// atomic load per event when no observer is registered.
+func (r *router) RegisterMeteringObserver(observer MeteringObserver) {
+	r.meteringObserver.Store(&meteringObserverHolder{observer: observer})
+}
+
+func (r *router) loadMeteringObserver() MeteringObserver {
+	holder := r.meteringObserver.Load()
+	if holder == nil {
+		return nil
+	}
+	return holder.observer
+}
+
+// observeMeteredEvent emits one MeteringObservation when an observer is
+// registered. A nil observer or nil token is a no-op. The Subject is read from
+// the SET sub_id claim.
+func (r *router) observeMeteredEvent(streamURN string, direction Direction, token *goSet.SecurityEventToken) {
+	observer := r.loadMeteringObserver()
+	if observer == nil || token == nil {
+		return
+	}
+	observer.ObserveEvent(MeteringObservation{
+		StreamURN: streamURN,
+		Direction: direction,
+		Subject:   token.SubjectId,
+	})
+}

--- a/internal/eventRouter/metering_test.go
+++ b/internal/eventRouter/metering_test.go
@@ -1,0 +1,134 @@
+package eventRouter
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/i2-open/i2goSignals/pkg/goSet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingMeteringObserver captures every MeteringObservation the router emits
+// so a test can assert direction, stream_urn, and subject after driving an
+// event through the live routing path.
+type recordingMeteringObserver struct {
+	mu           sync.Mutex
+	observations []MeteringObservation
+}
+
+func (o *recordingMeteringObserver) ObserveEvent(observation MeteringObservation) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.observations = append(o.observations, observation)
+}
+
+func (o *recordingMeteringObserver) snapshot() []MeteringObservation {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	out := make([]MeteringObservation, len(o.observations))
+	copy(out, o.observations)
+	return out
+}
+
+func (o *recordingMeteringObserver) byDirection(dir Direction) []MeteringObservation {
+	var out []MeteringObservation
+	for _, obs := range o.snapshot() {
+		if obs.Direction == dir {
+			out = append(out, obs)
+		}
+	}
+	return out
+}
+
+// TestRegisterMeteringObserver_FiresIngressOnLivePath is the ingress half of the
+// production-wiring AC (#218): it registers a metering observer on a real router
+// and drives one event through HandleEvent on the live routing path (not a
+// fake). The observer must fire exactly one ingress observation carrying the
+// inbound stream's urn and the event's subject identity.
+func TestRegisterMeteringObserver_FiresIngressOnLivePath(t *testing.T) {
+	s := setupDedupRouterPollStream(t)
+
+	observer := &recordingMeteringObserver{}
+	s.h.router.RegisterMeteringObserver(observer)
+
+	token := newRiscToken("metering-ingress-jti", dupTestIssuer, s.audience)
+	token.SubjectId = (&goSet.SubjectIdentifier{}).AddEmail("alice@example.com")
+
+	require.NoError(t, s.h.router.HandleEvent(token, `{"raw":true}`, s.streamID))
+
+	ingress := observer.byDirection(DirectionIngress)
+	require.Len(t, ingress, 1, "exactly one ingress observation per accepted event")
+	assert.Equal(t, s.streamID, ingress[0].StreamURN, "ingress urn is the inbound stream id")
+	require.NotNil(t, ingress[0].Subject, "ingress observation must carry the event subject")
+	assert.Equal(t, "alice@example.com", ingress[0].Subject.Email, "ingress subject identity captured")
+}
+
+// TestRegisterMeteringObserver_FiresEgressOnLivePath is the egress half of the
+// production-wiring AC (#218): the same event, driven through the live router,
+// is fanned out to the matching poll-transmit (business) stream. The observer
+// must fire an egress observation carrying the matched transmitter stream's urn
+// and the same subject identity.
+func TestRegisterMeteringObserver_FiresEgressOnLivePath(t *testing.T) {
+	s := setupDedupRouterPollStream(t)
+
+	observer := &recordingMeteringObserver{}
+	s.h.router.RegisterMeteringObserver(observer)
+
+	token := newRiscToken("metering-egress-jti", dupTestIssuer, s.audience)
+	token.SubjectId = (&goSet.SubjectIdentifier{}).AddEmail("bob@example.com")
+
+	require.NoError(t, s.h.router.HandleEvent(token, `{"raw":true}`, s.streamID))
+
+	egress := observer.byDirection(DirectionEgress)
+	require.Len(t, egress, 1, "exactly one egress observation per matched transmitter stream")
+	assert.Equal(t, s.streamID, egress[0].StreamURN, "egress urn is the matched transmitter stream id")
+	require.NotNil(t, egress[0].Subject, "egress observation must carry the event subject")
+	assert.Equal(t, "bob@example.com", egress[0].Subject.Email, "egress subject identity captured")
+}
+
+// TestMeteringObserver_DistinctFromPrometheusCounter proves the metering hook is
+// a separate seam from SetEventCounter (#218 AC): a registered observer fires
+// while the Prometheus inbound counter increments exactly once, unchanged. The
+// two surfaces coexist — the observer carries the subject the counter cannot,
+// and registering it does not perturb /metrics.
+func TestMeteringObserver_DistinctFromPrometheusCounter(t *testing.T) {
+	s := setupDedupRouterPollStream(t)
+
+	observer := &recordingMeteringObserver{}
+	s.h.router.RegisterMeteringObserver(observer)
+
+	token := newRiscToken("metering-distinct-jti", dupTestIssuer, s.audience)
+	token.SubjectId = (&goSet.SubjectIdentifier{}).AddEmail("carol@example.com")
+
+	require.NoError(t, s.h.router.HandleEvent(token, `{"raw":true}`, s.streamID))
+
+	// Prometheus path is unchanged: exactly one inbound count, as the
+	// observer-free dedup tests already assert.
+	assert.InDelta(t, 1.0, inCounterValue(t, s.inCounter, s.streamID), 0.0001,
+		"registering a metering observer must not change the Prometheus inbound counter")
+
+	// The distinct metering seam fired both directions, carrying the subject the
+	// Prometheus counter cannot express.
+	assert.Len(t, observer.byDirection(DirectionIngress), 1, "one ingress observation")
+	assert.Len(t, observer.byDirection(DirectionEgress), 1, "one egress observation")
+}
+
+// TestMeteringObserver_DuplicateJTI_NotObserved confirms the metering seam
+// inherits the router's JTI-dedup short-circuit: a duplicate ingestion that the
+// Prometheus path already suppresses produces no second observation either.
+func TestMeteringObserver_DuplicateJTI_NotObserved(t *testing.T) {
+	s := setupDedupRouterPollStream(t)
+
+	observer := &recordingMeteringObserver{}
+	s.h.router.RegisterMeteringObserver(observer)
+
+	token := newRiscToken("metering-dup-jti", dupTestIssuer, s.audience)
+	token.SubjectId = (&goSet.SubjectIdentifier{}).AddEmail("dave@example.com")
+
+	require.NoError(t, s.h.router.HandleEvent(token, `{"first":true}`, s.streamID))
+	require.NoError(t, s.h.router.HandleEvent(token, `{"second":true}`, s.streamID))
+
+	assert.Len(t, observer.byDirection(DirectionIngress), 1, "duplicate JTI must not re-observe ingress")
+	assert.Len(t, observer.byDirection(DirectionEgress), 1, "duplicate JTI must not re-observe egress")
+}

--- a/internal/server/admin_surface.go
+++ b/internal/server/admin_surface.go
@@ -160,6 +160,10 @@ func (a *adminRouterAdapter) SetEventCounter(*prometheus.CounterVec, *prometheus
 	a.unsupported("SetEventCounter")
 }
 
+func (a *adminRouterAdapter) RegisterMeteringObserver(eventRouter.MeteringObserver) {
+	a.unsupported("RegisterMeteringObserver")
+}
+
 func (a *adminRouterAdapter) PreInitializeCounter(*model.StreamStateRecord) {
 	a.unsupported("PreInitializeCounter")
 }

--- a/internal/server/wake_sstp_test.go
+++ b/internal/server/wake_sstp_test.go
@@ -80,6 +80,7 @@ func (rr *recordingRouter) SstpServerHandler(context.Context, string, goSetSstp.
 }
 func (rr *recordingRouter) Shutdown()                                                      {}
 func (rr *recordingRouter) SetEventCounter(*prometheus.CounterVec, *prometheus.CounterVec) {}
+func (rr *recordingRouter) RegisterMeteringObserver(eventRouter.MeteringObserver)          {}
 func (rr *recordingRouter) PreInitializeCounter(*model.StreamStateRecord)                  {}
 func (rr *recordingRouter) GetPushStreamCnt() float64                                      { return 0 }
 func (rr *recordingRouter) GetPollStreamCnt() float64                                      { return 0 }

--- a/pkg/eventRouter/event_router.go
+++ b/pkg/eventRouter/event_router.go
@@ -1,0 +1,73 @@
+// Package eventRouter is the exported embedding surface for the community
+// business-stream event router. It re-exports the minimal construct-and-drive
+// API plus the subject-carrying metering observer hook so an out-of-tree
+// superset (the enterprise edition, enterprise#86) can embed and meter the
+// router without importing internal/ (issue #218).
+//
+// Boundary note — reconciles PRD #50 / PR #54. PR #54 deliberately kept the
+// router in internal/eventRouter to restore the pkg/internal seam. This facade
+// does NOT move or fork that router: the implementation, its tests, and the
+// pkg/internal discipline #50 established all stay in internal/eventRouter.
+// What crosses the boundary is only this deliberately narrow, exported wrapper —
+// type aliases over the internal contract plus one constructor — so #50's seam
+// is preserved (community keeps a single router) while the enterprise superset
+// gains a no-internal-import embedding point. The enterprise product owner
+// authorized the export direction on 2026-06-27.
+package eventRouter
+
+import (
+	internalrouter "github.com/i2-open/i2goSignals/internal/eventRouter"
+	"github.com/i2-open/i2goSignals/pkg/goSet"
+	model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+)
+
+// Direction labels a MeteringObservation as ingress or egress.
+type Direction = internalrouter.Direction
+
+const (
+	// DirectionIngress marks an event accepted into the router on an inbound stream.
+	DirectionIngress = internalrouter.DirectionIngress
+	// DirectionEgress marks an event routed out to a matching transmitter stream.
+	DirectionEgress = internalrouter.DirectionEgress
+)
+
+// MeteringObservation is the per-routed-event record carrying {stream_urn,
+// direction, subject}. It is the type a MeteringObserver receives.
+type MeteringObservation = internalrouter.MeteringObservation
+
+// MeteringObserver receives one MeteringObservation per routed event. Implement
+// it in the embedder to aggregate business-stream usage; it carries the event
+// subject that the Prometheus counter hook cannot.
+type MeteringObserver = internalrouter.MeteringObserver
+
+// Deps is the dependency bundle NewBusinessRouter needs. The embedder populates
+// the exported service fields (pkg/services) and supplies a Coordinator value
+// obtained from the persistence layer — it never has to name an internal/ type.
+type Deps = internalrouter.RouterDeps
+
+// BusinessRouter is the minimal construct-and-drive surface an embedder uses:
+// feed inbound events, sync stream state, register the metering observer, and
+// shut down. It is intentionally narrower than the full internal EventRouter
+// (no cluster/SSTP/wake/Prometheus methods) per the minimal-surface AC of #218 —
+// just what the enterprise superset needs to embed and drive the router.
+type BusinessRouter interface {
+	// HandleEvent ingests an inbound SET on stream sid, persists it, and fans it
+	// out to matching transmitter streams. It fires the registered metering
+	// observer once for the ingress and once per egress.
+	HandleEvent(eventToken *goSet.SecurityEventToken, rawEvent string, sid string) error
+	// UpdateStreamState (re)syncs a stream's state into the router.
+	UpdateStreamState(stream *model.StreamStateRecord)
+	// RegisterMeteringObserver installs the subject-carrying metering observer.
+	// Distinct from any Prometheus wiring; /metrics is unaffected.
+	RegisterMeteringObserver(observer MeteringObserver)
+	// Shutdown stops the router's delivery goroutines.
+	Shutdown()
+}
+
+// NewBusinessRouter constructs the community business-stream router behind the
+// minimal BusinessRouter surface. nodeId is this node's cluster identity. The
+// returned router is the same deep internal implementation #50 protects; only
+// the exposed surface is narrowed.
+func NewBusinessRouter(deps Deps, nodeId string) BusinessRouter {
+	return internalrouter.NewRouter(deps, nodeId)
+}

--- a/pkg/eventRouter/event_router.go
+++ b/pkg/eventRouter/event_router.go
@@ -2,7 +2,9 @@
 // business-stream event router. It re-exports the minimal construct-and-drive
 // API plus the subject-carrying metering observer hook so an out-of-tree
 // superset (the enterprise edition, enterprise#86) can embed and meter the
-// router without importing internal/ (issue #218).
+// router without importing internal/ (issue #218). Embedders enter through
+// OpenPersistence — the composition-root opener that yields Deps's services +
+// Coordinator — then NewBusinessRouter and RegisterMeteringObserver.
 //
 // Boundary note — reconciles PRD #50 / PR #54. PR #54 deliberately kept the
 // router in internal/eventRouter to restore the pkg/internal seam. This facade
@@ -17,6 +19,7 @@ package eventRouter
 
 import (
 	internalrouter "github.com/i2-open/i2goSignals/internal/eventRouter"
+	"github.com/i2-open/i2goSignals/internal/providers/dbProviders"
 	"github.com/i2-open/i2goSignals/pkg/goSet"
 	model "github.com/i2-open/i2goSignals/pkg/ssfModels"
 )
@@ -43,7 +46,28 @@ type MeteringObserver = internalrouter.MeteringObserver
 // Deps is the dependency bundle NewBusinessRouter needs. The embedder populates
 // the exported service fields (pkg/services) and supplies a Coordinator value
 // obtained from the persistence layer — it never has to name an internal/ type.
+// OpenPersistence is the composition-root entry an out-of-tree embedder calls to
+// obtain those Coordinator + service values without importing internal/.
 type Deps = internalrouter.RouterDeps
+
+// OpenPersistence is the composition-root opener an out-of-tree embedder uses to
+// stand up the business-stream bundle (per-domain services + cluster coordinator
+// + lifecycle storage) and feed Deps — naming only this exported package. It is
+// a thin pass-through to the persistence factory: detect storeURL ("memorydb:"
+// or a Mongo URL) and return the bundle. The returned *dbProviders.Persistence
+// exposes the exported fields an embedder needs — StreamService, KeyService,
+// EventService and Coordinator for Deps, plus the Storage handle to Close on
+// shutdown. (Returning the internal Persistence type in an exported signature
+// matches the repo's existing posture: pkg/goSsfServer.NewApplication already
+// accepts *dbProviders.Persistence; an external module consumes it via :=
+// inference + exported-field access.)
+//
+// This re-export is the #218 seam closure: without it the construct-and-drive
+// surface above is unsatisfiable out-of-tree, because dbProviders is internal/
+// and a separate Go module (enterprise#87) physically cannot import it.
+func OpenPersistence(storeURL, dbName string) (*dbProviders.Persistence, error) {
+	return dbProviders.OpenPersistence(storeURL, dbName)
+}
 
 // BusinessRouter is the minimal construct-and-drive surface an embedder uses:
 // feed inbound events, sync stream state, register the metering observer, and

--- a/pkg/eventRouter/event_router_embed_test.go
+++ b/pkg/eventRouter/event_router_embed_test.go
@@ -1,0 +1,131 @@
+package eventRouter_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	// IMPORTANT: this file imports NO internal/ package. It uses ONLY exported
+	// github.com/i2-open/i2goSignals/pkg/... symbols — the compile-time proof
+	// that an out-of-tree embedder (enterprise#87) can stand up the
+	// business-stream composition root, build Deps, and construct + drive +
+	// meter the router with zero internal imports. The composition-root opener
+	// it relies on is eventRouter.OpenPersistence (#218 seam closure).
+	"github.com/i2-open/i2goSignals/pkg/authSupport"
+	pkgrouter "github.com/i2-open/i2goSignals/pkg/eventRouter"
+	"github.com/i2-open/i2goSignals/pkg/goSet"
+	model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+)
+
+// embedObserver implements pkgrouter.MeteringObserver naming only the exported
+// package — the metering hook an embedder satisfies.
+type embedObserver struct {
+	mu           sync.Mutex
+	observations []pkgrouter.MeteringObservation
+}
+
+func (o *embedObserver) ObserveEvent(observation pkgrouter.MeteringObservation) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.observations = append(o.observations, observation)
+}
+
+func (o *embedObserver) byDirection(dir pkgrouter.Direction) []pkgrouter.MeteringObservation {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	var out []pkgrouter.MeteringObservation
+	for _, obs := range o.observations {
+		if obs.Direction == dir {
+			out = append(out, obs)
+		}
+	}
+	return out
+}
+
+// TestEmbedderRecipe_NoInternalImports is the enterprise#87 construct-and-drive
+// recipe proven through the exported facade ALONE. It opens the composition-root
+// persistence via eventRouter.OpenPersistence (the #218 seam closure), builds
+// Deps from the returned persistence's exported fields, constructs the router,
+// registers a metering observer, drives a real event through the live
+// HandleEvent path, and asserts the observer fires ingress + egress. The import
+// block above names zero internal/ packages: that is the whole point — this file
+// compiles as an external module consumer would.
+func TestEmbedderRecipe_NoInternalImports(t *testing.T) {
+	t.Setenv("I2SIG_STORE_MEM_DIRECTORY", t.TempDir())
+
+	// Composition-root opener — the ONLY symbol an embedder needs to obtain
+	// Deps's services + Coordinator and the Storage handle to Close on shutdown.
+	persistence, err := pkgrouter.OpenPersistence("memorydb:", "pkg_eventrouter_embed_test")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if persistence.Storage != nil {
+			_ = persistence.Storage.Close()
+		}
+	})
+
+	br := pkgrouter.NewBusinessRouter(pkgrouter.Deps{
+		StreamService: persistence.StreamService,
+		KeyService:    persistence.KeyService,
+		EventService:  persistence.EventService,
+		Coordinator:   persistence.Coordinator,
+	}, "node-embed-test")
+	t.Cleanup(br.Shutdown)
+
+	observer := &embedObserver{}
+	br.RegisterMeteringObserver(observer)
+
+	// A project IAT scopes the stream create (mirrors the internal harness).
+	iat, err := persistence.KeyService.GetAuthIssuer().IssueProjectIat(nil)
+	require.NoError(t, err)
+	parsed, err := persistence.KeyService.GetAuthIssuer().ParseAuthToken(iat)
+	require.NoError(t, err)
+	projectId := parsed.ProjectId
+
+	const issuer = "https://issuer.example.com"
+	const audience = "https://receiver.example.com"
+	cfg := model.StreamConfiguration{
+		Iss:             issuer,
+		Aud:             []string{audience},
+		EventsRequested: []string{typeAcctDisabled},
+		Delivery: &model.OneOfStreamConfigurationDelivery{
+			PollTransmitMethod: &model.PollTransmitMethod{
+				Method:      model.DeliveryPoll,
+				EndpointUrl: "https://transmitter.example.com/events",
+			},
+		},
+	}
+	ctx := context.WithValue(context.Background(), authSupport.AuthContextKey, authSupport.ConvertProject(projectId))
+	created, err := persistence.StreamService.CreateStream(ctx, model.StreamStateRecord{StreamConfiguration: cfg}, projectId, nil)
+	require.NoError(t, err)
+	state, err := persistence.StreamService.GetStreamState(context.Background(), created.Id)
+	require.NoError(t, err)
+	br.UpdateStreamState(state)
+
+	token := &goSet.SecurityEventToken{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:   issuer,
+			Audience: jwt.ClaimStrings{audience},
+		},
+		Events: map[string]interface{}{typeAcctDisabled: map[string]interface{}{}},
+	}
+	token.ID = "pkg-embed-jti"
+	token.SubjectId = (&goSet.SubjectIdentifier{}).AddEmail("erin@example.com")
+
+	require.NoError(t, br.HandleEvent(token, `{"raw":true}`, created.Id))
+
+	ingress := observer.byDirection(pkgrouter.DirectionIngress)
+	require.Len(t, ingress, 1, "embedder seam must fire one ingress observation")
+	assert.Equal(t, created.Id, ingress[0].StreamURN)
+	require.NotNil(t, ingress[0].Subject)
+	assert.Equal(t, "erin@example.com", ingress[0].Subject.Email)
+
+	egress := observer.byDirection(pkgrouter.DirectionEgress)
+	require.Len(t, egress, 1, "embedder seam must fire one egress observation")
+	assert.Equal(t, created.Id, egress[0].StreamURN)
+	require.NotNil(t, egress[0].Subject)
+	assert.Equal(t, "erin@example.com", egress[0].Subject.Email)
+}

--- a/pkg/eventRouter/event_router_test.go
+++ b/pkg/eventRouter/event_router_test.go
@@ -1,0 +1,128 @@
+package eventRouter_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	// dbProviders (internal) is used only to stand up persistence for the test —
+	// that is the composition-root seam an embedder wires separately (enterprise
+	// #87). The router seam under test below names ONLY exported pkg/ types.
+	"github.com/i2-open/i2goSignals/internal/providers/dbProviders"
+	"github.com/i2-open/i2goSignals/pkg/authSupport"
+	pkgrouter "github.com/i2-open/i2goSignals/pkg/eventRouter"
+	"github.com/i2-open/i2goSignals/pkg/goSet"
+	model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+)
+
+const typeAcctDisabled = "https://schemas.openid.net/secevent/risc/event-type/account-disabled"
+
+// recordingObserver implements pkgrouter.MeteringObserver — proving an embedder
+// can satisfy the metering hook naming only the exported package.
+type recordingObserver struct {
+	mu           sync.Mutex
+	observations []pkgrouter.MeteringObservation
+}
+
+func (o *recordingObserver) ObserveEvent(observation pkgrouter.MeteringObservation) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.observations = append(o.observations, observation)
+}
+
+func (o *recordingObserver) byDirection(dir pkgrouter.Direction) []pkgrouter.MeteringObservation {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	var out []pkgrouter.MeteringObservation
+	for _, obs := range o.observations {
+		if obs.Direction == dir {
+			out = append(out, obs)
+		}
+	}
+	return out
+}
+
+// TestExportedBusinessRouter_DrivesAndObserves proves the #218 export AC end to
+// end through the EXPORTED facade only: construct the router via
+// pkgrouter.NewBusinessRouter naming only exported types, register a metering
+// observer, drive a real event through the live HandleEvent path, and assert the
+// observer fires ingress + egress with the correct stream_urn and subject.
+func TestExportedBusinessRouter_DrivesAndObserves(t *testing.T) {
+	t.Setenv("I2SIG_STORE_MEM_DIRECTORY", t.TempDir())
+	persistence, err := dbProviders.OpenPersistence("memorydb:", "pkg_eventrouter_test")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if persistence.Storage != nil {
+			_ = persistence.Storage.Close()
+		}
+	})
+
+	// Construct the router naming only pkgrouter.Deps + pkg/services values. The
+	// Coordinator flows through from persistence without the embedder naming the
+	// internal cluster type — the no-internal-import seam #218 requires.
+	br := pkgrouter.NewBusinessRouter(pkgrouter.Deps{
+		StreamService: persistence.StreamService,
+		KeyService:    persistence.KeyService,
+		EventService:  persistence.EventService,
+		Coordinator:   persistence.Coordinator,
+	}, "node-pkg-test")
+	t.Cleanup(br.Shutdown)
+
+	observer := &recordingObserver{}
+	br.RegisterMeteringObserver(observer)
+
+	// A project IAT scopes the stream create (mirrors the internal harness).
+	iat, err := persistence.KeyService.GetAuthIssuer().IssueProjectIat(nil)
+	require.NoError(t, err)
+	parsed, err := persistence.KeyService.GetAuthIssuer().ParseAuthToken(iat)
+	require.NoError(t, err)
+	projectId := parsed.ProjectId
+
+	const issuer = "https://issuer.example.com"
+	const audience = "https://receiver.example.com"
+	cfg := model.StreamConfiguration{
+		Iss:             issuer,
+		Aud:             []string{audience},
+		EventsRequested: []string{typeAcctDisabled},
+		Delivery: &model.OneOfStreamConfigurationDelivery{
+			PollTransmitMethod: &model.PollTransmitMethod{
+				Method:      model.DeliveryPoll,
+				EndpointUrl: "https://transmitter.example.com/events",
+			},
+		},
+	}
+	ctx := context.WithValue(context.Background(), authSupport.AuthContextKey, authSupport.ConvertProject(projectId))
+	created, err := persistence.StreamService.CreateStream(ctx, model.StreamStateRecord{StreamConfiguration: cfg}, projectId, nil)
+	require.NoError(t, err)
+	state, err := persistence.StreamService.GetStreamState(context.Background(), created.Id)
+	require.NoError(t, err)
+	br.UpdateStreamState(state)
+
+	token := &goSet.SecurityEventToken{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:   issuer,
+			Audience: jwt.ClaimStrings{audience},
+		},
+		Events: map[string]interface{}{typeAcctDisabled: map[string]interface{}{}},
+	}
+	token.ID = "pkg-export-jti"
+	token.SubjectId = (&goSet.SubjectIdentifier{}).AddEmail("erin@example.com")
+
+	require.NoError(t, br.HandleEvent(token, `{"raw":true}`, created.Id))
+
+	ingress := observer.byDirection(pkgrouter.DirectionIngress)
+	require.Len(t, ingress, 1, "exported seam must fire one ingress observation")
+	assert.Equal(t, created.Id, ingress[0].StreamURN)
+	require.NotNil(t, ingress[0].Subject)
+	assert.Equal(t, "erin@example.com", ingress[0].Subject.Email)
+
+	egress := observer.byDirection(pkgrouter.DirectionEgress)
+	require.Len(t, egress, 1, "exported seam must fire one egress observation")
+	assert.Equal(t, created.Id, egress[0].StreamURN)
+	require.NotNil(t, egress[0].Subject)
+	assert.Equal(t, "erin@example.com", egress[0].Subject.Email)
+}


### PR DESCRIPTION
## Slice 4A (community side) — export the event router to `pkg/` + metering observation hook

Part of `independentid/i2gosignals-enterprise#86` (PRD Slice 4A — enterprise business-stream data plane + server-side metering capture). This is the community-side seam the enterprise superset depends on; it is the first-unblocked root of the 4A DAG (→ enterprise #87 → #88 → #89). Resolves `#218`.

### What ships
- **Exported embedding seam** `pkg/eventRouter` — a deliberately narrow facade so the enterprise superset (a separate Go module) can embed and drive the business-stream router with **no `internal/` import**:
  - `NewBusinessRouter(deps Deps, nodeId string) BusinessRouter`
  - `BusinessRouter`: `HandleEvent`, `UpdateStreamState`, `RegisterMeteringObserver`, `Shutdown`
  - `Deps` (alias over the internal `RouterDeps`): `StreamService` / `KeyService` / `EventService` (from `pkg/services`) + `Coordinator`
- **Metering observation hook** (`internal/eventRouter/metering.go`) — `MeteringObserver.ObserveEvent(MeteringObservation)` where `MeteringObservation = {StreamURN, Direction (ingress|egress), Subject}`. Registered via `RegisterMeteringObserver`; fires once per routed event on the live routing path. Lock-free read (`atomic.Pointer`) so the hot path is unaffected.
- **Distinct from Prometheus.** The new hook is separate from `SetEventCounter(in, out *prometheus.CounterVec)` — different field, different path. `/metrics` behavior is **byte-unchanged**; the existing Prometheus counter/dedup tests stay green. The metering hook carries the per-event `subject` identity that the Prometheus counter cannot, which distinct-subject MAS requires.

### PRD #50 / PR #54 reconciliation
PR #54 deliberately restored the `pkg/internal` boundary, keeping the router in `internal/eventRouter`. This change **does not move or fork** that router — implementation and all its tests stay in `internal/`, preserving #50's seam discipline. The only thing crossing the boundary is the narrow exported wrapper (`pkg/eventRouter`): type aliases over the internal contract plus one constructor. Community keeps exactly one router; the enterprise superset gets a no-`internal`-import embedding point. (Full export direction authorized by the enterprise product owner 2026-06-27.)

### Acceptance criteria
- ✅ Router type + constructor reachable from an exported `pkg/` (external embedder needs no `internal/` import) — `pkg/eventRouter/event_router.go`.
- ✅ Metering observer fires once per routed event with correct `{stream_urn, direction, subject}` — `internal/eventRouter/metering.go` + live-path tests.
- ✅ Production-wiring AC: real events driven through the router on the live routing path assert the observer fires for **both** ingress and egress — `internal/eventRouter/metering_test.go`, plus an end-to-end test through the exported seam (`pkg/eventRouter/event_router_test.go`).
- ✅ `SetEventCounter` / `/metrics` unchanged — Prometheus distinctness test + existing tests green.
- ✅ Minimal exported surface — only what the enterprise superset needs to embed and drive the router.

### Design note for reviewers
Egress is observed at the routing/fan-out selection point (where the Prometheus inbound counter increments), not at delivery time. This is deterministic and testable on the live path without standing up push delivery. If delivery-time egress semantics are preferred (e.g. to exclude subject-filter discards at delivery), it is a one-line relocation per transport — flagged here for the review.

### Gates
- `go test -race ./...` — green module-wide (this LOCAL run is authoritative; family CI is paused over quota).
- `go vet ./...` — no new warnings (only the pre-existing `pkg/goScim`, `pkg/ssfModels`, `cmd/cluster-monitor` baseline).
- `gofmt -l` — clean on touched files.

### Downstream
Enterprise consumes `github.com/i2-open/i2goSignals/pkg/eventRouter` via a local `go.work` replace today; the go.mod tag-pin bump happens on the next family release-train once this merges.
