### PR TITLE
feat(retention): per-stream retention window + ack-anchored refcount purge + daily occupancy sampler (#226)

### DIFF
--- a/internal/dao/mongo/event_dao.go
+++ b/internal/dao/mongo/event_dao.go
@@ -324,6 +324,109 @@ func (d *EventDAOMongo) MarkDelivered(ctx context.Context, event *interfaces.Del
 	return err
 }
 
+// ListDeliveredForStream returns streamID's delivered (post-ack) events with
+// their AckDate — the retention purge clock's enumerator (ADR 0055).
+func (d *EventDAOMongo) ListDeliveredForStream(ctx context.Context, streamID string) ([]interfaces.DeliveredEvent, error) {
+	c, err := d.deliveredColLoad()
+	if err != nil {
+		return nil, err
+	}
+	sid, err := ParseObjectID(streamID)
+	if err != nil {
+		return nil, err
+	}
+	cursor, err := c.Find(ctx, bson.M{"sid": sid})
+	if err != nil {
+		eLog.Error("Error listing delivered events", "error", err)
+		return nil, err
+	}
+	var docs []deliveredDoc
+	if err = cursor.All(ctx, &docs); err != nil {
+		eLog.Error("Error parsing delivered events", "error", err)
+		return nil, err
+	}
+	out := make([]interfaces.DeliveredEvent, len(docs))
+	for i, doc := range docs {
+		out[i] = interfaces.DeliveredEvent{
+			DeliverableEvent: interfaces.DeliverableEvent{Jti: doc.Jti, StreamId: doc.Sid.Hex()},
+			AckDate:          doc.AckDate,
+		}
+	}
+	return out, nil
+}
+
+// RemoveDelivered drops streamID's delivered entry for jti (its retention clock
+// firing). The global body is left untouched.
+func (d *EventDAOMongo) RemoveDelivered(ctx context.Context, jti string, streamID string) error {
+	c, err := d.deliveredColLoad()
+	if err != nil {
+		return err
+	}
+	sid, err := ParseObjectID(streamID)
+	if err != nil {
+		return err
+	}
+	_, err = c.DeleteOne(ctx, bson.M{"jti": jti, "sid": sid})
+	if err != nil {
+		eLog.Error("Error removing delivered event", "error", err)
+	}
+	return err
+}
+
+// DeleteBodyIfUnreferenced deletes the global body for jti only when no stream
+// still references it in pending or delivered (refcount 0).
+func (d *EventDAOMongo) DeleteBodyIfUnreferenced(ctx context.Context, jti string) (bool, error) {
+	pendingCol, err := d.pendingColLoad()
+	if err != nil {
+		return false, err
+	}
+	deliveredCol, err := d.deliveredColLoad()
+	if err != nil {
+		return false, err
+	}
+	eventCol, err := d.eventColLoad()
+	if err != nil {
+		return false, err
+	}
+
+	pendingRefs, err := pendingCol.CountDocuments(ctx, bson.M{"jti": jti})
+	if err != nil {
+		eLog.Error("Error counting pending refs", "error", err)
+		return false, err
+	}
+	if pendingRefs > 0 {
+		return false, nil
+	}
+	deliveredRefs, err := deliveredCol.CountDocuments(ctx, bson.M{"jti": jti})
+	if err != nil {
+		eLog.Error("Error counting delivered refs", "error", err)
+		return false, err
+	}
+	if deliveredRefs > 0 {
+		return false, nil
+	}
+
+	res, err := eventCol.DeleteOne(ctx, bson.M{"jti": jti})
+	if err != nil {
+		eLog.Error("Error deleting event body", "error", err)
+		return false, err
+	}
+	return res.DeletedCount > 0, nil
+}
+
+// CountRetainedForStream counts streamID's delivered (post-ack-retained) JTIs.
+func (d *EventDAOMongo) CountRetainedForStream(ctx context.Context, streamID string) (int64, error) {
+	c, err := d.deliveredColLoad()
+	if err != nil {
+		return 0, err
+	}
+	sid, err := ParseObjectID(streamID)
+	if err != nil {
+		return 0, err
+	}
+	return c.CountDocuments(ctx, bson.M{"sid": sid})
+}
+
 func (d *EventDAOMongo) WatchPending(ctx context.Context, callback func(jti string, streamID string)) error {
 	c, err := d.pendingColLoad()
 	if err != nil {

--- a/internal/providers/dbProviders/memory_provider/notifying_dao.go
+++ b/internal/providers/dbProviders/memory_provider/notifying_dao.go
@@ -156,6 +156,33 @@ func (d *notifyingEventDAO) MarkDelivered(ctx context.Context, event *interfaces
 	return nil
 }
 
+func (d *notifyingEventDAO) ListDeliveredForStream(ctx context.Context, streamID string) ([]interfaces.DeliveredEvent, error) {
+	return d.inner.ListDeliveredForStream(ctx, streamID)
+}
+
+func (d *notifyingEventDAO) RemoveDelivered(ctx context.Context, jti string, streamID string) error {
+	if err := d.inner.RemoveDelivered(ctx, jti, streamID); err != nil {
+		return err
+	}
+	d.notify()
+	return nil
+}
+
+func (d *notifyingEventDAO) DeleteBodyIfUnreferenced(ctx context.Context, jti string) (bool, error) {
+	deleted, err := d.inner.DeleteBodyIfUnreferenced(ctx, jti)
+	if err != nil {
+		return deleted, err
+	}
+	if deleted {
+		d.notify()
+	}
+	return deleted, nil
+}
+
+func (d *notifyingEventDAO) CountRetainedForStream(ctx context.Context, streamID string) (int64, error) {
+	return d.inner.CountRetainedForStream(ctx, streamID)
+}
+
 func (d *notifyingEventDAO) WatchPending(ctx context.Context, callback func(jti string, streamID string)) error {
 	return d.inner.WatchPending(ctx, callback)
 }

--- a/pkg/dao/dao_interfaces.go
+++ b/pkg/dao/dao_interfaces.go
@@ -71,6 +71,33 @@ type EventDAO interface {
 	// Delivered events
 	MarkDelivered(ctx context.Context, event *DeliverableEvent, ackDate time.Time) error
 
+	// --- Ack-anchored retention purge + occupancy sampling (ADR 0055) ---
+
+	// ListDeliveredForStream returns streamID's delivered (post-ack,
+	// not-yet-purged) events, each carrying its AckDate. It is the enumerator the
+	// per-(stream, JTI) retention clock reads to decide expiry. Order is
+	// unspecified.
+	ListDeliveredForStream(ctx context.Context, streamID string) ([]DeliveredEvent, error)
+
+	// RemoveDelivered drops streamID's delivered entry for jti when its
+	// retention clock fires. It does NOT touch the global event body; body
+	// deletion is refcount-gated via DeleteBodyIfUnreferenced. Removing an entry
+	// that does not exist is not an error.
+	RemoveDelivered(ctx context.Context, jti string, streamID string) error
+
+	// DeleteBodyIfUnreferenced deletes the global event body for jti ONLY when no
+	// stream still references it in pending or delivered (refcount 0 — the body
+	// survives to the maximum effective window across all referencing streams).
+	// Because pending is never purged, a still-pending JTI always keeps its body.
+	// It reports whether the body was deleted; a still-referenced or absent body
+	// is not an error.
+	DeleteBodyIfUnreferenced(ctx context.Context, jti string) (deleted bool, err error)
+
+	// CountRetainedForStream returns the number of post-ack-retained (delivered,
+	// not-yet-purged) JTIs for streamID — the daily occupancy sampler's per-stream
+	// retained_count (pending excluded).
+	CountRetainedForStream(ctx context.Context, streamID string) (int64, error)
+
 	// Change streams
 	WatchPending(ctx context.Context, callback func(jti string, streamID string)) error
 }

--- a/pkg/dao/memory/event_dao.go
+++ b/pkg/dao/memory/event_dao.go
@@ -214,6 +214,80 @@ func (d *EventDAOMemory) MarkDelivered(_ context.Context, event *interfaces.Deli
 	return nil
 }
 
+// ListDeliveredForStream returns a copy of streamID's delivered events (ADR 0055).
+func (d *EventDAOMemory) ListDeliveredForStream(_ context.Context, streamID string) ([]interfaces.DeliveredEvent, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	delivered := d.deliveredEvents[streamID]
+	out := make([]interfaces.DeliveredEvent, len(delivered))
+	copy(out, delivered)
+	return out, nil
+}
+
+// RemoveDelivered drops streamID's delivered entry for jti. The global body is
+// left intact — refcount-gated deletion is DeleteBodyIfUnreferenced's job.
+func (d *EventDAOMemory) RemoveDelivered(_ context.Context, jti string, streamID string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	delivered, ok := d.deliveredEvents[streamID]
+	if !ok {
+		return nil
+	}
+	kept := delivered[:0:0]
+	for _, evt := range delivered {
+		if evt.Jti != jti {
+			kept = append(kept, evt)
+		}
+	}
+	if len(kept) == 0 {
+		delete(d.deliveredEvents, streamID)
+	} else {
+		d.deliveredEvents[streamID] = kept
+	}
+	return nil
+}
+
+// DeleteBodyIfUnreferenced deletes the global body for jti only when no stream
+// references it in pending or delivered (refcount 0).
+func (d *EventDAOMemory) DeleteBodyIfUnreferenced(_ context.Context, jti string) (bool, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if _, ok := d.events[jti]; !ok {
+		return false, nil
+	}
+	for _, pending := range d.pendingEvents {
+		for _, evt := range pending {
+			if evt.Jti == jti {
+				return false, nil
+			}
+		}
+	}
+	for _, delivered := range d.deliveredEvents {
+		for _, evt := range delivered {
+			if evt.Jti == jti {
+				return false, nil
+			}
+		}
+	}
+
+	delete(d.events, jti)
+	if d.useDisk {
+		d.deleteEventFromDiskLocked(jti)
+	}
+	return true, nil
+}
+
+// CountRetainedForStream returns the count of post-ack-retained (delivered)
+// JTIs for streamID — the daily occupancy sampler's retained_count.
+func (d *EventDAOMemory) CountRetainedForStream(_ context.Context, streamID string) (int64, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return int64(len(d.deliveredEvents[streamID])), nil
+}
+
 func (d *EventDAOMemory) WatchPending(ctx context.Context, _ func(jti string, streamID string)) error {
 	// Mock implementation: for now, we don't need to do anything here
 	// since HandleEvent already updates local buffers in the router.
@@ -234,6 +308,14 @@ func (d *EventDAOMemory) saveEventToDiskLocked(record *model.EventRecord) error 
 		return err
 	}
 	return os.WriteFile(path, data, 0644)
+}
+
+func (d *EventDAOMemory) deleteEventFromDiskLocked(jti string) {
+	if d.persistDir == "" {
+		return
+	}
+	path := filepath.Join(d.persistDir, "events", jti+".set")
+	_ = os.Remove(path)
 }
 
 func (d *EventDAOMemory) loadEventFromDisk(jti string) (*model.EventRecord, error) {

--- a/pkg/dao/memory/event_dao_retention_test.go
+++ b/pkg/dao/memory/event_dao_retention_test.go
@@ -1,0 +1,147 @@
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	interfaces "github.com/i2-open/i2goSignals/pkg/dao"
+	"github.com/i2-open/i2goSignals/pkg/goSet"
+	"github.com/i2-open/i2goSignals/pkg/ssfModels"
+)
+
+func insertBody(t *testing.T, dao *EventDAOMemory, jti string) {
+	t.Helper()
+	ev := &goSet.SecurityEventToken{Events: map[string]interface{}{"test": "e"}}
+	ev.ID = jti
+	rec := &model.EventRecord{Jti: jti, Event: *ev, SortTime: time.Now()}
+	if err := dao.Insert(context.Background(), rec); err != nil {
+		t.Fatalf("insert %s: %v", jti, err)
+	}
+}
+
+func markDelivered(t *testing.T, dao *EventDAOMemory, jti, streamID string, ack time.Time) {
+	t.Helper()
+	err := dao.MarkDelivered(context.Background(), &interfaces.DeliverableEvent{Jti: jti, StreamId: streamID}, ack)
+	if err != nil {
+		t.Fatalf("mark delivered %s/%s: %v", jti, streamID, err)
+	}
+}
+
+func TestEventDAOMemory_ListDeliveredForStream(t *testing.T) {
+	ctx := context.Background()
+	dao := NewEventDAO()
+	ack := time.Now()
+	insertBody(t, dao, "j1")
+	markDelivered(t, dao, "j1", "s1", ack)
+
+	got, err := dao.ListDeliveredForStream(ctx, "s1")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 1 || got[0].Jti != "j1" || !got[0].AckDate.Equal(ack) {
+		t.Fatalf("unexpected delivered list: %#v", got)
+	}
+	if empty, _ := dao.ListDeliveredForStream(ctx, "other"); len(empty) != 0 {
+		t.Fatalf("expected no delivered for unknown stream, got %#v", empty)
+	}
+}
+
+func TestEventDAOMemory_CountRetainedForStream(t *testing.T) {
+	ctx := context.Background()
+	dao := NewEventDAO()
+	now := time.Now()
+	insertBody(t, dao, "j1")
+	insertBody(t, dao, "j2")
+	markDelivered(t, dao, "j1", "s1", now)
+	markDelivered(t, dao, "j2", "s1", now)
+
+	n, err := dao.CountRetainedForStream(ctx, "s1")
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("expected 2 retained, got %d", n)
+	}
+}
+
+func TestEventDAOMemory_RemoveDelivered_LeavesBody(t *testing.T) {
+	ctx := context.Background()
+	dao := NewEventDAO()
+	insertBody(t, dao, "j1")
+	markDelivered(t, dao, "j1", "s1", time.Now())
+
+	if err := dao.RemoveDelivered(ctx, "j1", "s1"); err != nil {
+		t.Fatalf("remove delivered: %v", err)
+	}
+	if n, _ := dao.CountRetainedForStream(ctx, "s1"); n != 0 {
+		t.Fatalf("expected delivered entry removed, count=%d", n)
+	}
+	// Body must survive until a refcount-gated delete.
+	if rec, _ := dao.FindByJTI(ctx, "j1"); rec == nil {
+		t.Fatalf("RemoveDelivered must not delete the global body")
+	}
+	// Removing a non-existent entry is not an error.
+	if err := dao.RemoveDelivered(ctx, "nope", "s1"); err != nil {
+		t.Fatalf("remove missing: %v", err)
+	}
+}
+
+func TestEventDAOMemory_DeleteBodyIfUnreferenced_Refcount(t *testing.T) {
+	ctx := context.Background()
+	dao := NewEventDAO()
+	insertBody(t, dao, "j1")
+	markDelivered(t, dao, "j1", "s1", time.Now())
+	markDelivered(t, dao, "j1", "s2", time.Now())
+
+	// Referenced by s2's delivered entry — must not delete.
+	if err := dao.RemoveDelivered(ctx, "j1", "s1"); err != nil {
+		t.Fatalf("remove s1: %v", err)
+	}
+	deleted, err := dao.DeleteBodyIfUnreferenced(ctx, "j1")
+	if err != nil {
+		t.Fatalf("delete-if-unref: %v", err)
+	}
+	if deleted {
+		t.Fatalf("body must survive while s2 still references it")
+	}
+	if rec, _ := dao.FindByJTI(ctx, "j1"); rec == nil {
+		t.Fatalf("body wrongly deleted while referenced")
+	}
+
+	// Drop the last reference — now it deletes.
+	if err := dao.RemoveDelivered(ctx, "j1", "s2"); err != nil {
+		t.Fatalf("remove s2: %v", err)
+	}
+	deleted, err = dao.DeleteBodyIfUnreferenced(ctx, "j1")
+	if err != nil {
+		t.Fatalf("delete-if-unref (2): %v", err)
+	}
+	if !deleted {
+		t.Fatalf("body should be deleted once unreferenced")
+	}
+	if rec, _ := dao.FindByJTI(ctx, "j1"); rec != nil {
+		t.Fatalf("body should be gone")
+	}
+}
+
+func TestEventDAOMemory_DeleteBodyIfUnreferenced_PendingHolds(t *testing.T) {
+	ctx := context.Background()
+	dao := NewEventDAO()
+	insertBody(t, dao, "j1")
+	if err := dao.AddPending(ctx, "j1", "s1"); err != nil {
+		t.Fatalf("add pending: %v", err)
+	}
+
+	// A still-pending JTI must keep its body (pending is never purged).
+	deleted, err := dao.DeleteBodyIfUnreferenced(ctx, "j1")
+	if err != nil {
+		t.Fatalf("delete-if-unref: %v", err)
+	}
+	if deleted {
+		t.Fatalf("pending reference must hold the body")
+	}
+	if rec, _ := dao.FindByJTI(ctx, "j1"); rec == nil {
+		t.Fatalf("pending body wrongly deleted")
+	}
+}

--- a/pkg/services/event_service_test.go
+++ b/pkg/services/event_service_test.go
@@ -80,6 +80,16 @@ func (f *fakeEventDAO) MarkDelivered(_ context.Context, _ *interfaces.Deliverabl
 func (f *fakeEventDAO) WatchPending(_ context.Context, _ func(jti string, streamID string)) error {
 	return nil
 }
+func (f *fakeEventDAO) ListDeliveredForStream(_ context.Context, _ string) ([]interfaces.DeliveredEvent, error) {
+	return nil, nil
+}
+func (f *fakeEventDAO) RemoveDelivered(_ context.Context, _ string, _ string) error { return nil }
+func (f *fakeEventDAO) DeleteBodyIfUnreferenced(_ context.Context, _ string) (bool, error) {
+	return false, nil
+}
+func (f *fakeEventDAO) CountRetainedForStream(_ context.Context, _ string) (int64, error) {
+	return 0, nil
+}
 
 func newTokenWithJTI(jti string) *goSet.SecurityEventToken {
 	token := &goSet.SecurityEventToken{

--- a/pkg/services/retention.go
+++ b/pkg/services/retention.go
@@ -1,0 +1,151 @@
+package services
+
+import (
+	"context"
+	"time"
+
+	interfaces "github.com/i2-open/i2goSignals/pkg/dao"
+	"github.com/i2-open/i2goSignals/pkg/logger"
+	"github.com/i2-open/i2goSignals/pkg/ssfModels"
+)
+
+var retLog = logger.Sub("RETENTION")
+
+// EffectiveWindowFunc resolves the effective retention window (in days) for a
+// stream. A nil result — or a non-positive value — means keep-forever, so the
+// purge engine skips the stream entirely. The community default resolver
+// (DefaultEffectiveWindow) returns the per-stream RetentionWindowDays override
+// only, which is nil unless an operator set it: that is why the engine ships
+// DORMANT (ADR 0055 decision 3). The enterprise superset supplies its own
+// resolver that folds in the enrollment-bundle default and cap.
+type EffectiveWindowFunc func(stream *model.StreamStateRecord) *int
+
+// DefaultEffectiveWindow is community's dormant-by-default window resolver: it
+// honors only the per-stream override, treating an unset (nil) override as
+// keep-forever. Without a finite window from this or an enterprise-supplied
+// resolver, nothing ever expires.
+func DefaultEffectiveWindow(stream *model.StreamStateRecord) *int {
+	return stream.RetentionWindowDays
+}
+
+// OccupancySample is one daily per-stream retained-occupancy observation — the
+// community→enterprise contract feeding ADR 0055's Mean Retained Events (MRE)
+// aggregation. The idempotency key is (ServerURN, StreamURN, SampleDate); every
+// HA replica emits an identical sample because the event store is shared, and
+// tenancy dedups on that key. RetainedCount counts post-ack-retained (delivered,
+// not-yet-purged) JTIs only — pending is excluded.
+type OccupancySample struct {
+	ServerURN     string
+	StreamURN     string
+	SampleDate    string // UTC calendar date, "YYYY-MM-DD"
+	RetainedCount int64
+}
+
+// OccupancySink receives the daily per-stream occupancy samples. Community
+// registers none (the sampler is inert without a sink); the enterprise superset
+// registers one to forward samples to the tenancy MRE aggregator — mirroring the
+// event-router MeteringObserver seam.
+type OccupancySink interface {
+	ObserveOccupancy(sample OccupancySample)
+}
+
+// RetentionEngine owns the ack-anchored refcount purge and the daily occupancy
+// sampler. It holds no scheduler of its own: PurgeExpired and SampleOccupancy
+// are driven by the server's periodic tick (or a test clock), each handed the
+// current stream set so the engine stays decoupled from the StreamDAO.
+type RetentionEngine struct {
+	eventDAO interfaces.EventDAO
+}
+
+// NewRetentionEngine constructs a RetentionEngine over the given event store.
+func NewRetentionEngine(eventDAO interfaces.EventDAO) *RetentionEngine {
+	return &RetentionEngine{eventDAO: eventDAO}
+}
+
+// PurgeExpired runs one ack-anchored purge pass over streams at time now,
+// resolving each stream's effective window via window. The clock is per (stream,
+// JTI): a delivered entry expires when AckDate + window <= now. On expiry the
+// stream's delivered entry is dropped; the global body is deleted ONLY when no
+// stream (pending or delivered) still references the JTI — so a body referenced
+// by two streams survives until BOTH windows expire (refcount → 0). Pending is
+// never touched. Streams whose effective window is keep-forever (nil or
+// non-positive) are skipped, which is why the engine is inert until a finite
+// window is set. It returns the number of global bodies deleted.
+func (e *RetentionEngine) PurgeExpired(ctx context.Context, now time.Time, streams []model.StreamStateRecord, window EffectiveWindowFunc) (int, error) {
+	if window == nil {
+		window = DefaultEffectiveWindow
+	}
+
+	// Candidate JTIs whose per-stream entry expired this pass; each is re-checked
+	// for refcount 0 after all per-stream removals so a body shared across streams
+	// with different windows is only deleted once the last reference is gone.
+	candidates := make(map[string]struct{})
+
+	for i := range streams {
+		stream := &streams[i]
+		days := window(stream)
+		if days == nil || *days <= 0 {
+			continue // keep-forever — engine stays dormant for this stream
+		}
+		streamID := stream.Id.Hex()
+		cutoff := now.Add(-time.Duration(*days) * 24 * time.Hour)
+
+		delivered, err := e.eventDAO.ListDeliveredForStream(ctx, streamID)
+		if err != nil {
+			return 0, err
+		}
+		for _, evt := range delivered {
+			// Not yet expired when AckDate is at/after the cutoff.
+			if evt.AckDate.After(cutoff) || evt.AckDate.Equal(cutoff) {
+				continue
+			}
+			if err := e.eventDAO.RemoveDelivered(ctx, evt.Jti, streamID); err != nil {
+				return 0, err
+			}
+			candidates[evt.Jti] = struct{}{}
+		}
+	}
+
+	purged := 0
+	for jti := range candidates {
+		deleted, err := e.eventDAO.DeleteBodyIfUnreferenced(ctx, jti)
+		if err != nil {
+			return purged, err
+		}
+		if deleted {
+			purged++
+		}
+	}
+	if purged > 0 {
+		retLog.Debug("Retention purge deleted event bodies", "count", purged)
+	}
+	return purged, nil
+}
+
+// SampleOccupancy emits one OccupancySample per stream to sink at time now,
+// stamped with serverURN. RetainedCount is the stream's delivered
+// (post-ack-retained) JTI count read from the shared store, so every HA replica
+// produces an identical sample; SampleDate is now's UTC calendar date, making
+// (serverURN, streamURN, sampleDate) the idempotency key tenancy dedups on. A
+// nil sink is a no-op (the sampler is inert until the enterprise superset
+// registers one).
+func (e *RetentionEngine) SampleOccupancy(ctx context.Context, now time.Time, serverURN string, streams []model.StreamStateRecord, sink OccupancySink) error {
+	if sink == nil {
+		return nil
+	}
+	sampleDate := now.UTC().Format("2006-01-02")
+	for i := range streams {
+		streamID := streams[i].Id.Hex()
+		count, err := e.eventDAO.CountRetainedForStream(ctx, streamID)
+		if err != nil {
+			return err
+		}
+		sink.ObserveOccupancy(OccupancySample{
+			ServerURN:     serverURN,
+			StreamURN:     streamID,
+			SampleDate:    sampleDate,
+			RetainedCount: count,
+		})
+	}
+	return nil
+}

--- a/pkg/services/retention_test.go
+++ b/pkg/services/retention_test.go
@@ -1,0 +1,211 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	interfaces "github.com/i2-open/i2goSignals/pkg/dao"
+	"github.com/i2-open/i2goSignals/pkg/dao/memory"
+	"github.com/i2-open/i2goSignals/pkg/goSet"
+	"github.com/i2-open/i2goSignals/pkg/ssfModels"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func days(n int) *int { return &n }
+
+func streamWithWindow(win *int) model.StreamStateRecord {
+	return model.StreamStateRecord{Id: bson.NewObjectID(), RetentionWindowDays: win}
+}
+
+func seedBody(t *testing.T, dao *memory.EventDAOMemory, jti string) {
+	t.Helper()
+	ev := &goSet.SecurityEventToken{Events: map[string]interface{}{"t": "e"}}
+	ev.ID = jti
+	if err := dao.Insert(context.Background(), &model.EventRecord{Jti: jti, Event: *ev, SortTime: time.Now()}); err != nil {
+		t.Fatalf("seed %s: %v", jti, err)
+	}
+}
+
+func deliver(t *testing.T, dao *memory.EventDAOMemory, jti, streamID string, ack time.Time) {
+	t.Helper()
+	if err := dao.MarkDelivered(context.Background(), &interfaces.DeliverableEvent{Jti: jti, StreamId: streamID}, ack); err != nil {
+		t.Fatalf("deliver %s/%s: %v", jti, streamID, err)
+	}
+}
+
+// TestPurgeExpired_Dormant asserts keep-forever (nil window) never purges,
+// however old the ack is — the engine ships DORMANT (ADR 0055 decision 3).
+func TestPurgeExpired_Dormant(t *testing.T) {
+	ctx := context.Background()
+	dao := memory.NewEventDAO()
+	eng := NewRetentionEngine(dao)
+
+	stream := streamWithWindow(nil) // keep-forever
+	seedBody(t, dao, "j1")
+	deliver(t, dao, "j1", stream.Id.Hex(), time.Now().Add(-365*24*time.Hour))
+
+	purged, err := eng.PurgeExpired(ctx, time.Now(), []model.StreamStateRecord{stream}, DefaultEffectiveWindow)
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if purged != 0 {
+		t.Fatalf("dormant engine purged %d bodies", purged)
+	}
+	if n, _ := dao.CountRetainedForStream(ctx, stream.Id.Hex()); n != 1 {
+		t.Fatalf("dormant engine dropped a delivered entry, count=%d", n)
+	}
+	if rec, _ := dao.FindByJTI(ctx, "j1"); rec == nil {
+		t.Fatalf("dormant engine deleted a body")
+	}
+}
+
+// TestPurgeExpired_FinitePurgesPostAck asserts a post-ack event older than the
+// finite window is purged, while a fresh one and a pending one survive.
+func TestPurgeExpired_FinitePurgesPostAck(t *testing.T) {
+	ctx := context.Background()
+	dao := memory.NewEventDAO()
+	eng := NewRetentionEngine(dao)
+
+	stream := streamWithWindow(days(7))
+	sid := stream.Id.Hex()
+	now := time.Now()
+
+	seedBody(t, dao, "old")   // acked 10 days ago -> expired
+	seedBody(t, dao, "fresh") // acked 1 day ago -> retained
+	seedBody(t, dao, "pend")  // pending -> never purged
+	deliver(t, dao, "old", sid, now.Add(-10*24*time.Hour))
+	deliver(t, dao, "fresh", sid, now.Add(-1*24*time.Hour))
+	if err := dao.AddPending(ctx, "pend", sid); err != nil {
+		t.Fatalf("add pending: %v", err)
+	}
+
+	purged, err := eng.PurgeExpired(ctx, now, []model.StreamStateRecord{stream}, DefaultEffectiveWindow)
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("expected 1 purged body, got %d", purged)
+	}
+	if rec, _ := dao.FindByJTI(ctx, "old"); rec != nil {
+		t.Fatalf("expired body should be gone")
+	}
+	if rec, _ := dao.FindByJTI(ctx, "fresh"); rec == nil {
+		t.Fatalf("fresh body wrongly purged")
+	}
+	if rec, _ := dao.FindByJTI(ctx, "pend"); rec == nil {
+		t.Fatalf("pending body wrongly purged")
+	}
+	// Pending entry itself is untouched.
+	jtis, total, _ := dao.GetPendingForStream(ctx, sid, 10)
+	if total != 1 || len(jtis) != 1 || jtis[0] != "pend" {
+		t.Fatalf("pending entry disturbed: %v total=%d", jtis, total)
+	}
+}
+
+// TestPurgeExpired_RefcountAcrossStreams asserts a body fanned out to two streams
+// with different windows survives to the MAX window (refcount 0 gate).
+func TestPurgeExpired_RefcountAcrossStreams(t *testing.T) {
+	ctx := context.Background()
+	dao := memory.NewEventDAO()
+	eng := NewRetentionEngine(dao)
+
+	short := streamWithWindow(days(1))
+	long := streamWithWindow(days(10))
+	streams := []model.StreamStateRecord{short, long}
+
+	t0 := time.Now().Add(-100 * 24 * time.Hour) // fixed ack anchor in the past
+	seedBody(t, dao, "shared")
+	deliver(t, dao, "shared", short.Id.Hex(), t0)
+	deliver(t, dao, "shared", long.Id.Hex(), t0)
+
+	// Pass 1 at t0+2d: only the short window has elapsed. Body must survive.
+	purged, err := eng.PurgeExpired(ctx, t0.Add(2*24*time.Hour), streams, DefaultEffectiveWindow)
+	if err != nil {
+		t.Fatalf("pass1: %v", err)
+	}
+	if purged != 0 {
+		t.Fatalf("pass1 purged %d; body must survive to the max window", purged)
+	}
+	if rec, _ := dao.FindByJTI(ctx, "shared"); rec == nil {
+		t.Fatalf("body deleted while long-window stream still references it")
+	}
+	if n, _ := dao.CountRetainedForStream(ctx, short.Id.Hex()); n != 0 {
+		t.Fatalf("short-window delivered entry should be dropped, count=%d", n)
+	}
+	if n, _ := dao.CountRetainedForStream(ctx, long.Id.Hex()); n != 1 {
+		t.Fatalf("long-window delivered entry should remain, count=%d", n)
+	}
+
+	// Pass 2 at t0+11d: the long window has now elapsed too. Body deleted.
+	purged, err = eng.PurgeExpired(ctx, t0.Add(11*24*time.Hour), streams, DefaultEffectiveWindow)
+	if err != nil {
+		t.Fatalf("pass2: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("pass2 should delete the now-unreferenced body, purged=%d", purged)
+	}
+	if rec, _ := dao.FindByJTI(ctx, "shared"); rec != nil {
+		t.Fatalf("body should be gone once both windows expired")
+	}
+}
+
+type captureSink struct{ samples []OccupancySample }
+
+func (c *captureSink) ObserveOccupancy(s OccupancySample) { c.samples = append(c.samples, s) }
+
+// TestSampleOccupancy_EmitsPerStreamRetained asserts the sampler emits the pinned
+// tuple with post-ack-retained counts and a stable idempotency key.
+func TestSampleOccupancy_EmitsPerStreamRetained(t *testing.T) {
+	ctx := context.Background()
+	dao := memory.NewEventDAO()
+	eng := NewRetentionEngine(dao)
+
+	s1 := streamWithWindow(nil)
+	s2 := streamWithWindow(nil)
+	now := time.Now()
+	seedBody(t, dao, "a")
+	seedBody(t, dao, "b")
+	seedBody(t, dao, "c")
+	deliver(t, dao, "a", s1.Id.Hex(), now)
+	deliver(t, dao, "b", s1.Id.Hex(), now)
+	deliver(t, dao, "c", s2.Id.Hex(), now)
+	// A pending event must NOT count toward retained.
+	if err := dao.AddPending(ctx, "a", s2.Id.Hex()); err != nil {
+		t.Fatalf("add pending: %v", err)
+	}
+
+	sink := &captureSink{}
+	sampleTime := time.Date(2026, 7, 4, 15, 4, 5, 0, time.UTC)
+	if err := eng.SampleOccupancy(ctx, sampleTime, "urn:server:test", []model.StreamStateRecord{s1, s2}, sink); err != nil {
+		t.Fatalf("sample: %v", err)
+	}
+	if len(sink.samples) != 2 {
+		t.Fatalf("expected 2 samples, got %d", len(sink.samples))
+	}
+	byStream := map[string]OccupancySample{}
+	for _, s := range sink.samples {
+		byStream[s.StreamURN] = s
+		if s.ServerURN != "urn:server:test" {
+			t.Fatalf("wrong server urn: %q", s.ServerURN)
+		}
+		if s.SampleDate != "2026-07-04" {
+			t.Fatalf("wrong sample date: %q", s.SampleDate)
+		}
+	}
+	if got := byStream[s1.Id.Hex()].RetainedCount; got != 2 {
+		t.Fatalf("s1 retained = %d, want 2", got)
+	}
+	if got := byStream[s2.Id.Hex()].RetainedCount; got != 1 {
+		t.Fatalf("s2 retained = %d, want 1 (pending excluded)", got)
+	}
+}
+
+// TestSampleOccupancy_NilSinkNoop asserts a nil sink is inert (no sink registered).
+func TestSampleOccupancy_NilSinkNoop(t *testing.T) {
+	dao := memory.NewEventDAO()
+	eng := NewRetentionEngine(dao)
+	if err := eng.SampleOccupancy(context.Background(), time.Now(), "urn:s", []model.StreamStateRecord{streamWithWindow(nil)}, nil); err != nil {
+		t.Fatalf("nil sink should be a no-op, got %v", err)
+	}
+}

--- a/pkg/ssfModels/model_stream_state.go
+++ b/pkg/ssfModels/model_stream_state.go
@@ -106,6 +106,16 @@ type StreamStateRecord struct {
 	// slice — it is settable, persisted, and round-trippable.
 	SubjectRemovalGraceSeconds int `json:"subject_removal_grace_seconds,omitempty" bson:"subject_removal_grace_seconds,omitempty"`
 
+	// RetentionWindowDays is the per-stream event-retention override (ADR 0055,
+	// Q91.1). Like DefaultSubjects it is a goSignals operator knob and is
+	// deliberately kept OFF the SSF wire-format StreamConfiguration — it is NOT
+	// an RFC 8935 StreamConfiguration field. `nil` means inherit the tenancy
+	// default (which itself defaults to keep-forever), so the ack-anchored purge
+	// engine stays dormant until a finite window is set. The effective window is
+	// resolved server-side as stream.RetentionWindowDays ?? bundle default ??
+	// keep-forever. A non-positive value is treated as keep-forever.
+	RetentionWindowDays *int `json:"retention_window_days,omitempty" bson:"retention_window_days,omitempty"`
+
 	// --- SSTP bidirectional pair fields (PRD #154, ADR 0018) ---
 	// A single StreamStateRecord represents both directions of an SSTP pair on
 	// one node: the embedded StreamConfiguration is the transmit (outbound)
@@ -162,6 +172,10 @@ func (ss *StreamStateRecord) DeepCopy() *StreamStateRecord {
 	res := *ss
 	res.StreamConfiguration = ss.StreamConfiguration.DeepCopy()
 	res.EventSource = ss.EventSource.DeepCopy()
+	if ss.RetentionWindowDays != nil {
+		v := *ss.RetentionWindowDays
+		res.RetentionWindowDays = &v
+	}
 	if ss.SstpInbound != nil {
 		inbound := ss.SstpInbound.DeepCopy()
 		res.SstpInbound = &inbound
@@ -186,6 +200,7 @@ func (ss *StreamStateRecord) Update(mod *StreamStateRecord) {
 	ss.SubjectFilterMode = mod.SubjectFilterMode
 	ss.EventSource = mod.EventSource
 	ss.SubjectRemovalGraceSeconds = mod.SubjectRemovalGraceSeconds
+	ss.RetentionWindowDays = mod.RetentionWindowDays
 	ss.SstpInbound = mod.SstpInbound
 	ss.SstpMethod = mod.SstpMethod
 	ss.PairId = mod.PairId

--- a/pkg/ssfModels/model_stream_state_retention_test.go
+++ b/pkg/ssfModels/model_stream_state_retention_test.go
@@ -1,0 +1,104 @@
+package model
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func intPtr(v int) *int { return &v }
+
+// TestRetentionWindow_OffSsfWire asserts the retention knob is deliberately kept
+// off the RFC 8935 StreamConfiguration wire object (ADR 0055 Q91.1): marshaling
+// a StreamConfiguration never emits a retention field.
+func TestRetentionWindow_OffSsfWire(t *testing.T) {
+	cfg := StreamConfiguration{Id: "stream-1", Iss: "https://issuer.example"}
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal StreamConfiguration: %v", err)
+	}
+	if strings.Contains(strings.ToLower(string(b)), "retention") {
+		t.Fatalf("SSF wire StreamConfiguration must not carry a retention field, got: %s", b)
+	}
+}
+
+// TestRetentionWindow_PersistsOnState verifies the override round-trips on the
+// server-internal StreamStateRecord over both JSON and BSON, mirroring the
+// DefaultSubjects precedent.
+func TestRetentionWindow_PersistsOnState(t *testing.T) {
+	rec := StreamStateRecord{
+		Id:                  bson.NewObjectID(),
+		RetentionWindowDays: intPtr(30),
+	}
+
+	// JSON round-trip
+	jb, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatalf("json marshal: %v", err)
+	}
+	if !strings.Contains(string(jb), "retention_window_days") {
+		t.Fatalf("state record JSON must carry retention_window_days, got: %s", jb)
+	}
+	var fromJSON StreamStateRecord
+	if err := json.Unmarshal(jb, &fromJSON); err != nil {
+		t.Fatalf("json unmarshal: %v", err)
+	}
+	if fromJSON.RetentionWindowDays == nil || *fromJSON.RetentionWindowDays != 30 {
+		t.Fatalf("json round-trip lost retention window: %#v", fromJSON.RetentionWindowDays)
+	}
+
+	// BSON round-trip
+	bb, err := bson.Marshal(rec)
+	if err != nil {
+		t.Fatalf("bson marshal: %v", err)
+	}
+	var fromBSON StreamStateRecord
+	if err := bson.Unmarshal(bb, &fromBSON); err != nil {
+		t.Fatalf("bson unmarshal: %v", err)
+	}
+	if fromBSON.RetentionWindowDays == nil || *fromBSON.RetentionWindowDays != 30 {
+		t.Fatalf("bson round-trip lost retention window: %#v", fromBSON.RetentionWindowDays)
+	}
+}
+
+// TestRetentionWindow_NilOmitted confirms the keep-forever default (nil) is
+// omitted from both encodings — no field emitted means "inherit".
+func TestRetentionWindow_NilOmitted(t *testing.T) {
+	rec := StreamStateRecord{Id: bson.NewObjectID()}
+	jb, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatalf("json marshal: %v", err)
+	}
+	if strings.Contains(string(jb), "retention_window_days") {
+		t.Fatalf("nil retention window must be omitted from JSON, got: %s", jb)
+	}
+}
+
+// TestRetentionWindow_DeepCopyIndependent verifies DeepCopy clones the pointer
+// so mutating the copy never aliases the source.
+func TestRetentionWindow_DeepCopyIndependent(t *testing.T) {
+	src := &StreamStateRecord{Id: bson.NewObjectID(), RetentionWindowDays: intPtr(7)}
+	cp := src.DeepCopy()
+	if cp.RetentionWindowDays == nil || *cp.RetentionWindowDays != 7 {
+		t.Fatalf("deep copy did not carry the window: %#v", cp.RetentionWindowDays)
+	}
+	if cp.RetentionWindowDays == src.RetentionWindowDays {
+		t.Fatalf("deep copy must not share the RetentionWindowDays pointer")
+	}
+	*cp.RetentionWindowDays = 99
+	if *src.RetentionWindowDays != 7 {
+		t.Fatalf("mutating copy aliased the source window")
+	}
+}
+
+// TestRetentionWindow_Update confirms Update() carries the override over.
+func TestRetentionWindow_Update(t *testing.T) {
+	dst := &StreamStateRecord{Id: bson.NewObjectID()}
+	mod := &StreamStateRecord{RetentionWindowDays: intPtr(14)}
+	dst.Update(mod)
+	if dst.RetentionWindowDays == nil || *dst.RetentionWindowDays != 14 {
+		t.Fatalf("Update did not carry retention window: %#v", dst.RetentionWindowDays)
+	}
+}


### PR DESCRIPTION
Implements the community-owned slice of ADR 0055 (enterprise `docs/adr/0055-event-retention-purge-and-replay-accounting.md`, Q91.1/.3/.5). Self-contained against the ADR-pinned seam; no sibling dependency.

## What shipped
- **Per-stream retention window.** `RetentionWindowDays *int` on `StreamStateRecord` — a server-internal operator knob kept OFF the SSF wire `StreamConfiguration` (mirrors `DefaultSubjects`). `nil` ⇒ inherit (keep-forever). Carried through `Update` + `DeepCopy` (pointer cloned, no aliasing).
- **Ack-anchored refcount purge engine (`RetentionEngine`, ships dormant).** Per-(stream, JTI) clock anchored on `DeliveredEvent.AckDate`. Pending is never purged. On expiry the stream's delivered entry is dropped; the global body is deleted only at refcount 0 (survives to the max effective window across referencing streams). The community default window resolver honors only the per-stream override, so the engine is inert until a finite window is set.
- **Daily occupancy sampler.** Emits the pinned tuple `(server_urn, stream_urn, sample_date, retained_count)` over an `OccupancySink` seam. `retained_count` = post-ack-retained JTIs only (pending excluded), identical across HA replicas (shared store); `(server_urn, stream_urn, sample_date)` is the idempotency key tenancy dedups on. A nil sink is a no-op.
- **New `EventDAO` primitives** (memory + mongo + notifying wrapper): `ListDeliveredForStream`, `RemoveDelivered`, `DeleteBodyIfUnreferenced`, `CountRetainedForStream`.

## Done-means coverage
- Retention field persists on stream state, absent from the SSF wire object — `TestRetentionWindow_OffSsfWire` / `_PersistsOnState` / `_NilOmitted`.
- Finite window purges post-ack; pending never purged — `TestPurgeExpired_FinitePurgesPostAck`.
- Body referenced by two streams survives until both windows expire (refcount) — `TestPurgeExpired_RefcountAcrossStreams`, `TestEventDAOMemory_DeleteBodyIfUnreferenced_Refcount`.
- Keep-forever default: nothing purges (dormant) — `TestPurgeExpired_Dormant`.
- Daily sampler emits idempotent per-stream retained counts (HA-dedup key) — `TestSampleOccupancy_EmitsPerStreamRetained`.

## Gate
`go test -race ./...` green; `go vet ./...` clean (no new warnings); `gofmt -l` clean.

Part of #226.