### PR TITLE
chore(deps): bump Keycloak substrate pin 26.4.7 -> 26.6.4 (#232)

### DIFF
--- a/docker-compose-cluster-dev.yml
+++ b/docker-compose-cluster-dev.yml
@@ -321,7 +321,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
   keycloak:
-    image: quay.io/keycloak/keycloak:26.4.7
+    image: quay.io/keycloak/keycloak:26.6.4
     hostname: keycloak
     command: start-dev --import-realm
     environment:

--- a/docker-compose-cluster.yml
+++ b/docker-compose-cluster.yml
@@ -289,7 +289,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
   keycloak:
-    image: quay.io/keycloak/keycloak:26.4.7
+    image: quay.io/keycloak/keycloak:26.6.4
     hostname: keycloak
     command: start --import-realm
     environment:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -465,7 +465,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
   keycloak:
-    image: quay.io/keycloak/keycloak:26.4.7
+    image: quay.io/keycloak/keycloak:26.6.4
     container_name: keycloak-signals
     hostname: keycloak
     networks:

--- a/docker-compose-spiffe-dev.yml
+++ b/docker-compose-spiffe-dev.yml
@@ -546,7 +546,7 @@ services:
       I2SIG_SPIFFE_TRUST_DOMAIN: cluster.i2gosignals.internal
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.4.7
+    image: quay.io/keycloak/keycloak:26.6.4
     container_name: keycloak-signals
     hostname: keycloak
     networks:

--- a/docker-compose-spiffe.yml
+++ b/docker-compose-spiffe.yml
@@ -527,7 +527,7 @@ services:
       I2SIG_SPIFFE_TRUST_DOMAIN: cluster.i2gosignals.internal
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.4.7
+    image: quay.io/keycloak/keycloak:26.6.4
     container_name: keycloak-signals
     hostname: keycloak
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -348,7 +348,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
   keycloak:
-    image: quay.io/keycloak/keycloak:26.4.7
+    image: quay.io/keycloak/keycloak:26.6.4
     container_name: keycloak-signals
     hostname: keycloak
     networks:


### PR DESCRIPTION
Closes #232. Community share of the family-wide lockstep Keycloak bump round — coordination anchor: independentid/i2gosignals-planning#31.

## What changed

All six compose pin sites bumped to `quay.io/keycloak/keycloak:26.6.4`:

- `docker-compose.yml`
- `docker-compose-cluster.yml`
- `docker-compose-dev.yml`
- `docker-compose-cluster-dev.yml`
- `docker-compose-spiffe.yml`
- `docker-compose-spiffe-dev.yml`

A repo-wide grep confirms these are the only Keycloak pin sites — nothing in the Makefile, CI workflows, or scripts.

## Acceptance criteria

| Criterion | Status |
|---|---|
| Six compose pin sites → `26.6.4` | Met |
| `docs/keycloak-ssf-guide.md` `26.4.0` → `26.6.4` | **Not done — see below** |
| `gosignals-realm.json` imports clean on `26.6.4` | Verified |
| Demo/cluster stacks green | Deferred (port collision with a running dev stack) |
| `integration-e2e` green | Deferred — explicit join gate, waits on tenancy + enterprise + admin |

### Realm import verification

Ran `start-dev --import-realm` against a throwaway `26.6.4` container mounting `config/keycloak/realm/`:

```
Realm 'gosignals' imported
KC-SERVICES0032: Import finished successfully
Keycloak 26.6.4 ... started
```

A `WARN`/`ERROR`/deprecated/unknown-field scan of the container log returned zero lines.

## Deviation from acceptance criterion 2 (doc bump) — deliberate

Issue #232 describes `docs/keycloak-ssf-guide.md` as carrying stale `26.4.0` drift against our own pin. It does not. Every `26.4.0` in that guide describes the **external** [`identitytailor/keycloak-ssf-support`](https://github.com/identitytailor/keycloak-ssf-support) PoC repo — its README, its committed `docker-compose.yml`, and a fenced block explicitly labelled *"Reproduced below verbatim from `main`"*. The guide never documents this repo's Keycloak pin.

Re-pinning those lines to `26.6.4` would turn four true statements into false ones, including rewriting a verbatim copy of a third-party file and asserting the PoC's JAR "is built against" a version it has never been built against. The guide is therefore left untouched.

There *is* real drift in that file — the table states "the latest Keycloak release is 26.6.1 (April 2026)". That deserves a separate doc-only cleanup, not this PR.

## Upstream finding worth relaying to the family round

Keycloak **26.6.0 changed the dev-mode `http-host` default** from all-interfaces to `localhost`. Community is unaffected — all six compose files already set `QUARKUS_HTTP_HOST: 0.0.0.0`. Sibling repos (tenancy, enterprise, admin) should confirm they override it too, or their `start-dev` Keycloak becomes unreachable from other containers and the join-gated `integration-e2e` fails for a reason that looks nothing like a version bump.

The 26.5/26.6 migration guides document **no realm-export field renames** — the risk planning#31 flagged for the mirrored `tenancy-realm.json`. The clean `gosignals` import corroborates this.

## Gates

- `go test ./...` — green
- `go vet ./...` — green, no new warnings

(Diff is YAML-only; both are formalities here.)