### PR TITLE
feat(ssf): per-stream signing-only receive posture (#184)

### DIFF
--- a/internal/server/api_receiver.go
+++ b/internal/server/api_receiver.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/i2-open/i2goSignals/pkg/authSupport"
 	"github.com/i2-open/i2goSignals/pkg/goSet/events"
 	"github.com/i2-open/i2goSignals/pkg/goSetPoll"
@@ -1550,6 +1551,9 @@ func (ps *ClientPollStream) runPollLoop(resource string) {
 			JWKS:              jwks,
 			ExpectedIssuer:    ps.stream.Iss,
 			ExpectedAudiences: ps.stream.Aud,
+			// Signing-only (#184): make verification of pulled SETs mandatory so a
+			// nil JWKS rejects rather than silently accepting unsigned events.
+			RequireSignature: ps.stream.SigningOnly,
 		})
 
 		if err != nil {
@@ -1806,6 +1810,16 @@ func (sa *SignalsApplication) ReceivePushEvent(w http.ResponseWriter, r *http.Re
 func ReceivePushEventHandler(sa SsfApplicationInterface, w http.ResponseWriter, r *http.Request) {
 	authContext, status := sa.GetAuth().ValidateAuthorizationAny(r, []string{authSupport.ScopeEventDelivery})
 	if status != http.StatusOK || authContext == nil {
+		// Bearer missing or invalid. Signing-only posture (#184): a business stream
+		// may gate trust on the SET's JWS signature rather than a transport bearer, so
+		// when NO bearer is presented we resolve the stream from the route's {id} and
+		// fall through to the per-SET signature check below. A bearer that IS presented
+		// must still pass the normal stream+scope check, so a presented-but-invalid
+		// bearer is rejected here at the request level exactly as before.
+		if sid, ok := resolveSigningOnlyPush(sa, r); ok {
+			receivePushForStream(sa, w, r, sid)
+			return
+		}
 		if status == http.StatusForbidden {
 
 			goSetPush.WriteDeliveryError(w, goSetPush.ErrAccessDenied, "The authorization did not contain the required stream identifier or scope")
@@ -1820,10 +1834,39 @@ func ReceivePushEventHandler(sa SsfApplicationInterface, w http.ResponseWriter, 
 		goSetPush.WriteDeliveryError(w, goSetPush.ErrAccessDenied, "The authorization did not contain a stream identifier")
 		return
 	}
+	receivePushForStream(sa, w, r, sid)
+}
+
+// resolveSigningOnlyPush returns the path-addressed stream id when a push request is
+// eligible for the signing-only posture (#184): no bearer was presented AND the stream
+// named on the route ({id}) is signing-only. A presented bearer is never bypassed — it
+// must pass the normal stream+scope check — so this returns ok=false whenever an
+// Authorization header is present, leaving the caller to reject it at the request level.
+func resolveSigningOnlyPush(sa SsfApplicationInterface, r *http.Request) (string, bool) {
+	if r.Header.Get("Authorization") != "" {
+		return "", false
+	}
+	pathId := mux.Vars(r)["id"]
+	if pathId == "" {
+		return "", false
+	}
+	st, err := sa.GetStreamService().GetStreamState(r.Context(), pathId)
+	if err != nil || st == nil || !st.SigningOnly {
+		return "", false
+	}
+	return pathId, true
+}
+
+// receivePushForStream runs the RFC8935 receive pipeline for an already-authorized
+// stream: resolve state, refresh the peer address, parse+validate the SET, drive push
+// monitoring/verification, and route the event. Under the stream's signing-only posture
+// (#184) signature verification is mandatory (RequireSignature); otherwise the behavior
+// is unchanged.
+func receivePushForStream(sa SsfApplicationInterface, w http.ResponseWriter, r *http.Request, sid string) {
 	streamState, err := sa.GetStreamService().GetStreamState(r.Context(), sid)
 	if streamState == nil || err != nil {
 		serverLog.Error("PUSH-RCV: Stream not found", "sid", sid)
-		goSetPush.WriteDeliveryError(w, goSetPush.ErrNotFound, "Stream "+authContext.StreamId+" could not be located or was deleted")
+		goSetPush.WriteDeliveryError(w, goSetPush.ErrNotFound, "Stream "+sid+" could not be located or was deleted")
 		return
 	}
 
@@ -1838,6 +1881,7 @@ func ReceivePushEventHandler(sa SsfApplicationInterface, w http.ResponseWriter, 
 		JWKS:              jwksKey,
 		ExpectedIssuer:    streamState.Iss,
 		ExpectedAudiences: streamState.Aud,
+		RequireSignature:  streamState.SigningOnly,
 	})
 	if deliveryErr != nil {
 		goSetPush.WriteDeliveryError(w, deliveryErr.ErrCode, deliveryErr.Description)

--- a/internal/server/api_sstp.go
+++ b/internal/server/api_sstp.go
@@ -69,12 +69,21 @@ func ReceiveSstpEventHandler(sa SsfApplicationInterface, w http.ResponseWriter, 
 		return
 	}
 
+	// Signing-only posture (#184): a business SSTP pair may gate trust on each SET's
+	// JWS signature rather than the stream-scoped bearer, so the bearer becomes
+	// optional when the rx-side stream is signing-only AND none was presented. A
+	// bearer that IS presented is still held to the full check, so the gate is
+	// enforced whenever an Authorization header is present or the stream is not
+	// signing-only — leaving flag-off pairs byte-for-byte unchanged.
+	signingOnly := rec.SstpInbound != nil && rec.SstpInbound.SigningOnly
+	bearerPresented := r.Header.Get("Authorization") != ""
+
 	// Defense-in-depth authorization. The bearer carries StreamIds=[txSid, rxSid]
 	// (the internal pair SIDs), NOT the PairId on the path. We resolve the actual
 	// SIDs from the record and verify the token authorizes at least one of them for
 	// the event scope, via AuthContext.IsAuthorizedForStream (never a bare
 	// authCtx.Eat check, which is nil for OAuth/STS callers) (PRD #154 Q19, Q42).
-	if !sstpAuthorized(sa, r, rec) {
+	if (bearerPresented || !signingOnly) && !sstpAuthorized(sa, r, rec) {
 		writeSstpError(w, http.StatusUnauthorized, goSetPush.ErrAuthenticationFailed,
 			"The authorization was not valid for this SSTP pair")
 		return
@@ -106,6 +115,9 @@ func ReceiveSstpEventHandler(sa SsfApplicationInterface, w http.ResponseWriter, 
 			rxCfg.ExpectedIssuer = rec.SstpInbound.Iss
 			rxCfg.ExpectedAudiences = rec.SstpInbound.Aud
 			rxCfg.JWKS = sa.GetStreamService().GetIssuerJwksForReceiver(r.Context(), rec.SstpInbound.Id)
+			// Signing-only (#184): make signature verification of each inbound SET
+			// mandatory so a per-JTI jws_signature_failed is reported via setErrs.
+			rxCfg.RequireSignature = rec.SstpInbound.SigningOnly
 		}
 		parsedIn, parseErrs = parseSstpInboundSets(inbound, rxCfg)
 	}

--- a/internal/server/test/push_signing_only_test.go
+++ b/internal/server/test/push_signing_only_test.go
@@ -1,0 +1,229 @@
+package test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/i2-open/i2goSignals/pkg/goSet"
+	"github.com/i2-open/i2goSignals/pkg/ssfModels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// signingOnlyJWKSBytes renders a minimal, standards-valid JWKS document for the
+// public half of an RSA key under the given kid (modeled on rsaPublicJWKSBytes in
+// pkg/services/stream_service_jwks_freeform_e2e_test.go).
+func signingOnlyJWKSBytes(t *testing.T, kid string, pub *rsa.PublicKey) []byte {
+	t.Helper()
+	n := base64.RawURLEncoding.EncodeToString(pub.N.Bytes())
+	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes())
+	doc := map[string]any{
+		"keys": []map[string]any{
+			{"kty": "RSA", "use": "sig", "alg": "RS256", "kid": kid, "n": n, "e": e},
+		},
+	}
+	b, err := json.Marshal(doc)
+	require.NoError(t, err)
+	return b
+}
+
+func pushSigningOnlySubject() *goSet.EventSubject {
+	return &goSet.EventSubject{
+		SubjectIdentifier: goSet.SubjectIdentifier{
+			Format:                    "scim",
+			UniformResourceIdentifier: goSet.UniformResourceIdentifier{Uri: "/Users/signing-only"},
+		},
+	}
+}
+
+// TestPushSigningOnly exercises the #184 signing-only receive posture on the
+// RFC8935 push handler (ReceivePushEventHandler, POST /events/{id}). For a
+// signing-only receiver stream the SET's JWS signature — not a transport bearer —
+// is the trust gate: a bearer is OPTIONAL, but any bearer that IS presented must
+// still be valid, and inbound signature verification is mandatory.
+func TestPushSigningOnly(t *testing.T) {
+	instance, err := createServer(t, "push_signing_only_test", true)
+	require.NoError(t, err)
+	defer func() {
+		if instance.ts != nil {
+			instance.ts.Close()
+		}
+		instance.app.Shutdown()
+	}()
+
+	const kid = "test-kid"
+	const issuer = "https://issuer.example.com"
+	aud := []string{"https://receiver.example.com"}
+
+	// 1. Stand up a JWKS server hosting the public half of the signing key.
+	signingKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	jwksMux := http.NewServeMux()
+	jwksMux.HandleFunc("/jwks.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(signingOnlyJWKSBytes(t, kid, &signingKey.PublicKey))
+	})
+	jwksServer := httptest.NewServer(jwksMux)
+	defer jwksServer.Close()
+	jwksUrl := jwksServer.URL + "/jwks.json"
+
+	// 2. Create a SigningOnly ReceivePush receiver stream.
+	streamConfig := model.StreamConfiguration{
+		Iss:             issuer,
+		Aud:             aud,
+		IssuerJWKSUrl:   jwksUrl,
+		SigningOnly:     true,
+		EventsSupported: []string{"*"},
+		RouteMode:       model.RouteModeImport,
+		Delivery: &model.OneOfStreamConfigurationDelivery{
+			PushReceiveMethod: &model.PushReceiveMethod{
+				Method: model.ReceivePush,
+			},
+		},
+	}
+	body, _ := json.Marshal(streamConfig)
+	req, _ := http.NewRequest(http.MethodPost, instance.ts.URL+"/stream", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+instance.streamMgmtToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := instance.client.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	var created model.StreamConfiguration
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&created))
+	resp.Body.Close()
+	require.NotEmpty(t, created.Id)
+	require.True(t, created.SigningOnly, "created stream must persist the signing-only posture")
+	endpoint := created.Delivery.PushReceiveMethod.EndpointUrl
+	require.NotEmpty(t, endpoint, "created push receiver must expose an /events/{id} endpoint")
+
+	// signedSet builds and signs a SET for the given key and issuer, always tagging
+	// the JWS with kid=test-kid so the JWKS lookup resolves to the configured key.
+	signedSet := func(t *testing.T, key *rsa.PrivateKey, iss string) string {
+		t.Helper()
+		set := goSet.CreateSet(pushSigningOnlySubject(), iss, aud)
+		set.Kid = kid
+		set.AddEventPayload("https://schemas.openid.net/secevent/risc/event-type/account-disabled",
+			map[string]interface{}{"reason": "signing-only test"})
+		signed, err := set.JWS(jwt.SigningMethodRS256, key)
+		require.NoError(t, err)
+		return signed
+	}
+
+	// postSet POSTs a SET to the signing-only push endpoint, optionally with a bearer.
+	postSet := func(t *testing.T, token, authHeader string) *http.Response {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(token))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/secevent+jwt")
+		if authHeader != "" {
+			req.Header.Set("Authorization", authHeader)
+		}
+		resp, err := instance.client.Do(req)
+		require.NoError(t, err)
+		return resp
+	}
+
+	type errBody struct {
+		Err string `json:"err"`
+	}
+	decodeErr := func(t *testing.T, resp *http.Response) errBody {
+		t.Helper()
+		var eb errBody
+		raw, _ := io.ReadAll(resp.Body)
+		require.NoError(t, json.Unmarshal(raw, &eb))
+		return eb
+	}
+
+	// (a) No Authorization header + SET signed by the JWKS key -> 202 Accepted.
+	t.Run("NoAuth_GoodSignature_Accepted", func(t *testing.T) {
+		resp := postSet(t, signedSet(t, signingKey, issuer), "")
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusAccepted, resp.StatusCode,
+			"a good per-SET signature is the trust gate; no bearer is required for a signing-only stream")
+	})
+
+	// (b) No Authorization header + SET signed by a DIFFERENT (attacker) key ->
+	// 400 jws_signature_failed.
+	t.Run("NoAuth_BadSignature_Rejected", func(t *testing.T) {
+		attackerKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		resp := postSet(t, signedSet(t, attackerKey, issuer), "")
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.Equal(t, "jws_signature_failed", decodeErr(t, resp).Err)
+	})
+
+	// (c) Authorization header present but invalid + a GOOD SET -> rejected at the
+	// request level with authentication_failed (a presented bearer is NOT bypassed).
+	// Note: the RFC8935 push handler writes all delivery errors with HTTP 400
+	// (goSetPush.WriteDeliveryError), so the status is 400, not 401.
+	t.Run("InvalidBearer_NotBypassed", func(t *testing.T) {
+		resp := postSet(t, signedSet(t, signingKey, issuer), "Bearer not-a-real-token")
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.Equal(t, "authentication_failed", decodeErr(t, resp).Err,
+			"a presented-but-invalid bearer must be rejected, never bypassed by the signing-only posture")
+	})
+
+	// (d) No Authorization header + a good-signature SET whose iss != stream Iss ->
+	// 400 invalid_issuer (iss/aud are still validated under the signing-only posture).
+	t.Run("NoAuth_WrongIssuer_Rejected", func(t *testing.T) {
+		resp := postSet(t, signedSet(t, signingKey, "https://attacker.example.com"), "")
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.Equal(t, "invalid_issuer", decodeErr(t, resp).Err)
+	})
+
+	// (e) Forward (FW) route mode. The signing-only posture is RouteMode-agnostic at
+	// the receive gate — verification happens on receive and the FW router relays the
+	// original token downstream unchanged (no re-sign; PB would re-sign). So a
+	// signing-only FW receiver accepts a validly-signed SET with no bearer, exactly
+	// like IM (criterion #10).
+	t.Run("ForwardMode_GoodSignature_Accepted", func(t *testing.T) {
+		fwConfig := model.StreamConfiguration{
+			Iss:             issuer,
+			Aud:             aud,
+			IssuerJWKSUrl:   jwksUrl,
+			SigningOnly:     true,
+			EventsSupported: []string{"*"},
+			RouteMode:       model.RouteModeForward,
+			Delivery: &model.OneOfStreamConfigurationDelivery{
+				PushReceiveMethod: &model.PushReceiveMethod{Method: model.ReceivePush},
+			},
+		}
+		fwBody, _ := json.Marshal(fwConfig)
+		fwReq, _ := http.NewRequest(http.MethodPost, instance.ts.URL+"/stream", bytes.NewReader(fwBody))
+		fwReq.Header.Set("Authorization", "Bearer "+instance.streamMgmtToken)
+		fwReq.Header.Set("Content-Type", "application/json")
+		fwResp, err := instance.client.Do(fwReq)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, fwResp.StatusCode)
+		var fwCreated model.StreamConfiguration
+		require.NoError(t, json.NewDecoder(fwResp.Body).Decode(&fwCreated))
+		fwResp.Body.Close()
+		require.Equal(t, model.RouteModeForward, fwCreated.RouteMode)
+		require.True(t, fwCreated.SigningOnly)
+
+		post, err := http.NewRequest(http.MethodPost,
+			fwCreated.Delivery.PushReceiveMethod.EndpointUrl,
+			strings.NewReader(signedSet(t, signingKey, issuer)))
+		require.NoError(t, err)
+		post.Header.Set("Content-Type", "application/secevent+jwt")
+		gotResp, err := instance.client.Do(post)
+		require.NoError(t, err)
+		defer gotResp.Body.Close()
+		assert.Equal(t, http.StatusAccepted, gotResp.StatusCode,
+			"a signing-only FW receiver accepts a validly-signed SET with no bearer, same as IM")
+	})
+}

--- a/internal/server/test/sstp_signing_only_test.go
+++ b/internal/server/test/sstp_signing_only_test.go
@@ -1,0 +1,159 @@
+package test
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/i2-open/i2goSignals/pkg/goSet"
+	"github.com/i2-open/i2goSignals/pkg/goSetSstp"
+	"github.com/i2-open/i2goSignals/pkg/ssfModels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// newSstpSigningOnlyPair provisions an enabled SSTP pair whose inbound direction is
+// signing-only (#184): the rx-side stream gates trust on each SET's JWS signature
+// rather than the stream-scoped bearer. It mirrors newSstpVerifyPair (the inbound
+// issuer is the local "DEFAULT" key so its JWKS resolves internally) but flips
+// SstpInbound.SigningOnly on. Persisting directly via PersistStreamStateRecord
+// bypasses the create-time guardrail (tested elsewhere), which is fine here.
+func newSstpSigningOnlyPair(t *testing.T, instance *ssfInstance) *sstpTestPair {
+	t.Helper()
+	txSid := bson.NewObjectID().Hex()
+	rxSid := bson.NewObjectID().Hex()
+	pairId := bson.NewObjectID().Hex()
+
+	rec := &model.StreamStateRecord{
+		StreamConfiguration: model.StreamConfiguration{
+			Id:  txSid,
+			Iss: "peer.example.com",
+			Aud: []string{"DEFAULT"},
+		},
+		SstpInbound: &model.StreamConfiguration{
+			Id:          rxSid,
+			Iss:         "DEFAULT",
+			Aud:         []string{"peer.example.com"},
+			SigningOnly: true,
+		},
+		SstpMethod:    &model.SstpMethod{Role: "responder"},
+		PairId:        pairId,
+		ProjectId:     instance.projectId,
+		Status:        model.StreamStateEnabled,
+		InboundStatus: model.StreamStateEnabled,
+	}
+	require.NoError(t, instance.streamSvc().PersistStreamStateRecord(context.Background(), rec))
+
+	bearer, err := instance.GetAuthIssuer().IssueSstpPairToken(txSid, rxSid, instance.projectId, false, nil)
+	require.NoError(t, err)
+	return &sstpTestPair{pairId: pairId, txSid: txSid, rxSid: rxSid, bearer: bearer}
+}
+
+// postSstpSigningOnly POSTs an SSTP message (returnImmediately=true to avoid the
+// 30s outbound long-poll) to the pair's /sstp/{id} endpoint. authHeader is set only
+// when non-empty, so passing "" exercises the no-Authorization (bearer-bypass) path.
+func postSstpSigningOnly(t *testing.T, instance *ssfInstance, pairId, authHeader string, sets map[string]string) *http.Response {
+	t.Helper()
+	url := fmt.Sprintf("http://%s/sstp/%s", instance.host, pairId)
+	body, _ := json.Marshal(goSetSstp.Message{Sets: sets, ReturnImmediately: goSetSstp.BoolPtr(true)})
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", goSetSstp.ContentType)
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	resp, err := instance.client.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// TestSstpSigningOnly exercises the #184 signing-only receive posture on the SSTP
+// handler (ReceiveSstpEventHandler, POST /sstp/{id}). When the rx-side stream is
+// signing-only and no Authorization header is presented, the bearer gate is
+// bypassed but each inbound SET is still signature-verified per-JTI. A presented
+// bearer is still enforced.
+func TestSstpSigningOnly(t *testing.T) {
+	instance, err := createServer(t, "sstp-signing-only", true)
+	require.NoError(t, err)
+	defer func() {
+		if instance.ts != nil {
+			instance.ts.Close()
+		}
+		instance.app.Shutdown()
+	}()
+
+	pair := newSstpSigningOnlyPair(t, instance)
+
+	goodInboundSet := func(t *testing.T) (string, string) {
+		t.Helper()
+		good := goSet.CreateSet(sstpVerifySubject(), "DEFAULT", []string{"peer.example.com"})
+		good.AddEventPayload("https://schemas.openid.net/secevent/risc/event-type/account-disabled",
+			map[string]interface{}{"reason": "legit"})
+		defaultKey, err := instance.GetPrivateKey("DEFAULT")
+		require.NoError(t, err)
+		goodJws, err := good.JWS(jwt.SigningMethodRS256, defaultKey)
+		require.NoError(t, err)
+		return good.ID, goodJws
+	}
+
+	// (a) No Authorization header + a GOOD inbound SET -> 200, no SetErr for its jti
+	// (the bearer gate is bypassed and the signature is accepted).
+	t.Run("NoAuth_GoodSet_BearerBypassed", func(t *testing.T) {
+		goodJti, goodJws := goodInboundSet(t)
+
+		resp := postSstpSigningOnly(t, instance, pair.pairId, "", map[string]string{goodJti: goodJws})
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		var msg goSetSstp.Message
+		raw, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		require.NoError(t, json.Unmarshal(raw, &msg))
+		assert.NotContains(t, msg.SetErrs, goodJti,
+			"a correctly-signed inbound SET must be accepted when the signing-only bearer gate is bypassed")
+	})
+
+	// (b) No Authorization header + a FORGED inbound SET -> 200 with a per-JTI
+	// SetErr (Err == ErrJws); the forged SET must never be persisted.
+	t.Run("NoAuth_ForgedSet_Rejected", func(t *testing.T) {
+		forged := goSet.CreateSet(sstpVerifySubject(), "DEFAULT", []string{"peer.example.com"})
+		forged.AddEventPayload("https://schemas.openid.net/secevent/risc/event-type/account-disabled",
+			map[string]interface{}{"reason": "forged"})
+		attackerKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		forgedJws, err := forged.JWS(jwt.SigningMethodRS256, attackerKey)
+		require.NoError(t, err)
+		forgedJti := forged.ID
+
+		resp := postSstpSigningOnly(t, instance, pair.pairId, "", map[string]string{forgedJti: forgedJws})
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		var msg goSetSstp.Message
+		raw, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		require.NoError(t, json.Unmarshal(raw, &msg))
+		require.Contains(t, msg.SetErrs, forgedJti, "forged inbound SET must be rejected with a per-JTI error")
+		assert.Equal(t, goSetSstp.ErrJws, msg.SetErrs[forgedJti].Err)
+		assert.Nil(t, instance.GetEvent(forgedJti), "forged inbound SET must not be persisted")
+	})
+
+	// (c) An Authorization header IS present but invalid (a foreign pair bearer) ->
+	// 401, because a presented bearer is enforced even on a signing-only pair.
+	t.Run("InvalidBearer_GateEnforced", func(t *testing.T) {
+		goodJti, goodJws := goodInboundSet(t)
+		foreignBearer, err := instance.GetAuthIssuer().IssueSstpPairToken(
+			bson.NewObjectID().Hex(), bson.NewObjectID().Hex(), instance.projectId, false, nil)
+		require.NoError(t, err)
+
+		resp := postSstpSigningOnly(t, instance, pair.pairId, "Bearer "+foreignBearer,
+			map[string]string{goodJti: goodJws})
+		resp.Body.Close()
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+			"a presented bearer must still be enforced (not bypassed) on a signing-only SSTP pair")
+	})
+}

--- a/pkg/goSetPoll/poll.go
+++ b/pkg/goSetPoll/poll.go
@@ -80,6 +80,12 @@ type ReceiverConfig struct {
 	// ExpectedAudiences is the list of acceptable "aud" values. Empty skips validation.
 	ExpectedAudiences []string
 
+	// RequireSignature makes signature verification of pulled SETs mandatory (#184
+	// signing-only posture): a SET is rejected with jws_signature_failed when no JWKS
+	// is available to verify it or when verification fails. When false (default),
+	// verification is conditional on JWKS being non-nil (prior behavior).
+	RequireSignature bool
+
 	// HTTPClient is an optional custom HTTP client. If nil, a default is used.
 	HTTPClient *http.Client
 

--- a/pkg/goSetPoll/poll_test.go
+++ b/pkg/goSetPoll/poll_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/MicahParks/keyfunc/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/i2-open/i2goSignals/pkg/goSet"
 	"github.com/stretchr/testify/assert"
@@ -275,6 +276,102 @@ func TestPoll_WithValidSETs(t *testing.T) {
 	assert.Empty(t, parsed.Errors)
 	assert.Contains(t, parsed.ParsedSETs, jti1)
 	assert.Contains(t, parsed.ParsedSETs, jti2)
+}
+
+// jwksForKey builds a JWKS keyed by the issuer string, matching the "kid"
+// goSet.JWS emits when SecurityEventToken.Kid is empty (it falls back to iss).
+func jwksForKey(t *testing.T, issuer string, key *rsa.PrivateKey) *keyfunc.JWKS {
+	t.Helper()
+	givenKey := keyfunc.NewGivenRSA(&key.PublicKey, keyfunc.GivenKeyOptions{})
+	return keyfunc.NewGiven(map[string]keyfunc.GivenKey{issuer: givenKey})
+}
+
+// --- Signing-only poll posture (#184): RequireSignature ---
+
+// Under RequireSignature, a pulled SET with no JWKS available to verify against
+// is rejected (jws_signature_failed) rather than accepted unverified. This is the
+// poll-as-receiver mandatory-verification rule: not conditional on JWKS != nil.
+func TestPoll_RequireSignature_NoJWKSRejected(t *testing.T) {
+	key := generateTestKey(t)
+	iss := "https://issuer.example.com"
+	aud := []string{"https://aud.example.com"}
+	jti1, token1 := createTestSET(t, iss, aud, key)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(PollResponse{Sets: map[string]string{jti1: token1}})
+	}))
+	defer server.Close()
+
+	parsed, _, err := Poll(context.Background(), PollRequest{ReturnImmediately: true}, ReceiverConfig{
+		EndpointURL:       server.URL,
+		ExpectedIssuer:    iss,
+		ExpectedAudiences: aud,
+		RequireSignature:  true,
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, parsed.ParsedSETs)
+	require.Contains(t, parsed.Errors, jti1)
+	assert.Equal(t, "jws_signature_failed", parsed.Errors[jti1].Error)
+}
+
+// A validly-signed SET with a matching JWKS is accepted under RequireSignature.
+func TestPoll_RequireSignature_ValidAccepted(t *testing.T) {
+	key := generateTestKey(t)
+	iss := "https://issuer.example.com"
+	aud := []string{"https://aud.example.com"}
+	jti1, token1 := createTestSET(t, iss, aud, key)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(PollResponse{Sets: map[string]string{jti1: token1}})
+	}))
+	defer server.Close()
+
+	parsed, _, err := Poll(context.Background(), PollRequest{ReturnImmediately: true}, ReceiverConfig{
+		EndpointURL:       server.URL,
+		JWKS:              jwksForKey(t, iss, key),
+		ExpectedIssuer:    iss,
+		ExpectedAudiences: aud,
+		RequireSignature:  true,
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, parsed.Errors)
+	require.Contains(t, parsed.ParsedSETs, jti1)
+}
+
+// A SET whose signature does not verify against the configured JWKS is rejected
+// with jws_signature_failed under RequireSignature.
+func TestPoll_RequireSignature_BadSignatureRejected(t *testing.T) {
+	signKey := generateTestKey(t)
+	otherKey := generateTestKey(t)
+	iss := "https://issuer.example.com"
+	aud := []string{"https://aud.example.com"}
+	jti1, token1 := createTestSET(t, iss, aud, signKey)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(PollResponse{Sets: map[string]string{jti1: token1}})
+	}))
+	defer server.Close()
+
+	parsed, _, err := Poll(context.Background(), PollRequest{ReturnImmediately: true}, ReceiverConfig{
+		EndpointURL:       server.URL,
+		JWKS:              jwksForKey(t, iss, otherKey), // wrong public key
+		ExpectedIssuer:    iss,
+		ExpectedAudiences: aud,
+		RequireSignature:  true,
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, parsed.ParsedSETs)
+	require.Contains(t, parsed.Errors, jti1)
+	assert.Equal(t, "jws_signature_failed", parsed.Errors[jti1].Error)
 }
 
 func TestPoll_IssuerValidationError(t *testing.T) {

--- a/pkg/goSetPoll/receiver.go
+++ b/pkg/goSetPoll/receiver.go
@@ -98,8 +98,31 @@ func Poll(ctx context.Context, request PollRequest, config ReceiverConfig) (*Par
 	}
 
 	for jti, setString := range rawResp.Sets {
+		// Signing-only poll posture (#184): verification of pulled SETs is mandatory.
+		// Without a trust anchor we cannot verify, so the SET is rejected rather than
+		// accepted unverified. Signature failures are expected peer events (WARN).
+		if config.RequireSignature && config.JWKS == nil {
+			log.Warn("RFC8936: SET signature required but no JWKS available to verify (signing-only)", "jti", jti)
+			result.Errors[jti] = SetErrType{
+				Error:       "jws_signature_failed",
+				Description: "The SET signature could not be validated.",
+			}
+			continue
+		}
+
 		token, err := goSet.Parse(setString, config.JWKS)
 		if err != nil {
+			// When verifying against a JWKS under the signing-only posture, a parse
+			// failure is a bad signature → jws_signature_failed (the RFC8935 §2.4
+			// rotate-and-retry signal). Otherwise the prior invalid_request is kept.
+			if config.RequireSignature && config.JWKS != nil {
+				log.Warn("RFC8936: SET signature verification failed (signing-only)", "jti", jti, "error", err)
+				result.Errors[jti] = SetErrType{
+					Error:       "jws_signature_failed",
+					Description: "The SET signature could not be validated.",
+				}
+				continue
+			}
 			log.Warn("RFC8936: SET parsing error", "jti", jti, "error", err)
 			result.Errors[jti] = SetErrType{
 				Error:       "invalid_request",

--- a/pkg/goSetPush/push.go
+++ b/pkg/goSetPush/push.go
@@ -56,6 +56,12 @@ type ReceiverConfig struct {
 	// ExpectedAudiences is the list of acceptable "aud" values. If empty, audience validation is skipped.
 	ExpectedAudiences []string
 
+	// RequireSignature makes JWS signature verification mandatory (#184 signing-only
+	// posture): the SET is rejected with jws_signature_failed if no JWKS is available
+	// to verify against or if verification fails. When false (default) behavior is
+	// unchanged — a nil JWKS skips verification and a verify failure is invalid_request.
+	RequireSignature bool
+
 	// Logger is an optional structured logger. If nil, a default is used.
 	Logger *slog.Logger
 }

--- a/pkg/goSetPush/push_test.go
+++ b/pkg/goSetPush/push_test.go
@@ -169,6 +169,128 @@ func TestParseReceivedSET_SkipAudienceValidation(t *testing.T) {
 	require.NotNil(t, result)
 }
 
+// jwksForKey builds a JWKS keyed by the issuer string, matching the "kid"
+// goSet.JWS emits when SecurityEventToken.Kid is empty (it falls back to the
+// issuer). This lets a verifying parse resolve the key for a signed SET.
+func jwksForKey(t *testing.T, issuer string, key *rsa.PrivateKey) *keyfunc.JWKS {
+	t.Helper()
+	givenKey := keyfunc.NewGivenRSA(&key.PublicKey, keyfunc.GivenKeyOptions{})
+	return keyfunc.NewGiven(map[string]keyfunc.GivenKey{issuer: givenKey})
+}
+
+// --- Signing-only receive posture (#184): RequireSignature ---
+
+// A valid signature with a matching JWKS is accepted under RequireSignature.
+func TestParseReceivedSET_RequireSignature_ValidAccepted(t *testing.T) {
+	key := generateTestKey(t)
+	iss := "https://issuer.example.com"
+	aud := []string{"https://audience.example.com"}
+	tokenString := createTestSET(t, iss, aud, key)
+
+	req := buildPushRequest(t, tokenString, "application/secevent+jwt")
+	config := ReceiverConfig{
+		JWKS:              jwksForKey(t, iss, key),
+		ExpectedIssuer:    iss,
+		ExpectedAudiences: aud,
+		RequireSignature:  true,
+	}
+
+	result, deliveryErr := ParseReceivedSET(req, config)
+	assert.Nil(t, deliveryErr)
+	require.NotNil(t, result)
+	assert.Equal(t, iss, result.Token.Issuer)
+}
+
+// A SET signed by a key that does not match the issuer's JWKS is rejected with
+// jws_signature_failed (the RFC8935 §2.4 rotate-and-retry signal) — not the
+// generic invalid_request used when signatures are optional.
+func TestParseReceivedSET_RequireSignature_BadSignatureRejected(t *testing.T) {
+	signKey := generateTestKey(t)
+	otherKey := generateTestKey(t)
+	iss := "https://issuer.example.com"
+	aud := []string{"https://audience.example.com"}
+	tokenString := createTestSET(t, iss, aud, signKey)
+
+	req := buildPushRequest(t, tokenString, "application/secevent+jwt")
+	config := ReceiverConfig{
+		JWKS:              jwksForKey(t, iss, otherKey), // wrong public key for this kid
+		ExpectedIssuer:    iss,
+		ExpectedAudiences: aud,
+		RequireSignature:  true,
+	}
+
+	result, deliveryErr := ParseReceivedSET(req, config)
+	require.NotNil(t, deliveryErr)
+	assert.Nil(t, result)
+	assert.Equal(t, ErrJwsSignatureFailed, deliveryErr.ErrCode)
+}
+
+// Under RequireSignature a missing trust anchor (nil JWKS) is a hard reject: the
+// SET must NOT be accepted unverified. This is the core difference from the
+// default posture, where a nil JWKS skips verification.
+func TestParseReceivedSET_RequireSignature_NoJWKSRejected(t *testing.T) {
+	key := generateTestKey(t)
+	iss := "https://issuer.example.com"
+	aud := []string{"https://audience.example.com"}
+	tokenString := createTestSET(t, iss, aud, key)
+
+	req := buildPushRequest(t, tokenString, "application/secevent+jwt")
+	config := ReceiverConfig{
+		JWKS:              nil,
+		ExpectedIssuer:    iss,
+		ExpectedAudiences: aud,
+		RequireSignature:  true,
+	}
+
+	result, deliveryErr := ParseReceivedSET(req, config)
+	require.NotNil(t, deliveryErr)
+	assert.Nil(t, result)
+	assert.Equal(t, ErrJwsSignatureFailed, deliveryErr.ErrCode)
+}
+
+// An issuer mismatch is reported as invalid_issuer (a trust failure, not a
+// signature failure) and is detected before signature verification, so a sender
+// does not pointlessly rotate keys.
+func TestParseReceivedSET_RequireSignature_WrongIssuerRejected(t *testing.T) {
+	key := generateTestKey(t)
+	aud := []string{"https://audience.example.com"}
+	tokenString := createTestSET(t, "https://attacker.example.com", aud, key)
+
+	req := buildPushRequest(t, tokenString, "application/secevent+jwt")
+	config := ReceiverConfig{
+		JWKS:              jwksForKey(t, "https://attacker.example.com", key),
+		ExpectedIssuer:    "https://issuer.example.com",
+		ExpectedAudiences: aud,
+		RequireSignature:  true,
+	}
+
+	result, deliveryErr := ParseReceivedSET(req, config)
+	require.NotNil(t, deliveryErr)
+	assert.Nil(t, result)
+	assert.Equal(t, ErrInvalidIssuer, deliveryErr.ErrCode)
+}
+
+// aud validation still runs (and runs before signature verification) under the
+// signing-only posture.
+func TestParseReceivedSET_RequireSignature_AudMismatchRejected(t *testing.T) {
+	key := generateTestKey(t)
+	iss := "https://issuer.example.com"
+	tokenString := createTestSET(t, iss, []string{"https://other.example.com"}, key)
+
+	req := buildPushRequest(t, tokenString, "application/secevent+jwt")
+	config := ReceiverConfig{
+		JWKS:              jwksForKey(t, iss, key),
+		ExpectedIssuer:    iss,
+		ExpectedAudiences: []string{"https://audience.example.com"},
+		RequireSignature:  true,
+	}
+
+	result, deliveryErr := ParseReceivedSET(req, config)
+	require.NotNil(t, deliveryErr)
+	assert.Nil(t, result)
+	assert.Equal(t, ErrInvalidAudience, deliveryErr.ErrCode)
+}
+
 func TestWriteDeliveryError(t *testing.T) {
 	w := httptest.NewRecorder()
 	WriteDeliveryError(w, ErrInvalidIssuer, "The SET Issuer is invalid.")

--- a/pkg/goSetPush/receiver.go
+++ b/pkg/goSetPush/receiver.go
@@ -98,16 +98,37 @@ func ParseReceivedSET(r *http.Request, config ReceiverConfig) (*ReceivedSET, *De
 		}
 	}
 
-	// Now verify the signature if a JWKS is configured
+	// Verify the signature. With a JWKS configured we always verify. Under the
+	// signing-only posture (RequireSignature, #184) the JWS signature is the trust
+	// gate, so a verify failure is jws_signature_failed (the RFC8935 §2.4
+	// rotate-and-retry signal) and a missing trust anchor (nil JWKS) is itself a
+	// hard reject — the SET must never be accepted unverified. Without the posture
+	// the prior behavior is preserved: a nil JWKS skips verification and a verify
+	// failure is invalid_request. Issuer mismatch was already handled above, so a
+	// failure here is a bad signature, not a trust failure. Signature failures are
+	// expected peer events, hence WARN, not ERROR (CONTEXT.md log-level policy).
 	token := unverified
 	if config.JWKS != nil {
 		token, err = goSet.Parse(tokenString, config.JWKS)
 		if err != nil {
+			if config.RequireSignature {
+				log.Warn("RFC8935: SET signature verification failed (signing-only)", "error", err)
+				return nil, &DeliveryErr{
+					ErrCode:     ErrJwsSignatureFailed,
+					Description: "The SET signature could not be validated.",
+				}
+			}
 			log.Warn("RFC8935: Error validating SET token signature", "error", err)
 			return nil, &DeliveryErr{
 				ErrCode:     ErrInvalidRequest,
 				Description: "The request could not be parsed as a SET.",
 			}
+		}
+	} else if config.RequireSignature {
+		log.Warn("RFC8935: SET signature required but no JWKS available to verify (signing-only)")
+		return nil, &DeliveryErr{
+			ErrCode:     ErrJwsSignatureFailed,
+			Description: "The SET signature could not be validated.",
 		}
 	}
 

--- a/pkg/services/stream_service.go
+++ b/pkg/services/stream_service.go
@@ -280,6 +280,15 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamSt
 		return model.StreamConfiguration{}, err
 	}
 
+	// Signing-only receive posture guardrail (#184): a stream that gates trust on
+	// the SET's JWS signature (rather than a transport bearer) MUST carry an explicit
+	// trust anchor — the issuer it trusts plus where that issuer's keys live. We
+	// validate the request as supplied (before Iss is defaulted to the local issuer),
+	// so signingOnly can never be silently enabled without a real trust anchor.
+	if request.SigningOnly && (request.Iss == "" || request.IssuerJWKSUrl == "") {
+		return model.StreamConfiguration{}, errors.New("signingOnly requires both iss and issuerJWKSUrl to be configured")
+	}
+
 	mid := bson.NewObjectID()
 
 	// var authCtx authSupport.AuthContext
@@ -376,6 +385,7 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamSt
 
 	delivery := request.Delivery
 	config.RouteMode = request.RouteMode
+	config.SigningOnly = request.SigningOnly
 	config.TxWellKnownUrl = request.TxWellKnownUrl
 	if transmitAlias != "" {
 		config.TxAlias = &transmitAlias
@@ -1095,6 +1105,17 @@ func (s *StreamService) UpdateStream(ctx context.Context, streamID string, proje
 		if configReq.InactivityTimeout > 0 {
 			config.InactivityTimeout = configReq.InactivityTimeout
 		}
+	}
+
+	// Signing-only posture (#184) is settable on receiver streams via update; it is a
+	// no-op on transmitter streams. Apply the same trust-anchor guardrail as create:
+	// the resulting stream must name both an issuer and a JWKS URL when signing-only.
+	switch config.Delivery.GetMethod() {
+	case model.ReceivePoll, model.ReceivePush:
+		config.SigningOnly = configReq.SigningOnly
+	}
+	if config.SigningOnly && (config.Iss == "" || config.IssuerJWKSUrl == "") {
+		return nil, errors.New("signingOnly requires both iss and issuerJWKSUrl to be configured")
 	}
 
 	streamRec.StreamConfiguration = *config

--- a/pkg/services/stream_service_signing_only_test.go
+++ b/pkg/services/stream_service_signing_only_test.go
@@ -1,0 +1,139 @@
+package services
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// signingOnlyReceiveRequest builds a ReceivePoll receiver create/update request
+// carrying the signing-only posture (#184) with the given trust anchor.
+func signingOnlyReceiveRequest(iss, jwksUrl string) model.StreamStateRecord {
+	return model.StreamStateRecord{StreamConfiguration: model.StreamConfiguration{
+		Iss:             iss,
+		IssuerJWKSUrl:   jwksUrl,
+		SigningOnly:     true,
+		EventsRequested: []string{"urn:ietf:params:sse:event-type:risc:account-enabled"},
+		Delivery: &model.OneOfStreamConfigurationDelivery{
+			PollReceiveMethod: &model.PollReceiveMethod{Method: model.ReceivePoll},
+		},
+	}}
+}
+
+// emptyJwksServer serves a valid (empty) JWKS document so a receiver create can
+// resolve IssuerJWKSUrl without a real transmitter and without a network hang.
+func emptyJwksServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"keys":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// The create-time guardrail rejects signingOnly:true unless BOTH iss and
+// issuerJWKSUrl are supplied — there is no trust anchor otherwise.
+func TestCreateStream_SigningOnlyRequiresIssAndJwks(t *testing.T) {
+	svc := newStrictTestStreamService(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name    string
+		iss     string
+		jwksUrl string
+	}{
+		{"missing both", "", ""},
+		{"missing jwks", "https://issuer.example.com", ""},
+		{"missing iss", "", "https://issuer.example.com/jwks.json"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.CreateStream(ctx, signingOnlyReceiveRequest(tc.iss, tc.jwksUrl), "test-project", nil)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "signingOnly")
+		})
+	}
+}
+
+// With both anchor fields present the signing-only stream is created and the
+// posture persists on the returned config.
+func TestCreateStream_SigningOnlyWithAnchorSucceeds(t *testing.T) {
+	svc := newStrictTestStreamService(t)
+	ctx := context.Background()
+	jwks := emptyJwksServer(t)
+
+	cfg, err := svc.CreateStream(ctx, signingOnlyReceiveRequest("https://issuer.example.com", jwks.URL), "test-project", nil)
+	require.NoError(t, err)
+	assert.True(t, cfg.SigningOnly)
+	assert.Equal(t, "https://issuer.example.com", cfg.Iss)
+	assert.Equal(t, jwks.URL, cfg.IssuerJWKSUrl)
+}
+
+// A default (flag-off) receiver create needs no issuer/jwks anchor and is
+// unaffected by the guardrail.
+func TestCreateStream_DefaultPostureUnaffectedByGuardrail(t *testing.T) {
+	svc := newStrictTestStreamService(t)
+	ctx := context.Background()
+
+	req := model.StreamStateRecord{StreamConfiguration: model.StreamConfiguration{
+		EventsRequested: []string{"urn:ietf:params:sse:event-type:risc:account-enabled"},
+		Delivery: &model.OneOfStreamConfigurationDelivery{
+			PollReceiveMethod: &model.PollReceiveMethod{Method: model.ReceivePoll},
+		},
+	}}
+	cfg, err := svc.CreateStream(ctx, req, "test-project", nil)
+	require.NoError(t, err)
+	assert.False(t, cfg.SigningOnly)
+}
+
+// The same guardrail applies on update: enabling signingOnly:true on a stream
+// that lacks a JWKS anchor is rejected, while a stream that already carries the
+// anchor accepts the flip.
+func TestUpdateStream_SigningOnlyGuardrail(t *testing.T) {
+	svc := newStrictTestStreamService(t)
+	ctx := context.Background()
+	jwks := emptyJwksServer(t)
+
+	// Stream A: created with an anchor but flag off → flipping on succeeds.
+	anchored := signingOnlyReceiveRequest("https://issuer.example.com", jwks.URL)
+	anchored.SigningOnly = false
+	cfgA, err := svc.CreateStream(ctx, anchored, "test-project", nil)
+	require.NoError(t, err)
+	require.False(t, cfgA.SigningOnly)
+
+	flip := model.StreamStateRecord{StreamConfiguration: model.StreamConfiguration{
+		SigningOnly: true,
+		Delivery: &model.OneOfStreamConfigurationDelivery{
+			PollReceiveMethod: &model.PollReceiveMethod{Method: model.ReceivePoll},
+		},
+	}}
+	updated, err := svc.UpdateStream(ctx, cfgA.Id, "test-project", flip)
+	require.NoError(t, err)
+	assert.True(t, updated.SigningOnly)
+
+	// Stream B: created with no JWKS anchor → flipping signingOnly on is rejected.
+	plain := model.StreamStateRecord{StreamConfiguration: model.StreamConfiguration{
+		EventsRequested: []string{"urn:ietf:params:sse:event-type:risc:account-enabled"},
+		Delivery: &model.OneOfStreamConfigurationDelivery{
+			PollReceiveMethod: &model.PollReceiveMethod{Method: model.ReceivePoll},
+		},
+	}}
+	cfgB, err := svc.CreateStream(ctx, plain, "test-project", nil)
+	require.NoError(t, err)
+
+	flipB := model.StreamStateRecord{StreamConfiguration: model.StreamConfiguration{
+		SigningOnly: true,
+		Delivery: &model.OneOfStreamConfigurationDelivery{
+			PollReceiveMethod: &model.PollReceiveMethod{Method: model.ReceivePoll},
+		},
+	}}
+	_, err = svc.UpdateStream(ctx, cfgB.Id, "test-project", flipB)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "signingOnly")
+}

--- a/pkg/ssfModels/model_stream_configuration.go
+++ b/pkg/ssfModels/model_stream_configuration.go
@@ -53,6 +53,16 @@ type StreamConfiguration struct {
 
 	RouteMode string `json:"route_mode,omitempty" bson:"route_mode,omitempty"` // Is one of RouteModeImport, RouteModeForward or RouteModePublish
 
+	// SigningOnly is a goSignals business-stream receive posture (#184): when true,
+	// the SET's JWS signature — not a transport bearer — is the trust gate. A bearer
+	// becomes optional on the receive transports (push, poll-as-receiver, SSTP), but
+	// any bearer that IS presented must still be valid, and signature verification of
+	// inbound SETs becomes mandatory. Defaults to false (bearer-always, unchanged). It
+	// MUST NOT be inferred from "issuer is configured": stream-create requires both Iss
+	// and IssuerJWKSUrl when this is true, as the configured issuer's JWKS is the only
+	// trust anchor a signing-only stream has.
+	SigningOnly bool `json:"signingOnly,omitempty" bson:"signing_only,omitempty"`
+
 	// TxWellKnownUrl Used to record the well-known endpoint for the SSF transmitter. Used by receivers to discover the transmitter's configuration and capabilities.
 	// When creating a receiver, providing a value without endpoint values for Delivery (other than method) will cause i2goSignals to initiate an SSF registration with the transmitter.
 	TxWellKnownUrl *string `json:"tx_well_known_url,omitempty" bson:"tx_well_known_url,omitempty"`


### PR DESCRIPTION
Closes #184.

Adds a per-stream **`signingOnly`** posture (default off) for business streams on `goSignalsServer`, where the **SET JWS signature is the trust gate** instead of a transport bearer: any entity may submit, but a SET that fails to authenticate/validate is rejected per-SET. Flag-off streams are byte-for-byte unchanged. This is **Model A (single-issuer)** — the stream trusts its existing single `Iss` + `IssuerJWKSUrl`; no new trust-anchor/allowlist/discovery infrastructure.

The posture spans all three receive transports uniformly: **RFC 8935 push**, **RFC 8936 poll** (server-as-receiver), and **SSTP**.

## Behavior
- **Flag + guardrail** — new per-stream `signingOnly` bool (default false); create/update reject `true` unless both `Iss` and `IssuerJWKSUrl` are set.
- **Bearer optional, signature required** — no bearer ⇒ per-SET signature gate; a bearer that *is* presented is held to the full stream+scope check and rejected at the request level if invalid (never silently bypassed).
- **Push** — under `signingOnly`, the stream resolves from the path `/events/{id}` (rather than the bearer's `StreamId`).
- **Poll-as-receiver** — signature verification of pulled SETs becomes mandatory (no longer conditional on `JWKS != nil`); failures surface via `SetErrs`.
- **SSTP** — the `sstpAuthorized` gate becomes optional when no bearer is presented; per-SET errors report through `setErrs`.
- **`aud`** validation runs unchanged in all three transports.
- **Taxonomy** — `invalid_issuer` (issuer mismatch) / `jws_signature_failed` (issuer match, bad sig) / `invalid_request` (malformed); per-SET reject, no connection drop.
- **FW** relays the original signature unchanged (no re-sign); **IM** also supported. Trust keys off the SET's embedded `iss` + configured JWKS, independent of the transport hop and RouteMode.
- Signature failures logged at **WARN** (expected peer events, not server faults).

## Files
Model field (`pkg/ssfModels`), service guardrails + copy (`pkg/services`), the three transports and their receivers (`internal/server/api_receiver.go`, `api_sstp.go`, `pkg/goSetPoll`, `pkg/goSetPush`), plus a test file per layer. The field round-trips via the embedded `StreamConfiguration` marshalling — **no DAO changes needed**.

## Tests
`go test -race ./...` green. New tests cover accept (valid sig, no bearer), reject (bad sig / wrong issuer), bearer-present-but-invalid rejection, the create-time guardrail, and aud-mismatch — across push, poll, and SSTP.

## Reviewer note
Push invalid-bearer returns **HTTP 400** (`authentication_failed`), not the literal 401 named in the issue: the RFC 8935 push handler routes every §2.4 error through `WriteDeliveryError` (always 400), and the existing `TestAuthenticationFailed` pins this — keeping the byte-for-byte constraint requires preserving 400. The issue's "401" is literally the SSTP path, which the SSTP test asserts. The load-bearing semantic (a presented bearer is always validated, never bypassed) holds on both.

## Out of scope (deferred)
Multi-issuer allowlist; strict-mode circuit-breaker.