### PR TITLE
feat(providers): expose live EventDAO on dbProviders.Persistence for retention drive-loop (#229)

### DIFF
--- a/internal/providers/dbProviders/factory.go
+++ b/internal/providers/dbProviders/factory.go
@@ -8,6 +8,7 @@ import (
 	"github.com/i2-open/i2goSignals/internal/providers/dbProviders/memory_provider"
 	"github.com/i2-open/i2goSignals/internal/providers/dbProviders/mongo_provider"
 	"github.com/i2-open/i2goSignals/internal/providers/storage"
+	interfaces "github.com/i2-open/i2goSignals/pkg/dao"
 	"github.com/i2-open/i2goSignals/pkg/logger"
 	"github.com/i2-open/i2goSignals/pkg/services"
 )
@@ -30,6 +31,12 @@ type Persistence struct {
 	TokenService         *services.TokenService
 	SubjectFilterService *services.SubjectFilterService
 	SubjectRelayService  *services.SubjectRelayService
+
+	// EventDAO is the live, storage-backed EventDAO — the SAME instance the
+	// EventService above writes through — exposed so an enterprise embedder can
+	// bind services.NewRetentionEngine(p.EventDAO) to the running store (issue
+	// #229, ADR 0055 A5.2). Additive and off the SSF wire.
+	EventDAO interfaces.EventDAO
 
 	Coordinator cluster.ClusterCoordinator
 	Storage     storage.Storage
@@ -57,6 +64,7 @@ func (p *Persistence) Refresh() {
 	p.TokenService = p.src.GetTokenService()
 	p.SubjectFilterService = p.src.GetSubjectFilterService()
 	p.SubjectRelayService = p.src.GetSubjectRelayService()
+	p.EventDAO = p.src.GetEventDAO()
 }
 
 // serviceSource is the accessor surface present on both *MemoryProvider and
@@ -72,6 +80,7 @@ type serviceSource interface {
 	GetTokenService() *services.TokenService
 	GetSubjectFilterService() *services.SubjectFilterService
 	GetSubjectRelayService() *services.SubjectRelayService
+	GetEventDAO() interfaces.EventDAO
 }
 
 // OpenPersistence detects the database URL and returns the Persistence record
@@ -122,6 +131,7 @@ func persistenceFromMemory(mp *memory_provider.MemoryProvider) *Persistence {
 		TokenService:         mp.GetTokenService(),
 		SubjectFilterService: mp.GetSubjectFilterService(),
 		SubjectRelayService:  mp.GetSubjectRelayService(),
+		EventDAO:             mp.GetEventDAO(),
 		Coordinator:          mp.Coordinator(),
 		Storage:              memory_provider.NewMemoryStorage(mp),
 		src:                  mp,
@@ -139,6 +149,7 @@ func persistenceFromMongo(mp *mongo_provider.MongoProvider) *Persistence {
 		TokenService:         svcSrc.GetTokenService(),
 		SubjectFilterService: svcSrc.GetSubjectFilterService(),
 		SubjectRelayService:  svcSrc.GetSubjectRelayService(),
+		EventDAO:             svcSrc.GetEventDAO(),
 		Coordinator:          mp.Coordinator(),
 		Storage:              mongo_provider.NewMongoStorage(mp),
 		src:                  mp,

--- a/internal/providers/dbProviders/factory.go
+++ b/internal/providers/dbProviders/factory.go
@@ -36,6 +36,12 @@ type Persistence struct {
 	// EventService above writes through — exposed so an enterprise embedder can
 	// bind services.NewRetentionEngine(p.EventDAO) to the running store (issue
 	// #229, ADR 0055 A5.2). Additive and off the SSF wire.
+	//
+	// Lifecycle: like the service references above, the memory adapter swaps
+	// this instance on Storage.ResetDb(true) (Mongo rebinds in place). Callers
+	// must re-read p.EventDAO after Refresh(); a RetentionEngine captured from
+	// the pre-reset value keeps operating on the discarded store, so rebuild it
+	// after a reset on a memory-backed server.
 	EventDAO interfaces.EventDAO
 
 	Coordinator cluster.ClusterCoordinator

--- a/internal/providers/dbProviders/factory_test.go
+++ b/internal/providers/dbProviders/factory_test.go
@@ -5,13 +5,23 @@ import (
 	"errors"
 	"path/filepath"
 	"testing"
+	"time"
 
 	interfaces "github.com/i2-open/i2goSignals/pkg/dao"
 	"github.com/i2-open/i2goSignals/pkg/goSet"
+	"github.com/i2-open/i2goSignals/pkg/services"
 	"github.com/i2-open/i2goSignals/pkg/ssfModels"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
+
+// captureSink records the occupancy samples SampleOccupancy emits so the test
+// can assert the RetentionEngine read the live store through p.EventDAO.
+type captureSink struct{ samples []services.OccupancySample }
+
+func (c *captureSink) ObserveOccupancy(s services.OccupancySample) {
+	c.samples = append(c.samples, s)
+}
 
 // assertDedupParity exercises the slice #156 cross-provider parity check: a
 // double-AddEvent on the same JTI must return interfaces.ErrDuplicateJTI on
@@ -129,6 +139,70 @@ func TestOpenPersistence_Memory(t *testing.T) {
 	// SSTP pair parity: the bidirectional StreamStateRecord round-trips and is
 	// retrievable by inbound SID and PairId through the memory provider.
 	assertSstpPairParity(t, p)
+
+	_ = p.Storage.Close()
+}
+
+// TestOpenPersistence_EventDAO_LiveInstance proves issue #229 (ADR-0055 A5.2):
+// Persistence exposes the live, storage-backed EventDAO — the SAME instance the
+// router's EventService writes through — so an enterprise embedder can bind
+// services.NewRetentionEngine(p.EventDAO) to the live store. It drives an event
+// to delivered state THROUGH p.EventService and observes it via p.EventDAO, then
+// runs the RetentionEngine sampler/purge against that same store.
+func TestOpenPersistence_EventDAO_LiveInstance(t *testing.T) {
+	t.Setenv("I2SIG_STORE_MEM_DIRECTORY", t.TempDir())
+	p, err := OpenPersistence("memorydb:", "test_persist_eventdao")
+	assert.NoError(t, err)
+	assert.NotNil(t, p)
+	assert.NotNil(t, p.EventDAO, "EventDAO must be exposed on Persistence")
+
+	ctx := context.Background()
+	// The RetentionEngine keys the store by stream.Id.Hex(), so the delivered
+	// streamID must be an ObjectID hex for the sampler/purge to line up.
+	oid := bson.NewObjectID()
+	streamID := oid.Hex()
+
+	// Drive an event THROUGH the router (p.EventService) to delivered state:
+	// AddEvent (insert body) -> AddEventToStream (pending) -> AckEvent (delivered).
+	evt := &goSet.SecurityEventToken{Events: map[string]interface{}{"x": "y"}}
+	evt.ID = "retention-jti-1"
+	_, err = p.EventService.AddEvent(ctx, evt, streamID, "raw-1")
+	assert.NoError(t, err, "AddEvent through the router should succeed")
+	assert.NoError(t, p.EventService.AddEventToStream(ctx, evt.ID, streamID))
+	assert.NoError(t, p.EventService.AckEvent(ctx, evt.ID, streamID, 0))
+
+	// Same-instance visibility: a write performed through EventService is
+	// observable via the EventDAO handle exposed on Persistence.
+	count, err := p.EventDAO.CountRetainedForStream(ctx, streamID)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), count, "delivered event must be visible via p.EventDAO")
+
+	delivered, err := p.EventDAO.ListDeliveredForStream(ctx, streamID)
+	assert.NoError(t, err)
+	assert.Len(t, delivered, 1, "delivered list must reflect the router write")
+
+	// The live EventDAO drives a RetentionEngine against the same store.
+	window := 1
+	streams := []model.StreamStateRecord{{Id: oid, RetentionWindowDays: &window}}
+	engine := services.NewRetentionEngine(p.EventDAO)
+
+	// SampleOccupancy reads CountRetainedForStream from the live store.
+	sink := &captureSink{}
+	assert.NoError(t, engine.SampleOccupancy(ctx, time.Now(), "urn:test:server", streams, sink))
+	if assert.Len(t, sink.samples, 1, "sampler should emit one sample from the live store") {
+		assert.Equal(t, int64(1), sink.samples[0].RetainedCount, "sample reflects the retained event")
+	}
+
+	// PurgeExpired at a time past the window purges the delivered body via the
+	// same live store (ackDate is ~now; a future 'now' pushes it past cutoff).
+	purged, err := engine.PurgeExpired(ctx, time.Now().Add(48*time.Hour), streams, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, purged, "expired body should be purged from the live store")
+
+	// Post-purge the live store no longer retains the event.
+	count, err = p.EventDAO.CountRetainedForStream(ctx, streamID)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), count, "purge is observable via p.EventDAO")
 
 	_ = p.Storage.Close()
 }

--- a/internal/providers/dbProviders/memory_provider/provider.go
+++ b/internal/providers/dbProviders/memory_provider/provider.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/i2-open/i2goSignals/internal/envcompat"
 	"github.com/i2-open/i2goSignals/internal/providers/cluster"
+	interfaces "github.com/i2-open/i2goSignals/pkg/dao"
 	"github.com/i2-open/i2goSignals/pkg/dao/memory"
 	"github.com/i2-open/i2goSignals/pkg/logger"
 	"github.com/i2-open/i2goSignals/pkg/services"
@@ -62,6 +63,13 @@ type MemoryProvider struct {
 	subjectFilterService *services.SubjectFilterService
 	subjectRelayService  *services.SubjectRelayService
 
+	// eventDAO is the notifyingEventDAO wrapper the eventService above writes
+	// through. Held so GetEventDAO can hand out the SAME live instance (not the
+	// raw DAO, not a fresh wrapper). Reassigned in buildServices so a
+	// ResetDb(true) rebuild keeps it in lockstep with the new EventService
+	// (issue #229, ADR 0055 A5.2).
+	eventDAO interfaces.EventDAO
+
 	// Direct references to the raw memory DAOs. Services see notifyingDAO
 	// wrappers around these for after-mutation persistence triggering (#44);
 	// PersistenceManager works against the raw DAOs because it needs the
@@ -98,6 +106,11 @@ func (m *MemoryProvider) Coordinator() cluster.ClusterCoordinator {
 func (m *MemoryProvider) GetStreamService() *services.StreamService { return m.streamService }
 func (m *MemoryProvider) GetKeyService() *services.KeyService       { return m.keyService }
 func (m *MemoryProvider) GetEventService() *services.EventService   { return m.eventService }
+
+// GetEventDAO returns the live notifyingEventDAO the EventService writes
+// through — the SAME instance, so reads via this handle see router writes and
+// dirty-tracking notifications still fire (issue #229, ADR 0055 A5.2).
+func (m *MemoryProvider) GetEventDAO() interfaces.EventDAO          { return m.eventDAO }
 func (m *MemoryProvider) GetClientService() *services.ClientService { return m.clientService }
 func (m *MemoryProvider) GetServerService() *services.ServerService { return m.serverService }
 func (m *MemoryProvider) GetTokenService() *services.TokenService   { return m.tokenService }
@@ -122,7 +135,7 @@ func (m *MemoryProvider) Name() string {
 // ResetDb(true) so the wiring stays in one place.
 func (m *MemoryProvider) buildServices() {
 	streamDAO := newNotifyingStreamDAO(m.rawStreamDAO, m.markDirty)
-	eventDAO := newNotifyingEventDAO(m.rawEventDAO, m.markDirty)
+	m.eventDAO = newNotifyingEventDAO(m.rawEventDAO, m.markDirty)
 	keyDAO := newNotifyingKeyDAO(m.rawKeyDAO, m.markDirty)
 	clientDAO := newNotifyingClientDAO(m.rawClientDAO, m.markDirty)
 	serverDAO := newNotifyingServerDAO(m.rawServerDAO, m.markDirty)
@@ -132,7 +145,7 @@ func (m *MemoryProvider) buildServices() {
 	m.tokenService.SetStreamDAO(streamDAO)
 	m.keyService = services.NewKeyService(keyDAO, m.TokenIssuer, m.tokenService, oauthServersFromEnv)
 	m.streamService = services.NewStreamService(streamDAO, m.keyService, m.DefaultIssuer, streamServiceConfigFromEnv())
-	m.eventService = services.NewEventService(eventDAO)
+	m.eventService = services.NewEventService(m.eventDAO)
 	m.clientService = services.NewClientService(clientDAO, m.keyService)
 	m.serverService = services.NewServerService(serverDAO)
 	m.subjectFilterService = services.NewSubjectFilterService(memory.NewSubjectFilterDAO())

--- a/internal/providers/dbProviders/mongo_provider/event_index_test.go
+++ b/internal/providers/dbProviders/mongo_provider/event_index_test.go
@@ -9,6 +9,7 @@ import (
 
 	mongodao "github.com/i2-open/i2goSignals/internal/dao/mongo"
 	interfaces "github.com/i2-open/i2goSignals/pkg/dao"
+	"github.com/i2-open/i2goSignals/pkg/goSet"
 	model "github.com/i2-open/i2goSignals/pkg/ssfModels"
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
@@ -55,6 +56,34 @@ func findEventJtiIndex(t *testing.T, p *MongoProvider) (sparse, unique bool, fou
 		}
 	}
 	return false, false, false
+}
+
+// TestGetEventDAO_LiveInstance proves issue #229 on the Mongo path: GetEventDAO
+// returns a non-nil, live, storage-backed EventDAO that is the SAME instance the
+// EventService writes through. A write driven through the router's EventService
+// must be observable via the EventDAO handle. Skips when Mongo is unavailable.
+func TestGetEventDAO_LiveInstance(t *testing.T) {
+	p := openEventIdxProvider(t)
+	ctx := context.Background()
+
+	dao := p.GetEventDAO()
+	if dao == nil {
+		t.Fatal("GetEventDAO must be non-nil")
+	}
+
+	evt := &goSet.SecurityEventToken{Events: map[string]interface{}{"x": "y"}}
+	evt.ID = "eventdao-live-jti"
+	if _, err := p.GetEventService().AddEvent(ctx, evt, "sid-1", "raw-1"); err != nil {
+		t.Fatalf("AddEvent through EventService: %v", err)
+	}
+
+	rec, err := dao.FindByJTI(ctx, "eventdao-live-jti")
+	if err != nil {
+		t.Fatalf("FindByJTI via GetEventDAO: %v", err)
+	}
+	if rec == nil || rec.Jti != "eventdao-live-jti" {
+		t.Fatalf("EventDAO did not observe the router write; got %+v", rec)
+	}
 }
 
 // TestEventJtiIndex_CreatedOnFreshDb: a fresh database's createIndexes run

--- a/internal/providers/dbProviders/mongo_provider/provider.go
+++ b/internal/providers/dbProviders/mongo_provider/provider.go
@@ -208,6 +208,13 @@ func (m *MongoProvider) GetSubjectRelayService() *services.SubjectRelayService {
 	return m.subjectRelayService
 }
 
+// GetEventDAO returns the live storage-backed EventDAO — the SAME instance
+// wired into the EventService (initServices). Rebinds on reconnect happen in
+// place via SetCollections, so the instance is stable for the process lifetime.
+// Exposed so dbProviders.Persistence can bind a RetentionEngine to the live
+// store (issue #229, ADR 0055 A5.2).
+func (m *MongoProvider) GetEventDAO() interfaces.EventDAO { return m.eventDAO }
+
 // GetKeyDAO returns the underlying KeyDAO. Used by rebind tests in
 // internal/providers/dbProviders/mongo_provider/test/rebind_test.go to assert
 // that collection rebinding takes effect on the same DAO instance.


### PR DESCRIPTION
Closes #229.

## What

Makes the live, storage-backed `EventDAO` — the same instance the running router's `EventService` writes through — reachable from `dbProviders.OpenPersistence(...)`, so an enterprise embedder can bind `services.NewRetentionEngine(p.EventDAO)` to the running store for ADR-0055 A5.2 retention purge + daily occupancy sampling.

Before this change `OpenPersistence` exported the services + `Storage` + `Coordinator` but not the `EventDAO`, and the only public `EventDAO` constructor was memory-only — so an embedder could not construct a `RetentionEngine` bound to the running store.

## Changes (additive, off the SSF wire)

- **`factory.go`** — add `GetEventDAO() interfaces.EventDAO` to the `serviceSource` interface; add an exported `EventDAO interfaces.EventDAO` field on `Persistence`; populate it in `persistenceFromMemory`/`persistenceFromMongo` and in `Refresh()`.
- **`memory_provider/provider.go`** — store the `notifyingEventDAO` wrapper on the provider and reassign it in `buildServices` (so a `ResetDb(true)` rebuild keeps it in lockstep with the rebuilt `EventService`); return that same wrapper from `GetEventDAO()` so purge/sample state matches the router's view and dirty-tracking notifications still fire.
- **`mongo_provider/provider.go`** — `GetEventDAO()` returns the stable, in-place-rebound `EventDAOMongo` already wired into `EventService`.

No SSF-wire / `StreamConfiguration` change.

## Tests

- `TestOpenPersistence_EventDAO_LiveInstance` (memory) — asserts `p.EventDAO` non-nil; drives an event to delivered state **through** `p.EventService` and observes it via `p.EventDAO.CountRetainedForStream`/`ListDeliveredForStream` (same-instance proof); then runs `NewRetentionEngine(p.EventDAO)` `SampleOccupancy` + `PurgeExpired` against the live store.
- `TestGetEventDAO_LiveInstance` (mongo) — same-instance write-visibility assertion.

`go test -race ./internal/providers/dbProviders/...` green; `go build ./...`, `go vet`, `gofmt -l` clean.

Refs ADR-0055 A5.2 (Amendment 2); enterprise #111 / #114. A family re-pin (`.community-sha`) follows.