### PR TITLE
fix(metering): emit source:reset egress on stream reset re-queue (#225)

### DIFF
--- a/internal/eventRouter/event_router.go
+++ b/internal/eventRouter/event_router.go
@@ -236,6 +236,10 @@ type RouterDeps struct {
 	SubjectRelayService *services.SubjectRelayService
 }
 
+// The router is the reset-egress sink EventService reports re-queued events to
+// (ADR 0055 Q91.4), translating each into a source:reset metering observation.
+var _ services.ResetEgressObserver = (*router)(nil)
+
 func NewRouter(deps RouterDeps, nodeId string) EventRouter {
 	ctx, cancel := context.WithCancel(context.Background())
 	router := &router{
@@ -264,6 +268,14 @@ func NewRouter(deps RouterDeps, nodeId string) EventRouter {
 		httpClient:             &http.Client{Timeout: 5 * time.Second},
 		clusterSecret:          os.Getenv("I2SIG_CLUSTER_INTERNAL_TOKEN"),
 		recentOutboundWakes:    make(map[string]time.Time),
+	}
+
+	// Route reset re-deliveries through this router's metering observer. A stream
+	// reset re-queues stored events directly (bypassing fan-out), so EventService
+	// reports each re-queue here and the router emits a source:reset egress
+	// observation to whatever MeteringObserver is registered (ADR 0055 Q91.4).
+	if deps.EventService != nil {
+		deps.EventService.SetResetEgressObserver(router)
 	}
 
 	if deps.PushDelivery != nil {

--- a/internal/eventRouter/metering.go
+++ b/internal/eventRouter/metering.go
@@ -2,6 +2,7 @@ package eventRouter
 
 import (
 	"github.com/i2-open/i2goSignals/pkg/goSet"
+	"github.com/i2-open/i2goSignals/pkg/ssfModels"
 )
 
 // Direction labels a metering observation as an inbound (ingress) or outbound
@@ -19,6 +20,21 @@ const (
 	DirectionEgress Direction = "egress"
 )
 
+// MeteringSource tags an egress observation with the delivery path that produced
+// it, so a downstream aggregator can carry a dispute-audit sub-count. It is
+// additive: the empty value is normal router fan-out egress and needs no
+// special-casing (ADR 0055 Q91.4).
+type MeteringSource string
+
+const (
+	// SourceReset marks an egress observation produced by ResetEventStream
+	// re-queuing an already-stored event. A reset is fresh chargeable delivery
+	// (ADR 0055 Q91.4) and bypasses the fan-out where egress is normally metered,
+	// so these observations are emitted from the reset path and tagged so the
+	// enterprise aggregator can sub-count reset volume for dispute transparency.
+	SourceReset MeteringSource = "reset"
+)
+
 // MeteringObservation is the per-routed-event record handed to a
 // MeteringObserver. Unlike the Prometheus counter hook (SetEventCounter) it
 // carries the event Subject, which distinct-set metering (MAS) requires and a
@@ -34,6 +50,11 @@ type MeteringObservation struct {
 	// claim), or nil when the event carries no subject (e.g. some operational
 	// events). It is read from the same field the subject filter selects on.
 	Subject *goSet.SubjectIdentifier
+	// Source names the delivery path that produced the observation. The empty
+	// value is normal router fan-out; SourceReset marks a re-delivery emitted by
+	// ResetEventStream. The aggregator consumes it additively — safe to ignore
+	// initially (ADR 0055 Q91.4).
+	Source MeteringSource
 }
 
 // MeteringObserver receives one MeteringObservation per routed event. It is the
@@ -67,10 +88,16 @@ func (r *router) loadMeteringObserver() MeteringObserver {
 	return holder.observer
 }
 
-// observeMeteredEvent emits one MeteringObservation when an observer is
-// registered. A nil observer or nil token is a no-op. The Subject is read from
-// the SET sub_id claim.
+// observeMeteredEvent emits one fan-out MeteringObservation (empty Source) when
+// an observer is registered. A nil observer or nil token is a no-op. The Subject
+// is read from the SET sub_id claim.
 func (r *router) observeMeteredEvent(streamURN string, direction Direction, token *goSet.SecurityEventToken) {
+	r.observeMeteredEventSourced(streamURN, direction, token, "")
+}
+
+// observeMeteredEventSourced emits one MeteringObservation tagged with source
+// when an observer is registered. A nil observer or nil token is a no-op.
+func (r *router) observeMeteredEventSourced(streamURN string, direction Direction, token *goSet.SecurityEventToken, source MeteringSource) {
 	observer := r.loadMeteringObserver()
 	if observer == nil || token == nil {
 		return
@@ -79,5 +106,19 @@ func (r *router) observeMeteredEvent(streamURN string, direction Direction, toke
 		StreamURN: streamURN,
 		Direction: direction,
 		Subject:   token.SubjectId,
+		Source:    source,
 	})
+}
+
+// ObserveResetEgress implements services.ResetEgressObserver. EventService calls
+// it once per event ResetEventStream re-queues onto a stream, so reset
+// re-deliveries — which bypass the fan-out where egress is normally metered —
+// are charged as fresh egress and tagged source:reset (ADR 0055 Q91.4). It funnels
+// through the same metering observer the fan-out uses, so no observer registered
+// means no-op.
+func (r *router) ObserveResetEgress(streamID string, event *model.EventRecord) {
+	if event == nil {
+		return
+	}
+	r.observeMeteredEventSourced(streamID, DirectionEgress, &event.Event, SourceReset)
 }

--- a/internal/eventRouter/metering_test.go
+++ b/internal/eventRouter/metering_test.go
@@ -1,10 +1,14 @@
 package eventRouter
 
 import (
+	"context"
+	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/i2-open/i2goSignals/pkg/goSet"
+	"github.com/i2-open/i2goSignals/pkg/ssfModels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,6 +43,88 @@ func (o *recordingMeteringObserver) byDirection(dir Direction) []MeteringObserva
 		}
 	}
 	return out
+}
+
+func (o *recordingMeteringObserver) bySource(src MeteringSource) []MeteringObservation {
+	var out []MeteringObservation
+	for _, obs := range o.snapshot() {
+		if obs.Source == src {
+			out = append(out, obs)
+		}
+	}
+	return out
+}
+
+// TestResetEventStream_EmitsEgressTaggedReset is the Q91.4 billing-escape fix
+// (ADR 0055): ResetEventStream re-queues already-stored events, bypassing the
+// router fan-out where egress is normally metered — so reset re-deliveries used
+// to escape billing entirely. Each re-queued (stream, JTI) must now emit a
+// DirectionEgress observation tagged source:reset (reset is fresh chargeable
+// delivery). A subsequent re-poll of the still-pending events (protocol replay)
+// must emit ZERO additional observations — charged once at reset, free
+// thereafter, per Q91.4 "free by construction".
+func TestResetEventStream_EmitsEgressTaggedReset(t *testing.T) {
+	s := setupDedupRouterPollStream(t)
+
+	observer := &recordingMeteringObserver{}
+	s.h.router.RegisterMeteringObserver(observer)
+
+	ctx := context.Background()
+	state, err := s.h.streamService.GetStreamState(ctx, s.streamID)
+	require.NoError(t, err)
+
+	const n = 3
+	for i := 0; i < n; i++ {
+		token := newRiscToken(fmt.Sprintf("reset-jti-%d", i), dupTestIssuer, s.audience)
+		token.SubjectId = (&goSet.SubjectIdentifier{}).AddEmail(fmt.Sprintf("user%d@example.com", i))
+		require.NoError(t, s.h.router.HandleEvent(token, `{"raw":true}`, s.streamID))
+	}
+
+	// Baseline: fan-out produced n normal (source-empty) egress observations and
+	// no reset-tagged ones yet.
+	require.Len(t, observer.byDirection(DirectionEgress), n, "fan-out egress before reset")
+	require.Empty(t, observer.bySource(SourceReset), "no reset observations before a reset")
+
+	// Reset by date: re-queue every stored, matching, non-operational event —
+	// exactly the predicate the stream-management handler applies.
+	resetDate := time.Now().Add(-time.Hour)
+	err = s.h.router.eventService.ResetEventStream(ctx, s.streamID, "", &resetDate,
+		func(e *model.EventRecord) bool {
+			if e.Operational {
+				return false
+			}
+			return s.h.router.eventService.MatchesStream(state, e)
+		})
+	require.NoError(t, err)
+
+	reset := observer.bySource(SourceReset)
+	require.Len(t, reset, n, "one reset-tagged egress per re-queued (stream, JTI) — date reset")
+	for _, obs := range reset {
+		assert.Equal(t, DirectionEgress, obs.Direction, "reset re-delivery is egress")
+		assert.Equal(t, s.streamID, obs.StreamURN, "reset egress urn is the target stream")
+		require.NotNil(t, obs.Subject, "reset observation carries the event subject")
+	}
+
+	// Protocol replay: re-polling the now-pending events (a failed-ack re-poll)
+	// must NOT re-observe — GetEventIds never re-enters fan-out or reset.
+	before := len(observer.snapshot())
+	_, _ = s.h.router.eventService.GetEventIds(ctx, s.streamID, model.PollParameters{MaxEvents: 100})
+	_, _ = s.h.router.eventService.GetEventIds(ctx, s.streamID, model.PollParameters{MaxEvents: 100})
+	assert.Equal(t, before, len(observer.snapshot()),
+		"re-polling pending events (protocol replay) must emit zero additional observations")
+
+	// Reset by JTI: re-queue the reference event and every following one. Reset to
+	// the first JTI re-delivers all n events again, each a fresh source:reset egress.
+	err = s.h.router.eventService.ResetEventStream(ctx, s.streamID, "reset-jti-0", nil,
+		func(e *model.EventRecord) bool {
+			if e.Operational {
+				return false
+			}
+			return s.h.router.eventService.MatchesStream(state, e)
+		})
+	require.NoError(t, err)
+	assert.Len(t, observer.bySource(SourceReset), 2*n,
+		"a JTI reset re-delivering n events adds n more reset-tagged egress observations")
 }
 
 // TestRegisterMeteringObserver_FiresIngressOnLivePath is the ingress half of the

--- a/pkg/services/event_service.go
+++ b/pkg/services/event_service.go
@@ -15,14 +15,38 @@ import (
 
 var esLog = logger.Sub("EVENT_SERVICE")
 
+// ResetEgressObserver is notified once per event that ResetEventStream re-queues
+// onto a stream. A stream reset re-delivers already-stored events as fresh
+// chargeable egress (ADR 0055 Q91.4), but it re-queues them directly — bypassing
+// the event-router fan-out where egress is normally metered — so ResetEventStream
+// reports them here instead. The sink tags the resulting observation source:reset.
+// A protocol replay (a re-poll of a still-pending, unacked event) never enters
+// this path and stays free by construction.
+type ResetEgressObserver interface {
+	ObserveResetEgress(streamID string, event *model.EventRecord)
+}
+
 type EventService struct {
 	eventDAO interfaces.EventDAO
+	// resetEgressObserver, when non-nil, receives one call per event
+	// ResetEventStream re-queues, so reset re-deliveries are metered as fresh
+	// egress. nil (the default) leaves the reset path unmetered — the community
+	// build registers none, mirroring the event-router metering observer.
+	resetEgressObserver ResetEgressObserver
 }
 
 func NewEventService(eventDAO interfaces.EventDAO) *EventService {
 	return &EventService{
 		eventDAO: eventDAO,
 	}
+}
+
+// SetResetEgressObserver installs (or clears, with nil) the sink notified per
+// event re-queued by ResetEventStream. The event router wires itself here at
+// construction so reset re-deliveries flow to the same metering observer the
+// fan-out egress uses (ADR 0055 Q91.4).
+func (s *EventService) SetResetEgressObserver(observer ResetEgressObserver) {
+	s.resetEgressObserver = observer
 }
 
 func (s *EventService) AddEvent(ctx context.Context, event *goSet.SecurityEventToken, sid string, raw string) (*model.EventRecord, error) {
@@ -304,9 +328,21 @@ func (s *EventService) ResetEventStream(ctx context.Context, streamID string, jt
 	// Now search and re-assign events from the event store
 	var events []*model.EventRecord
 	if jti != "" {
-		// TODO: Implement JTI-based reset (need to add to DAO)
-		esLog.Warn("JTI-based reset not yet implemented, using time-based reset")
-		return errors.New("JTI-based reset not yet implemented")
+		// Reset to a JTI = re-queue that event and every following one (the CLI's
+		// "reset to a JTI and include all following events"). Resolve the reference
+		// JTI to its sort time and reuse the same time-range query — and so the same
+		// metering path — as the date-based reset.
+		ref, ferr := s.eventDAO.FindByJTI(ctx, jti)
+		if ferr != nil {
+			return ferr
+		}
+		if ref == nil {
+			return errors.New("reset error: jti not found")
+		}
+		events, err = s.eventDAO.FindByTimeRange(ctx, ref.SortTime, nil, isStreamEvent)
+		if err != nil {
+			return err
+		}
 	} else if resetDate != nil {
 		events, err = s.eventDAO.FindByTimeRange(ctx, *resetDate, nil, isStreamEvent)
 		if err != nil {
@@ -316,11 +352,19 @@ func (s *EventService) ResetEventStream(ctx context.Context, streamID string, jt
 		return errors.New("no reset date or JTI reset point provided")
 	}
 
-	// Re-add events to pending
+	// Re-add events to pending. Each successful re-queue is a fresh chargeable
+	// egress (ADR 0055 Q91.4): reset bypasses the router fan-out where egress is
+	// normally metered, so we report the re-delivery to the reset-egress observer
+	// (tagged source:reset downstream). A failed re-queue is not re-delivered and
+	// so is not metered.
 	for _, event := range events {
 		err = s.AddEventToStream(ctx, event.Jti, streamID)
 		if err != nil {
 			esLog.Error("Error re-adding event to stream during reset", "jti", event.Jti, "streamID", streamID, "error", err)
+			continue
+		}
+		if s.resetEgressObserver != nil {
+			s.resetEgressObserver.ObserveResetEgress(streamID, event)
 		}
 	}
 


### PR DESCRIPTION
## What shipped

`EventService.ResetEventStream` re-queues already-stored events via `AddEventToStream`, which bypasses the event-router fan-out where `DirectionEgress` is metered — so **reset re-deliveries escaped egress billing entirely** (the SCIM backup-recovery / "pull past events" charge case). This closes that live billing gap.

- **Reset egress is now metered.** Each re-queued `(stream, JTI)` reports a `DirectionEgress` observation tagged `source: reset` (ADR 0055 Q91.4 — a reset is fresh chargeable delivery). Wiring: `EventService` gains a `ResetEgressObserver` seam (nil by default); the router registers itself at construction, so reset egress flows to the same `MeteringObserver` the fan-out uses.
- **Additive `Source` tag.** `MeteringObservation` gains a `Source` field; empty = normal fan-out, `SourceReset` = reset re-delivery. The enterprise aggregator consumes it additively (safe to ignore initially).
- **JTI-based reset implemented.** Previously `ResetEventStream` hard-failed for JTI resets; it now resolves the reference JTI to its `SortTime` and reuses `FindByTimeRange`, so both reset modes re-queue through the shared (now-metered) loop.

## Done-means

- [x] Integration test (`TestResetEventStream_EmitsEgressTaggedReset`): a stream reset **by JTI** and **by Date** re-delivering N previously-routed events produces N `source: reset` egress observations each.
- [x] A re-poll of still-pending events (protocol replay) produces **zero** additional observations — free by construction.
- [x] X3 preserved: adds only a count/tag, no new subject identifiers (the reset observation carries the same `Subject` the fan-out egress already does).

Gate: `go test -race ./...` green; `go vet` clean on touched files.

Part of #225. ADR: enterprise `docs/adr/0055-event-retention-purge-and-replay-accounting.md` (Q91.4). Parent: enterprise #111.