### PR TITLE
fix(oauthClient): seed RootCAs from global CA pool and append per-server certs (#220)

### DIFF
--- a/pkg/oauthClient/tls_helpers.go
+++ b/pkg/oauthClient/tls_helpers.go
@@ -9,9 +9,12 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/i2-open/i2goSignals/pkg/ssfModels"
+	"github.com/i2-open/i2goSignals/pkg/tlsSupport"
 )
 
 // CertificateInfo holds displayable information about a TLS certificate
@@ -163,31 +166,38 @@ func parseHostPort(urlStr string) (string, string, error) {
 // GetTlsConfigForServer returns a TLS configuration for the given server and allows support of a self-signed key or
 // administrative override to skip verification
 func GetTlsConfigForServer(server *model.Server) *tls.Config {
+	// Build the TLS config seeded with the global CA pool (system roots + ca-cert.pem).
+	tlsConfig := &tls.Config{
+		RootCAs: tlsSupport.GetGlobalCertPool("AUTH_CA_CERT"),
+	}
+
+	// Check global AUTH_DEBUG override
+	v := strings.ToLower(os.Getenv("AUTH_DEBUG"))
+	if v == "1" || v == "true" || v == "yes" || v == "on" {
+		tlsConfig.InsecureSkipVerify = true
+	}
+
 	if server == nil {
-		return &tls.Config{}
+		return tlsConfig
 	}
 
-	// If no custom TLS config needed, return default client
+	// If no custom TLS config needed, return config (already has global CA pool)
 	if server.TLSCertificate == "" && !server.TLSSkipVerify {
-		return &tls.Config{}
+		return tlsConfig
 	}
-
-	// Build custom TLS config
-	tlsConfig := &tls.Config{}
 
 	if server.TLSSkipVerify {
 		tlsConfig.InsecureSkipVerify = true
 		clientLog.Warn("Using InsecureSkipVerify for server", "alias", server.Alias)
 	} else if server.TLSCertificate != "" {
-		// Create a cert pool with the stored certificate
-		certPool, err := CreateCertPool(server.TLSCertificate)
-		if err != nil {
-			clientLog.Error("Failed to create cert pool, falling back to default",
-				"alias", server.Alias, "error", err)
-			return tlsConfig
+		// APPEND the custom certificate to the already-initialized global RootCAs
+		// pool (do not replace it, so system/global trust is retained).
+		if !tlsConfig.RootCAs.AppendCertsFromPEM([]byte(server.TLSCertificate)) {
+			clientLog.Error("Failed to add certificate to pool, falling back to default",
+				"alias", server.Alias)
+		} else {
+			clientLog.Debug("Using custom certificate (added to global pool) for server", "alias", server.Alias)
 		}
-		tlsConfig.RootCAs = certPool
-		clientLog.Debug("Using custom certificate for server", "alias", server.Alias)
 	}
 
 	return tlsConfig

--- a/pkg/oauthClient/tls_helpers_test.go
+++ b/pkg/oauthClient/tls_helpers_test.go
@@ -1,9 +1,18 @@
 package oauthClient
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/i2-open/i2goSignals/pkg/ssfModels"
 	"github.com/stretchr/testify/assert"
@@ -11,13 +20,17 @@ import (
 )
 
 func TestGetTlsConfigForServer_NilServer(t *testing.T) {
+	t.Setenv("AUTH_DEBUG", "")
 	config := GetTlsConfigForServer(nil)
 	assert.NotNil(t, config)
 	assert.False(t, config.InsecureSkipVerify)
-	assert.Nil(t, config.RootCAs)
+	// RootCAs must be seeded from the global CA pool (system roots + ca-cert.pem),
+	// never left nil. See issue #220.
+	assert.NotNil(t, config.RootCAs)
 }
 
 func TestGetTlsConfigForServer_NoCustomConfig(t *testing.T) {
+	t.Setenv("AUTH_DEBUG", "")
 	server := &model.Server{
 		Alias:          "test-server",
 		TLSCertificate: "",
@@ -26,7 +39,10 @@ func TestGetTlsConfigForServer_NoCustomConfig(t *testing.T) {
 	config := GetTlsConfigForServer(server)
 	assert.NotNil(t, config)
 	assert.False(t, config.InsecureSkipVerify)
-	assert.Nil(t, config.RootCAs)
+	// Core regression for issue #220: a server with no per-server cert and
+	// TLSSkipVerify=false must still load the global CA pool (ca-cert.pem), so
+	// RootCAs must be non-nil rather than an empty &tls.Config{}.
+	assert.NotNil(t, config.RootCAs)
 }
 
 func TestGetTlsConfigForServer_SkipVerify(t *testing.T) {
@@ -37,7 +53,8 @@ func TestGetTlsConfigForServer_SkipVerify(t *testing.T) {
 	config := GetTlsConfigForServer(server)
 	assert.NotNil(t, config)
 	assert.True(t, config.InsecureSkipVerify)
-	assert.Nil(t, config.RootCAs)
+	// RootCAs is still seeded from the global pool even though skip-verify ignores it.
+	assert.NotNil(t, config.RootCAs)
 }
 
 func TestGetTlsConfigForServer_CustomCertificate(t *testing.T) {
@@ -74,9 +91,10 @@ func TestGetTlsConfigForServer_InvalidCertificate(t *testing.T) {
 	}
 	config := GetTlsConfigForServer(server)
 	assert.NotNil(t, config)
-	// Should return empty config on error
+	// On append failure we fall back to the global pool rather than dropping all
+	// trust, so RootCAs stays non-nil (the global CA pool). See issue #220.
 	assert.False(t, config.InsecureSkipVerify)
-	assert.Nil(t, config.RootCAs)
+	assert.NotNil(t, config.RootCAs)
 }
 
 func TestGetBaseHTTPClientForServer_NilServer(t *testing.T) {
@@ -257,8 +275,8 @@ P1JT2eMb
 	config := GetTlsConfigForServer(server)
 	assert.NotNil(t, config)
 	assert.True(t, config.InsecureSkipVerify)
-	// RootCAs should not be set when SkipVerify is true
-	assert.Nil(t, config.RootCAs)
+	// RootCAs is still seeded from the global pool; skip-verify simply bypasses it.
+	assert.NotNil(t, config.RootCAs)
 }
 
 func TestParseHostPort(t *testing.T) {
@@ -284,6 +302,98 @@ func TestParseHostPort(t *testing.T) {
 			assert.Equal(t, tt.expectedPort, port)
 		})
 	}
+}
+
+// generateCAAndLeaf creates a self-signed CA certificate (returned as PEM) plus a
+// leaf certificate signed by that CA (returned parsed). Because the leaf chains to
+// the CA, verifying the leaf against a pool proves the CA is trusted in that pool.
+func generateCAAndLeaf(t *testing.T, cn string) (caPEM string, leaf *x509.Certificate) {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn + "-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caCert, err := x509.ParseCertificate(caDER)
+	require.NoError(t, err)
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: cn + "-leaf"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	require.NoError(t, err)
+	leaf, err = x509.ParseCertificate(leafDER)
+	require.NoError(t, err)
+
+	caPEM = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER}))
+	return caPEM, leaf
+}
+
+// TestGetTlsConfigForServer_AppendsToGlobalPoolWithoutDiscarding is the central
+// fix for issue #220: a per-server TLSCertificate must be APPENDED to the global
+// CA pool (system roots + ca-cert.pem), not REPLACE it. We wire a temp project CA
+// via I2SIG_TLS_CA_CERT and pin a distinct per-server CA, then assert both are
+// trusted by the resulting RootCAs pool.
+func TestGetTlsConfigForServer_AppendsToGlobalPoolWithoutDiscarding(t *testing.T) {
+	t.Setenv("AUTH_DEBUG", "")
+
+	// A "global/dev CA" written to a temp ca-cert.pem and wired via the env var
+	// GetGlobalCertPool consults, mirroring how the project CA is loaded.
+	globalCAPem, globalLeaf := generateCAAndLeaf(t, "global")
+	caFile := filepath.Join(t.TempDir(), "ca-cert.pem")
+	require.NoError(t, os.WriteFile(caFile, []byte(globalCAPem), 0o600))
+	t.Setenv("I2SIG_TLS_CA_CERT", caFile)
+
+	// A distinct per-server CA, pinned as the server's TLSCertificate.
+	perServerCAPem, perServerLeaf := generateCAAndLeaf(t, "perserver")
+
+	server := &model.Server{Alias: "test-server", TLSCertificate: perServerCAPem}
+	config := GetTlsConfigForServer(server)
+	require.NotNil(t, config)
+	require.NotNil(t, config.RootCAs, "RootCAs must be seeded from the global pool, not nil")
+	assert.False(t, config.InsecureSkipVerify)
+
+	// The per-server cert was appended -> its leaf must verify against the pool.
+	_, err := perServerLeaf.Verify(x509.VerifyOptions{Roots: config.RootCAs})
+	assert.NoError(t, err, "per-server certificate should be appended to the global pool")
+
+	// The global/dev CA must STILL be trusted -> we appended, not replaced.
+	_, err = globalLeaf.Verify(x509.VerifyOptions{Roots: config.RootCAs})
+	assert.NoError(t, err, "global CA roots must be retained (append, not replace)")
+}
+
+// TestGetTlsConfigForServer_AuthDebugEnablesSkipVerify covers the global AUTH_DEBUG
+// override: it forces InsecureSkipVerify even when there is no per-server cert and
+// TLSSkipVerify is false.
+func TestGetTlsConfigForServer_AuthDebugEnablesSkipVerify(t *testing.T) {
+	t.Setenv("AUTH_DEBUG", "true")
+
+	server := &model.Server{Alias: "test-server"}
+	config := GetTlsConfigForServer(server)
+	require.NotNil(t, config)
+	assert.True(t, config.InsecureSkipVerify)
+	assert.NotNil(t, config.RootCAs)
+
+	// Applies on the nil-server path too.
+	nilConfig := GetTlsConfigForServer(nil)
+	require.NotNil(t, nilConfig)
+	assert.True(t, nilConfig.InsecureSkipVerify)
 }
 
 func TestGetTLSConfigIntegrationWithHTTPClient(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes the receiver-side credential-`PUT` 500 in #220. Community's `GetTlsConfigForServer` (`pkg/oauthClient/tls_helpers.go`) never consulted the global/dev CA pool: a receiver with no per-server cert and `TLSSkipVerify=false` built an empty `tls.Config` (system roots only). The client-credentials token POST to a private/dev-CA issuer (Keycloak) then failed `x509: certificate signed by unknown authority`, so `PUT /server/{alias}` returned **500** and the updated credential was not persisted.

The admin sibling's copy of this function was already hardened; community's had diverged. This brings community back in line.

## Fix (Leg A — primary fix from #220)

In `GetTlsConfigForServer`:
- Seed `RootCAs` from `tlsSupport.GetGlobalCertPool("AUTH_CA_CERT")` (system roots + `ca-cert.pem`).
- **Append** any per-server `TLSCertificate` to that pool instead of replacing it, so a pinned transmitter cert no longer drops system/global trust.
- Honor the global `AUTH_DEBUG` skip.

This flows straight through the token client (`client.go` builds it from `GetTlsConfigForServer`), resolving the dev-fleet 500.

## Scope / deferred

Per the issue's own framing, this PR implements item #1 (Leg A) only. Deferred:
- **#2 Leg B parity** (`loadOAuthJWKS`) — that path has only discovery-URL strings, not `*model.Server`; honoring per-server config there is a cross-package restructure, and Leg B already trusts the dev CA today.
- **#3 host conflation** — "not required for this bug."
- **#4 validation-strictness-on-update** — design question.

## Tests

- 5 existing `GetTlsConfigForServer` tests updated (they asserted the buggy nil-`RootCAs`/replace behavior).
- New `TestGetTlsConfigForServer_AppendsToGlobalPoolWithoutDiscarding` — pins a distinct per-server CA against a temp global CA and proves both a per-server-signed leaf and a global-CA-signed leaf verify against `RootCAs` (append-not-replace).
- New `TestGetTlsConfigForServer_AuthDebugEnablesSkipVerify`.
- `go test -race ./...` green; `go vet ./...` clean (only pre-existing warnings); `gofmt` clean.

Fixes #220
