### PR TITLE
security(goSet): verify-only Parse + explicit Peek API split (#234)

### DIFF
--- a/internal/eventRouter/delivery/http_test.go
+++ b/internal/eventRouter/delivery/http_test.go
@@ -406,7 +406,9 @@ func TestHTTPAdapter_PBReSignPreservesJtiAndTxn(t *testing.T) {
 	require.Equal(t, goSetPush.ClassAccepted, out.Classification.Class)
 	require.Len(t, bodies, 1, "receiver must see exactly one signed SET")
 
-	parsed, err := goSet.Parse(bodies[0], nil)
+	// Test-side inspection only: we look at the captured wire body's claim
+	// shape; verification is not the concern here — use Peek per ADR-0066.
+	parsed, err := goSet.Peek(bodies[0])
 	require.NoError(t, err, "the pushed PB token must be a parseable SET")
 
 	assert.Equal(t, "jti-source-1", parsed.ID, "PB re-sign must preserve jti verbatim (ADR 0017)")
@@ -498,7 +500,8 @@ func TestHTTPAdapter_ConcurrentFanOutNoSharedMutation(t *testing.T) {
 	require.Len(t, bodiesB, iterations)
 
 	for _, body := range bodiesA {
-		parsed, err := goSet.Parse(body, nil)
+		// Test-side inspection only — Peek per ADR-0066 §D3.
+		parsed, err := goSet.Peek(body)
 		require.NoError(t, err)
 		assert.Equal(t, "https://issuer-A.example.com", parsed.Issuer, "stream A receiver must only ever see stream A's iss")
 		assert.Equal(t, jwt.ClaimStrings{"https://aud-A.example.com"}, parsed.Audience, "stream A receiver must only ever see stream A's aud")
@@ -506,7 +509,7 @@ func TestHTTPAdapter_ConcurrentFanOutNoSharedMutation(t *testing.T) {
 		assert.Equal(t, "txn-source-1", parsed.TransactionId, "txn must be preserved across fan-out")
 	}
 	for _, body := range bodiesB {
-		parsed, err := goSet.Parse(body, nil)
+		parsed, err := goSet.Peek(body)
 		require.NoError(t, err)
 		assert.Equal(t, "https://issuer-B.example.com", parsed.Issuer, "stream B receiver must only ever see stream B's iss")
 		assert.Equal(t, jwt.ClaimStrings{"https://aud-B.example.com"}, parsed.Audience, "stream B receiver must only ever see stream B's aud")

--- a/internal/eventRouter/pb_resign_test.go
+++ b/internal/eventRouter/pb_resign_test.go
@@ -174,7 +174,9 @@ func TestPrepareAndSendEvent_PBConcurrentFanOutProductionPath(t *testing.T) {
 	require.Len(t, bodiesB, iterations, "stream B receiver must see one SET per iteration")
 
 	for _, body := range bodiesA {
-		parsed, err := goSet.Parse(body, nil)
+		// Test-side inspection only: the captured HTTP body is examined for
+		// claim shape, not accepted as a trust decision — use Peek per ADR-0066.
+		parsed, err := goSet.Peek(body)
 		require.NoError(t, err)
 		assert.Equal(t, "https://issuer-A.example.com", parsed.Issuer, "stream A receiver must only see stream A's iss (no cross-stream leak)")
 		assert.Equal(t, jwt.ClaimStrings{"https://aud-A.example.com"}, parsed.Audience, "stream A receiver must only see stream A's aud")
@@ -182,7 +184,7 @@ func TestPrepareAndSendEvent_PBConcurrentFanOutProductionPath(t *testing.T) {
 		assert.Equal(t, "txn-"+parsed.ID, parsed.TransactionId, "txn must be preserved verbatim alongside jti")
 	}
 	for _, body := range bodiesB {
-		parsed, err := goSet.Parse(body, nil)
+		parsed, err := goSet.Peek(body)
 		require.NoError(t, err)
 		assert.Equal(t, "https://issuer-B.example.com", parsed.Issuer, "stream B receiver must only see stream B's iss (no cross-stream leak)")
 		assert.Equal(t, jwt.ClaimStrings{"https://aud-B.example.com"}, parsed.Audience, "stream B receiver must only see stream B's aud")

--- a/internal/server/api_sstp_test.go
+++ b/internal/server/api_sstp_test.go
@@ -1,8 +1,11 @@
 package server
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"testing"
 
+	"github.com/MicahParks/keyfunc/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/i2-open/i2goSignals/pkg/goSet"
 	"github.com/i2-open/i2goSignals/pkg/goSetPush"
@@ -11,12 +14,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// unsignedSet renders a SET to its compact (alg=none) JWS string so the parse
-// helper can validate it with goSetPush.ParseReceivedSET (JWKS=nil verifies an
-// alg=none token's claims without a signature).
-func unsignedSet(t *testing.T, jti, iss, aud string) string {
+// signedSet renders a SET to its compact JWS string using RS256 and returns
+// both the wire string and a matching JWKS the receiver can use to verify it.
+// Per ADR-0066 §D2 the receiver requires a configured trust anchor — the
+// alg=none unsigned test-fixture path is retired (goSet.JWS with nil key is
+// now refused, and ParseReceivedSET rejects any SET when JWKS is nil).
+func signedSet(t *testing.T, jti, iss, aud string) (string, *keyfunc.JWKS) {
 	t.Helper()
-	tok := &goSet.SecurityEventToken{
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	set := goSet.SecurityEventToken{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:   iss,
 			Audience: jwt.ClaimStrings{aud},
@@ -25,10 +33,16 @@ func unsignedSet(t *testing.T, jti, iss, aud string) string {
 			"https://schemas.openid.net/secevent/risc/event-type/account-disabled": map[string]interface{}{},
 		},
 	}
-	tok.ID = jti
-	s, err := tok.JWT().SignedString(jwt.UnsafeAllowNoneSignatureType)
+	set.ID = jti
+	// Force a kid the JWKS below is keyed by.
+	set.Kid = "kid-" + jti
+
+	signed, err := set.JWS(jwt.SigningMethodRS256, priv)
 	require.NoError(t, err)
-	return s
+
+	given := keyfunc.NewGivenRSA(&priv.PublicKey, keyfunc.GivenKeyOptions{Algorithm: "RS256"})
+	jwks := keyfunc.NewGiven(map[string]keyfunc.GivenKey{set.Kid: given})
+	return signed, jwks
 }
 
 // TestParseSstpInboundSets_ValidSetIsParsed: each byte-identical RFC8935 SET in
@@ -36,10 +50,11 @@ func unsignedSet(t *testing.T, jti, iss, aud string) string {
 // returned as an SstpInboundSet carrying the verified token + raw string (Q5.1).
 func TestParseSstpInboundSets_ValidSetIsParsed(t *testing.T) {
 	const iss, aud = "https://peer.example", "https://local.example"
-	raw := unsignedSet(t, "jti-ok", iss, aud)
+	raw, jwks := signedSet(t, "jti-ok", iss, aud)
 	msg := goSetSstp.Message{Sets: map[string]string{"jti-ok": raw}}
 
 	parsed, setErrs := parseSstpInboundSets(msg, goSetPush.ReceiverConfig{
+		JWKS:              jwks,
 		ExpectedIssuer:    iss,
 		ExpectedAudiences: []string{aud},
 	})
@@ -54,13 +69,16 @@ func TestParseSstpInboundSets_ValidSetIsParsed(t *testing.T) {
 
 // TestParseSstpInboundSets_BadIssuerYieldsSetErr: a SET whose issuer does not
 // match the rx-side expected issuer is rejected per-JTI (mapped to the SSTP §2.3
-// vocabulary), not parsed into the inbound batch.
+// vocabulary), not parsed into the inbound batch. The bad-issuer decision fires
+// on the pre-verify Peek per ADR-0066 §D3 (which is why no JWKS is needed here —
+// the receiver never reaches the verify step).
 func TestParseSstpInboundSets_BadIssuerYieldsSetErr(t *testing.T) {
 	const aud = "https://local.example"
-	raw := unsignedSet(t, "jti-bad-iss", "https://attacker.example", aud)
+	raw, jwks := signedSet(t, "jti-bad-iss", "https://attacker.example", aud)
 	msg := goSetSstp.Message{Sets: map[string]string{"jti-bad-iss": raw}}
 
 	parsed, setErrs := parseSstpInboundSets(msg, goSetPush.ReceiverConfig{
+		JWKS:              jwks,
 		ExpectedIssuer:    "https://peer.example",
 		ExpectedAudiences: []string{aud},
 	})

--- a/pkg/goSet/set.go
+++ b/pkg/goSet/set.go
@@ -212,13 +212,33 @@ func (set *SecurityEventToken) GetEventIds() []string {
 	return keys
 }
 
+// JWT returns a jwt.Token wrapper carrying this SET's claims with
+// SigningMethodNone as the wrapper method.
+//
+// Deprecated: this returns an alg=none token wrapper. Under ADR-0066 §D3
+// alg=none is never accepted on the trust path, and no production caller
+// produces unsigned SETs. This wrapper survives only for test fixtures that
+// need to inspect an unsigned token's header/claims; do not use it to emit
+// wire tokens. New code MUST use JWS with a real signing method + key.
 func (set *SecurityEventToken) JWT() *jwt.Token {
 	token := jwt.NewWithClaims(jwt.SigningMethodNone, set)
 	token.Header["typ"] = "secevent+jwt"
 	return token
 }
 
+// JWS produces a signed SET wire string. signingMethod defaults to ES256 when
+// nil; key MUST be non-nil.
+//
+// Per ADR-0066 §D3 the unsigned (alg=none) production path has been removed:
+// there is no legitimate production producer of unsigned SETs, and leaving
+// the write-side capability increases the injection blast-radius if a
+// verifier is ever misconfigured. Callers that previously passed nil to
+// obtain an alg=none token must construct one directly via jwt.NewWithClaims
+// (test fixtures only).
 func (set *SecurityEventToken) JWS(signingMethod jwt.SigningMethod, key *rsa.PrivateKey) (string, error) {
+	if key == nil {
+		return "", errors.New("goSet.JWS: key is required; alg=none production removed (ADR-0066 §D3)")
+	}
 	if signingMethod == nil {
 		signingMethod = jwt.SigningMethodES256
 	}
@@ -226,42 +246,31 @@ func (set *SecurityEventToken) JWS(signingMethod jwt.SigningMethod, key *rsa.Pri
 	token := jwt.NewWithClaims(signingMethod, set)
 	token.Header["typ"] = "secevent+jwt"
 
-	// publicKey := key.PublicKey
-
-	// givenKey := keyfunc.NewGivenRSA(&publicKey)
-
-	//	jwks := keyfunc.NewGiven(map[string]keyfunc.GivenKey{
-	//		"issuer": givenKey,
-	//	})
-
 	if set.Kid != "" {
 		token.Header["kid"] = set.Kid
 	} else {
 		token.Header["kid"] = set.Issuer
 	}
 
-	if key == nil {
-		return token.SignedString(jwt.UnsafeAllowNoneSignatureType)
-	}
 	return token.SignedString(key)
-
 }
 
-/*
-Parse will parse a SET or JWT into a SecurityEventToken. If issuerPublicJwks is provided the JWT will be validated.
-Note that if issuerPublicJwks is nil, the token will be validated if the header has alg=none only.
-*/
+// Parse parses a SET wire string and verifies its signature against the
+// supplied JWKS. It is a verify-only trust-path API: issuerPublicJwks MUST be
+// non-nil; passing nil returns an error.
+//
+// Per ADR-0066 §D3 the previous silent ParseUnverified fallback has been
+// removed — an accepted Parse result is always a signature-verified token,
+// and alg=none is never accepted where a signature is expected. For
+// explicit, unverified inspection (e.g. pre-verify routing on the push
+// receiver, or CLI display), use Peek — its result is never the accepted
+// token.
 func Parse(tokenString string, issuerPublicJwks *keyfunc.JWKS) (*SecurityEventToken, error) {
-	var token *jwt.Token
-	var err error
 	if issuerPublicJwks == nil {
-		token, _, err = new(jwt.Parser).ParseUnverified(tokenString, &SecurityEventToken{})
-
-	} else {
-
-		token, err = jwt.ParseWithClaims(tokenString, &SecurityEventToken{}, issuerPublicJwks.Keyfunc)
+		return nil, errors.New("goSet.Parse: JWKS is required for verified parsing; use Peek for explicit unverified inspection (ADR-0066 §D3)")
 	}
 
+	token, err := jwt.ParseWithClaims(tokenString, &SecurityEventToken{}, issuerPublicJwks.Keyfunc)
 	if err != nil {
 		log.Printf("Error validating token: %s", err.Error())
 		return nil, err
@@ -271,17 +280,34 @@ func Parse(tokenString string, issuerPublicJwks *keyfunc.JWKS) (*SecurityEventTo
 		return nil, errors.New("token type is not `secevent+jwt`")
 	}
 
-	// jsonByte, _ := json.MarshalIndent(token.Claims, "", "  ")
-	// claimString := string(jsonByte)
-	// log.Println(claimString)
 	return token.Claims.(*SecurityEventToken), nil
-	/*
-		if claims, ok := token.Claims.(*SecurityEventToken); ok && token.Valid {
-			return claims, nil
-		}
-		return nil, errors.New("****** Failed to validate")
+}
 
-	*/
+// Peek parses a SET wire string WITHOUT verifying its signature and returns
+// the claims for routing, dispatch, or display purposes only. The result is
+// UNTRUSTED — it MUST NOT be treated as an accepted token, forwarded as if
+// verified, or used to make any authorization decision. It exists to
+// support:
+//
+//   - RFC 8935 push receivers that need to inspect iss/aud before signature
+//     verification so that a wrong-issuer failure returns the correct
+//     invalid_issuer error code rather than a generic invalid_request from a
+//     JWKS lookup miss.
+//   - CLI display of an inbound token when the operator is only inspecting,
+//     not accepting.
+//
+// Per ADR-0066 §D3 unverified parsing is never a trust path. This function
+// is deliberately named so a reviewer or an agent cannot mistake it for
+// Parse.
+func Peek(tokenString string) (*SecurityEventToken, error) {
+	token, _, err := new(jwt.Parser).ParseUnverified(tokenString, &SecurityEventToken{})
+	if err != nil {
+		return nil, err
+	}
+	if token.Header["typ"] != "secevent+jwt" {
+		return nil, errors.New("token type is not `secevent+jwt`")
+	}
+	return token.Claims.(*SecurityEventToken), nil
 }
 
 func GenerateJti() string {

--- a/pkg/goSet/test/parse_peek_split_test.go
+++ b/pkg/goSet/test/parse_peek_split_test.go
@@ -1,0 +1,162 @@
+package test
+
+// ADR-0066 §D3 — verify-only Parse + explicit Peek API split.
+//
+// These tests pin the trust-path contract that i2goSignals#234 introduced:
+//   - goSet.Parse(tokenString, nil) MUST return an error (no silent
+//     ParseUnverified fallback; alg=none is never accepted where a signature
+//     is expected).
+//   - goSet.Peek(tokenString) MUST return the token's claims WITHOUT verifying
+//     the signature, and MUST NEVER be treated as an accepted-token API by any
+//     caller — the tests here only assert its parse-shape.
+//   - goSet.JWS with a nil key MUST be refused — the alg=none production path
+//     has been removed; if a test needs an unsigned wire string it must
+//     construct it directly via the jwt library.
+//
+// If any of these tests fail, /pkg/goSet is regressing on ADR-0066 §D3 and no
+// receiver in the family can be trusted to reject the "None + unverified"
+// injection shape.
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	"github.com/MicahParks/keyfunc/v2"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/i2-open/i2goSignals/pkg/goSet"
+)
+
+// newSignedSetForSplitTests produces a small signed SET wire string plus the
+// JWKS a verifier would need to accept it. Uses RS256 to match production
+// posture. Returned separately so tests can wire them in different orders.
+func newSignedSetForSplitTests(t *testing.T) (signedString string, jwks *keyfunc.JWKS, kid string) {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	set := goSet.CreateSet(
+		nil,
+		"https://issuer.example.com",
+		[]string{"https://aud.example.com"},
+	)
+	set.AddEventPayload("uri:test:event", map[string]interface{}{"a": 1})
+	set.Kid = "kid-parse-peek-split"
+
+	signed, err := set.JWS(jwt.SigningMethodRS256, priv)
+	require.NoError(t, err)
+
+	pub := priv.PublicKey
+	given := keyfunc.NewGivenRSA(&pub, keyfunc.GivenKeyOptions{Algorithm: "RS256"})
+	j := keyfunc.NewGiven(map[string]keyfunc.GivenKey{set.Kid: given})
+
+	return signed, j, set.Kid
+}
+
+// newUnsignedSetForSplitTests constructs an alg=none SET wire string directly
+// via the jwt library — the goSet package no longer produces one, per
+// ADR-0066 §D3. This exists ONLY to feed Peek and to prove Parse refuses it.
+func newUnsignedSetForSplitTests(t *testing.T) string {
+	t.Helper()
+	set := goSet.CreateSet(
+		nil,
+		"https://issuer.example.com",
+		[]string{"https://aud.example.com"},
+	)
+	set.AddEventPayload("uri:test:event", map[string]interface{}{"peek": true})
+	tok := jwt.NewWithClaims(jwt.SigningMethodNone, &set)
+	tok.Header["typ"] = "secevent+jwt"
+	s, err := tok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	require.NoError(t, err)
+	return s
+}
+
+// TestParse_NilJwks_Rejected pins the ADR-0066 §D3 rule: the verify-only Parse
+// API refuses a nil JWKS. If this test starts passing again, the silent
+// ParseUnverified fallback has been reintroduced.
+func TestParse_NilJwks_Rejected(t *testing.T) {
+	signed, _, _ := newSignedSetForSplitTests(t)
+
+	got, err := goSet.Parse(signed, nil)
+	require.Error(t, err, "goSet.Parse with nil JWKS must be refused")
+	assert.Nil(t, got, "no token must be returned when Parse refuses")
+	assert.Contains(t, err.Error(), "JWKS is required", "refusal must cite the ADR-0066 §D3 posture")
+	assert.Contains(t, err.Error(), "Peek", "refusal must point callers at the explicit Peek API")
+}
+
+// TestParse_SignedTokenAccepted confirms Parse still accepts a well-signed
+// SET when a JWKS is provided — the guardrail must be strict, not blanket.
+func TestParse_SignedTokenAccepted(t *testing.T) {
+	signed, jwks, _ := newSignedSetForSplitTests(t)
+
+	got, err := goSet.Parse(signed, jwks)
+	require.NoError(t, err, "signed SET must be accepted when JWKS validates")
+	require.NotNil(t, got)
+	assert.Equal(t, "https://issuer.example.com", got.Issuer)
+}
+
+// TestParse_UnsignedRefusedEvenWithJwks proves alg=none is never accepted
+// where a signature is expected: an unsigned SET presented to Parse with a
+// real JWKS still fails signature verification.
+func TestParse_UnsignedRefusedEvenWithJwks(t *testing.T) {
+	unsigned := newUnsignedSetForSplitTests(t)
+	_, jwks, _ := newSignedSetForSplitTests(t)
+
+	got, err := goSet.Parse(unsigned, jwks)
+	require.Error(t, err, "alg=none must not be accepted where a signature is expected")
+	assert.Nil(t, got)
+}
+
+// TestPeek_ReturnsUnverifiedClaims confirms Peek exposes the claims for
+// routing/dispatch without ever running signature verification.
+func TestPeek_ReturnsUnverifiedClaims(t *testing.T) {
+	unsigned := newUnsignedSetForSplitTests(t)
+
+	got, err := goSet.Peek(unsigned)
+	require.NoError(t, err, "Peek must return unverified claims on an unsigned SET")
+	require.NotNil(t, got)
+	assert.Equal(t, "https://issuer.example.com", got.Issuer, "iss must be readable for pre-verify routing")
+	require.Contains(t, got.Audience, "https://aud.example.com")
+}
+
+// TestPeek_OnSignedToken_DoesNotVerify confirms Peek is signature-agnostic —
+// it happily returns claims from a signed SET without checking the signature.
+// (If Peek starts verifying, callers may mistake its output for an accepted
+// token, which is the exact conflation ADR-0066 §D3 rules out.)
+func TestPeek_OnSignedToken_DoesNotVerify(t *testing.T) {
+	signed, _, _ := newSignedSetForSplitTests(t)
+
+	got, err := goSet.Peek(signed)
+	require.NoError(t, err, "Peek must succeed on any well-formed SET, signed or not")
+	require.NotNil(t, got)
+	assert.Equal(t, "https://issuer.example.com", got.Issuer)
+}
+
+// TestPeek_TypeCheckEnforced confirms Peek still enforces the secevent+jwt
+// type header — a wrong-typ JWT is rejected even at peek time so misrouted
+// tokens can't leak into SET-handling code paths.
+func TestPeek_TypeCheckEnforced(t *testing.T) {
+	set := goSet.CreateSet(nil, "iss", []string{"aud"})
+	tok := jwt.NewWithClaims(jwt.SigningMethodNone, &set)
+	tok.Header["typ"] = "jwt" // wrong type
+	s, err := tok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	require.NoError(t, err)
+
+	got, err := goSet.Peek(s)
+	require.Error(t, err, "Peek must still enforce the secevent+jwt type")
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "secevent+jwt")
+}
+
+// TestJWS_NilKey_Refused pins that goSet.JWS refuses to produce an alg=none
+// wire token — the write-side None path was removed with ADR-0066 §D3.
+func TestJWS_NilKey_Refused(t *testing.T) {
+	set := goSet.CreateSet(nil, "iss", []string{"aud"})
+	got, err := set.JWS(jwt.SigningMethodRS256, nil)
+	require.Error(t, err, "JWS with nil key must be refused")
+	assert.Equal(t, "", got)
+	assert.Contains(t, err.Error(), "alg=none production removed", "refusal must cite the ADR-0066 §D3 rationale")
+}

--- a/pkg/goSet/test/set_test.go
+++ b/pkg/goSet/test/set_test.go
@@ -163,16 +163,32 @@ func TestSetJws(t *testing.T) {
 
 	assert.Truef(t, slices.Contains([]string(newSet.Audience), "cluster.example.com"), "Contains audience")
 
-	unsignedString, err := testSet.JWS(jwt.SigningMethodNone, nil)
-	fmt.Println("Alg=None unsigned value")
+	// ADR-0066 §D3: JWS with nil key is refused (alg=none production removed).
+	_, errUnsigned := testSet.JWS(jwt.SigningMethodNone, nil)
+	assert.Error(t, errUnsigned, "JWS with nil key must be refused (ADR-0066 §D3)")
+	assert.Contains(t, errUnsigned.Error(), "alg=none production removed", "Refusal must cite the ADR-0066 rationale")
+
+	// Peek supports explicit unverified inspection for routing/display only.
+	// Construct an unsigned token directly via the JWT wrapper (test fixture)
+	// to exercise Peek's parse+type-check path.
+	unsignedString, err := testSet.JWT().SignedString(jwt.UnsafeAllowNoneSignatureType)
+	assert.NoError(t, err, "test-only unsigned string produced via JWT wrapper")
+	fmt.Println("Alg=None unsigned value (test fixture)")
 	fmt.Println(unsignedString)
 
-	newUnSignedSet, err := goSet.Parse(unsignedString, nil)
-	assert.Nil(t, err, "Assert that unsigned token was valid and parsed")
-	if err != nil {
-		fmt.Println("Parsed Unsigned token")
-		println(newUnSignedSet.String())
+	peekedSet, err := goSet.Peek(unsignedString)
+	assert.Nil(t, err, "Peek returns unverified claims for routing/display")
+	if peekedSet != nil {
+		fmt.Println("Peeked Unsigned token")
+		println(peekedSet.String())
 	}
+
+	// Parse with nil JWKS must be refused — the verify-only trust path never
+	// accepts an unverified token (ADR-0066 §D3).
+	rejected, errNil := goSet.Parse(unsignedString, nil)
+	assert.Error(t, errNil, "Parse with nil JWKS must be refused (ADR-0066 §D3)")
+	assert.Nil(t, rejected, "No token returned when Parse refuses")
+	assert.Contains(t, errNil.Error(), "JWKS is required", "Refusal must cite the ADR-0066 posture")
 
 	altPrivateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {

--- a/pkg/goSetPoll/poll_test.go
+++ b/pkg/goSetPoll/poll_test.go
@@ -247,8 +247,9 @@ func TestPollRaw_ConnectionError(t *testing.T) {
 
 func TestPoll_WithValidSETs(t *testing.T) {
 	key := generateTestKey(t)
-	jti1, token1 := createTestSET(t, "https://issuer.example.com", []string{"https://aud.example.com"}, key)
-	jti2, token2 := createTestSET(t, "https://issuer.example.com", []string{"https://aud.example.com"}, key)
+	iss := "https://issuer.example.com"
+	jti1, token1 := createTestSET(t, iss, []string{"https://aud.example.com"}, key)
+	jti2, token2 := createTestSET(t, iss, []string{"https://aud.example.com"}, key)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := PollResponse{
@@ -265,7 +266,8 @@ func TestPoll_WithValidSETs(t *testing.T) {
 
 	parsed, status, err := Poll(context.Background(), PollRequest{ReturnImmediately: true}, ReceiverConfig{
 		EndpointURL:       server.URL,
-		ExpectedIssuer:    "https://issuer.example.com",
+		JWKS:              jwksForKey(t, iss, key),
+		ExpectedIssuer:    iss,
 		ExpectedAudiences: []string{"https://aud.example.com"},
 	})
 
@@ -376,7 +378,11 @@ func TestPoll_RequireSignature_BadSignatureRejected(t *testing.T) {
 
 func TestPoll_IssuerValidationError(t *testing.T) {
 	key := generateTestKey(t)
-	jti1, token1 := createTestSET(t, "https://wrong-issuer.example.com", nil, key)
+	// Create a well-signed SET whose iss does not match ExpectedIssuer. The
+	// key is registered under the token's actual iss so signature verification
+	// succeeds; the iss mismatch surfaces as invalid_issuer (post-verify).
+	tokenIss := "https://wrong-issuer.example.com"
+	jti1, token1 := createTestSET(t, tokenIss, nil, key)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := PollResponse{
@@ -390,6 +396,7 @@ func TestPoll_IssuerValidationError(t *testing.T) {
 
 	parsed, _, err := Poll(context.Background(), PollRequest{ReturnImmediately: true}, ReceiverConfig{
 		EndpointURL:    server.URL,
+		JWKS:           jwksForKey(t, tokenIss, key),
 		ExpectedIssuer: "https://expected-issuer.example.com",
 	})
 
@@ -401,7 +408,8 @@ func TestPoll_IssuerValidationError(t *testing.T) {
 
 func TestPoll_AudienceValidationError(t *testing.T) {
 	key := generateTestKey(t)
-	jti1, token1 := createTestSET(t, "https://issuer.example.com", []string{"https://wrong-aud.example.com"}, key)
+	iss := "https://issuer.example.com"
+	jti1, token1 := createTestSET(t, iss, []string{"https://wrong-aud.example.com"}, key)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := PollResponse{
@@ -415,6 +423,7 @@ func TestPoll_AudienceValidationError(t *testing.T) {
 
 	parsed, _, err := Poll(context.Background(), PollRequest{ReturnImmediately: true}, ReceiverConfig{
 		EndpointURL:       server.URL,
+		JWKS:              jwksForKey(t, iss, key),
 		ExpectedAudiences: []string{"https://expected-aud.example.com"},
 	})
 
@@ -425,6 +434,12 @@ func TestPoll_AudienceValidationError(t *testing.T) {
 }
 
 func TestPoll_MalformedSET(t *testing.T) {
+	// Malformed SET is refused at parse time; with a JWKS present it becomes
+	// jws_signature_failed under RequireSignature, and invalid_request without.
+	// We test the no-RequireSignature branch: invalid_request classification.
+	key := generateTestKey(t)
+	iss := "https://issuer.example.com"
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := PollResponse{
 			Sets: map[string]string{
@@ -439,6 +454,7 @@ func TestPoll_MalformedSET(t *testing.T) {
 
 	parsed, _, err := Poll(context.Background(), PollRequest{ReturnImmediately: true}, ReceiverConfig{
 		EndpointURL: server.URL,
+		JWKS:        jwksForKey(t, iss, key),
 	})
 
 	require.NoError(t, err)
@@ -449,7 +465,8 @@ func TestPoll_MalformedSET(t *testing.T) {
 
 func TestPoll_MixedValidAndInvalid(t *testing.T) {
 	key := generateTestKey(t)
-	goodJti, goodToken := createTestSET(t, "https://issuer.example.com", nil, key)
+	iss := "https://issuer.example.com"
+	goodJti, goodToken := createTestSET(t, iss, nil, key)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := PollResponse{
@@ -466,7 +483,8 @@ func TestPoll_MixedValidAndInvalid(t *testing.T) {
 
 	parsed, _, err := Poll(context.Background(), PollRequest{ReturnImmediately: true}, ReceiverConfig{
 		EndpointURL:    server.URL,
-		ExpectedIssuer: "https://issuer.example.com",
+		JWKS:           jwksForKey(t, iss, key),
+		ExpectedIssuer: iss,
 	})
 
 	require.NoError(t, err)
@@ -474,6 +492,35 @@ func TestPoll_MixedValidAndInvalid(t *testing.T) {
 	assert.Contains(t, parsed.ParsedSETs, goodJti)
 	assert.Len(t, parsed.Errors, 1)
 	assert.Contains(t, parsed.Errors, "bad-jti")
+}
+
+// TestPoll_NoJWKS_AlwaysRejected pins the ADR-0066 §D2 defense-in-depth: even
+// without RequireSignature, a poll receiver with no configured trust anchor
+// must never accept a SET — the "None + unverified" state is unrepresentable.
+// If this test ever starts accepting the token, the injection hole has
+// reopened.
+func TestPoll_NoJWKS_AlwaysRejected(t *testing.T) {
+	key := generateTestKey(t)
+	iss := "https://issuer.example.com"
+	jti1, token1 := createTestSET(t, iss, nil, key)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(PollResponse{Sets: map[string]string{jti1: token1}})
+	}))
+	defer server.Close()
+
+	parsed, _, err := Poll(context.Background(), PollRequest{ReturnImmediately: true}, ReceiverConfig{
+		EndpointURL: server.URL,
+		// no JWKS, no RequireSignature — the receiver must still refuse.
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, parsed.ParsedSETs, "no SET may be accepted without a configured trust anchor (ADR-0066 §D2)")
+	require.Contains(t, parsed.Errors, jti1)
+	assert.Equal(t, "invalid_request", parsed.Errors[jti1].Error)
+	assert.Contains(t, parsed.Errors[jti1].Description, "no trust anchor")
 }
 
 func TestPoll_EmptyResponse(t *testing.T) {

--- a/pkg/goSetPoll/receiver.go
+++ b/pkg/goSetPoll/receiver.go
@@ -98,14 +98,27 @@ func Poll(ctx context.Context, request PollRequest, config ReceiverConfig) (*Par
 	}
 
 	for jti, setString := range rawResp.Sets {
-		// Signing-only poll posture (#184): verification of pulled SETs is mandatory.
-		// Without a trust anchor we cannot verify, so the SET is rejected rather than
-		// accepted unverified. Signature failures are expected peer events (WARN).
-		if config.RequireSignature && config.JWKS == nil {
-			log.Warn("RFC8936: SET signature required but no JWKS available to verify (signing-only)", "jti", jti)
+		// Per ADR-0066 §D2 the "None + unverified" state is unrepresentable:
+		// every business stream MUST have at least one active authentication
+		// layer. Stream-config validation enforces this at configure time
+		// (i2goSignals#235); this poll receiver enforces it defensively at
+		// runtime — nil JWKS is always a rejection, an unverified parse is
+		// never the accepted token. Signature failures are expected peer
+		// events (WARN, CONTEXT.md log-level policy).
+		if config.JWKS == nil {
+			if config.RequireSignature {
+				log.Warn("RFC8936: SET signature required but no JWKS available to verify (signing-only)", "jti", jti)
+				result.Errors[jti] = SetErrType{
+					Error:       "jws_signature_failed",
+					Description: "The SET signature could not be validated.",
+				}
+				continue
+			}
+			// Defense in depth for ADR-0066 §D2 — see receiver.go in goSetPush.
+			log.Warn("RFC8936: no JWKS configured; refusing to accept unverified SET (ADR-0066)", "jti", jti)
 			result.Errors[jti] = SetErrType{
-				Error:       "jws_signature_failed",
-				Description: "The SET signature could not be validated.",
+				Error:       "invalid_request",
+				Description: "The SET could not be verified: no trust anchor is configured.",
 			}
 			continue
 		}
@@ -115,7 +128,7 @@ func Poll(ctx context.Context, request PollRequest, config ReceiverConfig) (*Par
 			// When verifying against a JWKS under the signing-only posture, a parse
 			// failure is a bad signature → jws_signature_failed (the RFC8935 §2.4
 			// rotate-and-retry signal). Otherwise the prior invalid_request is kept.
-			if config.RequireSignature && config.JWKS != nil {
+			if config.RequireSignature {
 				log.Warn("RFC8936: SET signature verification failed (signing-only)", "jti", jti, "error", err)
 				result.Errors[jti] = SetErrType{
 					Error:       "jws_signature_failed",

--- a/pkg/goSetPush/push_test.go
+++ b/pkg/goSetPush/push_test.go
@@ -55,29 +55,36 @@ func buildPushRequest(t *testing.T, body string, contentType string) *http.Reque
 
 func TestParseReceivedSET_ValidToken(t *testing.T) {
 	key := generateTestKey(t)
-	tokenString := createTestSET(t, "https://issuer.example.com", []string{"https://audience.example.com"}, key)
+	iss := "https://issuer.example.com"
+	tokenString := createTestSET(t, iss, []string{"https://audience.example.com"}, key)
 
-	// Parse without signature verification (no JWKS)
+	// Per ADR-0066 §D2, the receiver requires a configured trust anchor —
+	// provide a matching JWKS so signature verification succeeds.
 	req := buildPushRequest(t, tokenString, "application/secevent+jwt")
 	config := ReceiverConfig{
-		ExpectedIssuer:    "https://issuer.example.com",
+		JWKS:              jwksForKey(t, iss, key),
+		ExpectedIssuer:    iss,
 		ExpectedAudiences: []string{"https://audience.example.com"},
 	}
 
 	result, deliveryErr := ParseReceivedSET(req, config)
 	assert.Nil(t, deliveryErr)
 	require.NotNil(t, result)
-	assert.Equal(t, "https://issuer.example.com", result.Token.Issuer)
+	assert.Equal(t, iss, result.Token.Issuer)
 	assert.Equal(t, tokenString, result.TokenString)
 }
 
 func TestParseReceivedSET_EmptyContentType(t *testing.T) {
 	key := generateTestKey(t)
-	tokenString := createTestSET(t, "https://issuer.example.com", nil, key)
+	iss := "https://issuer.example.com"
+	tokenString := createTestSET(t, iss, nil, key)
 
-	// Empty Content-Type should be accepted (per existing behavior)
+	// Empty Content-Type should be accepted (per existing behavior). Trust
+	// anchor is required by ADR-0066 §D2.
 	req := buildPushRequest(t, tokenString, "")
-	config := ReceiverConfig{}
+	config := ReceiverConfig{
+		JWKS: jwksForKey(t, iss, key),
+	}
 
 	result, deliveryErr := ParseReceivedSET(req, config)
 	assert.Nil(t, deliveryErr)
@@ -147,10 +154,14 @@ func TestParseReceivedSET_InvalidAudience(t *testing.T) {
 
 func TestParseReceivedSET_SkipIssuerValidation(t *testing.T) {
 	key := generateTestKey(t)
-	tokenString := createTestSET(t, "https://any-issuer.example.com", nil, key)
+	iss := "https://any-issuer.example.com"
+	tokenString := createTestSET(t, iss, nil, key)
 
 	req := buildPushRequest(t, tokenString, "application/secevent+jwt")
-	config := ReceiverConfig{} // no ExpectedIssuer set
+	// no ExpectedIssuer set — but trust anchor still required (ADR-0066 §D2).
+	config := ReceiverConfig{
+		JWKS: jwksForKey(t, iss, key),
+	}
 
 	result, deliveryErr := ParseReceivedSET(req, config)
 	assert.Nil(t, deliveryErr)
@@ -159,14 +170,38 @@ func TestParseReceivedSET_SkipIssuerValidation(t *testing.T) {
 
 func TestParseReceivedSET_SkipAudienceValidation(t *testing.T) {
 	key := generateTestKey(t)
-	tokenString := createTestSET(t, "https://issuer.example.com", []string{"https://any-aud.example.com"}, key)
+	iss := "https://issuer.example.com"
+	tokenString := createTestSET(t, iss, []string{"https://any-aud.example.com"}, key)
 
 	req := buildPushRequest(t, tokenString, "application/secevent+jwt")
-	config := ReceiverConfig{} // no ExpectedAudiences set
+	// no ExpectedAudiences set — but trust anchor still required (ADR-0066 §D2).
+	config := ReceiverConfig{
+		JWKS: jwksForKey(t, iss, key),
+	}
 
 	result, deliveryErr := ParseReceivedSET(req, config)
 	assert.Nil(t, deliveryErr)
 	require.NotNil(t, result)
+}
+
+// TestParseReceivedSET_NoJWKS_AlwaysRejected pins ADR-0066 §D2: a push
+// receiver with no configured trust anchor MUST refuse the SET even when
+// RequireSignature is not set. The "None + unverified" combination is
+// unrepresentable at the receiver too — stream-config validation
+// (i2goSignals#235) prevents it at configure time, but the receiver enforces
+// it defensively.
+func TestParseReceivedSET_NoJWKS_AlwaysRejected(t *testing.T) {
+	key := generateTestKey(t)
+	tokenString := createTestSET(t, "https://issuer.example.com", nil, key)
+
+	req := buildPushRequest(t, tokenString, "application/secevent+jwt")
+	config := ReceiverConfig{} // no JWKS, no RequireSignature
+
+	result, deliveryErr := ParseReceivedSET(req, config)
+	assert.Nil(t, result, "no SET may be accepted without a configured trust anchor (ADR-0066 §D2)")
+	require.NotNil(t, deliveryErr)
+	assert.Equal(t, ErrInvalidRequest, deliveryErr.ErrCode)
+	assert.Contains(t, deliveryErr.Description, "no trust anchor")
 }
 
 // jwksForKey builds a JWKS keyed by the issuer string, matching the "kid"

--- a/pkg/goSetPush/receiver.go
+++ b/pkg/goSetPush/receiver.go
@@ -147,7 +147,9 @@ func ParseReceivedSET(r *http.Request, config ReceiverConfig) (*ReceivedSET, *De
 		}
 	}
 
-	_ = unverified // peek result was used for iss/aud pre-check only; never returned as trust
+	// The peek result (`unverified`) was consumed above for iss/aud pre-check
+	// only and is intentionally discarded here — the accepted token below is
+	// the signature-verified one (ADR-0066 §D3).
 
 	return &ReceivedSET{
 		Token:       token,

--- a/pkg/goSetPush/receiver.go
+++ b/pkg/goSetPush/receiver.go
@@ -57,10 +57,13 @@ func ParseReceivedSET(r *http.Request, config ReceiverConfig) (*ReceivedSET, *De
 
 	tokenString := string(bodyBytes)
 
-	// Parse unverified first to check issuer/audience before signature verification.
-	// This ensures we return the correct RFC8935 error code (invalid_issuer, invalid_audience)
-	// rather than a generic invalid_request when the JWKS kid lookup fails due to a wrong issuer.
-	unverified, err := goSet.Parse(tokenString, nil)
+	// Peek at the token's claims (UNVERIFIED) to check issuer/audience before
+	// signature verification. This ensures we return the correct RFC8935 error
+	// code (invalid_issuer, invalid_audience) rather than a generic
+	// invalid_request when the JWKS kid lookup fails due to a wrong issuer.
+	// Per ADR-0066 §D3 the peek result is never accepted as the trust decision —
+	// the accepted token below is the verified one only.
+	unverified, err := goSet.Peek(tokenString)
 	if err != nil {
 		log.Warn("RFC8935: Error parsing SET token", "error", err)
 		return nil, &DeliveryErr{
@@ -98,39 +101,53 @@ func ParseReceivedSET(r *http.Request, config ReceiverConfig) (*ReceivedSET, *De
 		}
 	}
 
-	// Verify the signature. With a JWKS configured we always verify. Under the
-	// signing-only posture (RequireSignature, #184) the JWS signature is the trust
-	// gate, so a verify failure is jws_signature_failed (the RFC8935 §2.4
-	// rotate-and-retry signal) and a missing trust anchor (nil JWKS) is itself a
-	// hard reject — the SET must never be accepted unverified. Without the posture
-	// the prior behavior is preserved: a nil JWKS skips verification and a verify
-	// failure is invalid_request. Issuer mismatch was already handled above, so a
-	// failure here is a bad signature, not a trust failure. Signature failures are
-	// expected peer events, hence WARN, not ERROR (CONTEXT.md log-level policy).
-	token := unverified
-	if config.JWKS != nil {
-		token, err = goSet.Parse(tokenString, config.JWKS)
-		if err != nil {
-			if config.RequireSignature {
-				log.Warn("RFC8935: SET signature verification failed (signing-only)", "error", err)
-				return nil, &DeliveryErr{
-					ErrCode:     ErrJwsSignatureFailed,
-					Description: "The SET signature could not be validated.",
-				}
-			}
-			log.Warn("RFC8935: Error validating SET token signature", "error", err)
+	// Verify the signature. Per ADR-0066 §D2 the "None + unverified" state is
+	// unrepresentable: every business stream MUST have at least one active
+	// authentication layer (L2 channel auth OR L3 SET-signature verification
+	// against a configured trust root). Stream-config validation enforces this
+	// at configure time (i2goSignals#235); this receiver enforces it defensively
+	// at runtime — a nil JWKS is always a hard reject, an unverified parse is
+	// never the accepted token.
+	//
+	// Issuer mismatch was already handled above, so a failure here is a bad
+	// signature, not a trust failure. Signature failures are expected peer
+	// events, hence WARN, not ERROR (CONTEXT.md log-level policy).
+	if config.JWKS == nil {
+		if config.RequireSignature {
+			log.Warn("RFC8935: SET signature required but no JWKS available to verify (signing-only)")
 			return nil, &DeliveryErr{
-				ErrCode:     ErrInvalidRequest,
-				Description: "The request could not be parsed as a SET.",
+				ErrCode:     ErrJwsSignatureFailed,
+				Description: "The SET signature could not be validated.",
 			}
 		}
-	} else if config.RequireSignature {
-		log.Warn("RFC8935: SET signature required but no JWKS available to verify (signing-only)")
+		// Defense in depth for ADR-0066 §D2: reaching this branch means the
+		// stream is configured without a trust anchor and without transport
+		// auth as the signature gate. Stream-config validation should have
+		// prevented this; reject the delivery rather than accept unverified.
+		log.Warn("RFC8935: no JWKS configured; refusing to accept unverified SET (ADR-0066)")
 		return nil, &DeliveryErr{
-			ErrCode:     ErrJwsSignatureFailed,
-			Description: "The SET signature could not be validated.",
+			ErrCode:     ErrInvalidRequest,
+			Description: "The SET could not be verified: no trust anchor is configured.",
 		}
 	}
+
+	token, err := goSet.Parse(tokenString, config.JWKS)
+	if err != nil {
+		if config.RequireSignature {
+			log.Warn("RFC8935: SET signature verification failed (signing-only)", "error", err)
+			return nil, &DeliveryErr{
+				ErrCode:     ErrJwsSignatureFailed,
+				Description: "The SET signature could not be validated.",
+			}
+		}
+		log.Warn("RFC8935: Error validating SET token signature", "error", err)
+		return nil, &DeliveryErr{
+			ErrCode:     ErrInvalidRequest,
+			Description: "The request could not be parsed as a SET.",
+		}
+	}
+
+	_ = unverified // peek result was used for iss/aud pre-check only; never returned as trust
 
 	return &ReceivedSET{
 		Token:       token,


### PR DESCRIPTION
Per [ADR-0066](https://github.com/independentid/i2gosignals-planning/blob/main/docs/adr/0066-business-stream-l2-menu-and-none-invariant.md) §D3 (planning#48), the trust path is now verify-only at the API level; unverified inspection survives only under an explicit, greppable name a reviewer cannot mistake for verification. The silent `ParseUnverified` fallback is removed. Complements #235 (stream-config validation) — together they close the "None + unverified" injection hole.

## What changes

### `pkg/goSet` (the API split)

- `Parse(tokenString, jwks)` — `jwks == nil` now returns an error citing the ADR-0066 §D3 posture and pointing callers at `Peek`.
- **New** `Peek(tokenString)` — explicit UNVERIFIED inspection API for routing/dispatch only. Documented as untrusted; enforces the `secevent+jwt` type header.
- `JWS(method, key)` — the `key == nil` (alg=none production) branch is removed. No legitimate production producer of unsigned SETs remains. Tests that need an unsigned wire string construct it directly via the `jwt` library.
- `JWT()` — kept as a test-only wrapper (no wire emission) with a `Deprecated:` doc-comment.

### `pkg/goSetPush/receiver.go`

- Pre-verify iss/aud peek migrated to `goSet.Peek` — the peek result is never returned as the accepted token.
- The `token := unverified` acceptance branch (nil JWKS + !RequireSignature) is removed. A missing trust anchor is now a hard reject (`invalid_request`, "no trust anchor is configured") as defense in depth for the ADR-0066 §D2 invariant that stream-config validation enforces upstream (#235).

### `pkg/goSetPoll/receiver.go`

- Same defense-in-depth: nil JWKS is always a rejection, regardless of `RequireSignature`.

### Test migration

- `internal/eventRouter/{pb_resign_test,delivery/http_test}` — test-side body inspection uses `goSet.Peek` (never a trust decision).
- `pkg/goSet/test/set_test.go` — unsigned-token flow migrated to `Peek`; `Parse(nil)` rejection is asserted.
- `pkg/goSet/test/parse_peek_split_test.go` (**new**) — pins the ADR-0066 §D3 contract: nil-JWKS `Parse` rejection, `Peek` is signature-agnostic, type-check still enforced, `JWS` nil-key refusal.
- `pkg/goSet{Push,Poll}` — receiver tests updated to provide a matching JWKS; new `NoJWKS_AlwaysRejected` tests pin the receiver-side defense-in-depth.
- `internal/server/api_sstp_test.go` — the alg=none SET fixture is replaced with signed-SET+matching-JWKS; bad-issuer coverage retained (rejection fires on the pre-verify Peek, before JWKS is consulted).

## Gates

- `go test -race ./...` green
- `go vet ./...` green
- `make seams` (ephemeral wide go.work self-check) green

Enterprise / admin pick this up via the next `/release-train` tag; they consume `goSet` types only and have no prod `Parse` call sites (grep-verified).

Delivers i2-open/i2goSignals#234
Part of independentid/i2gosignals-planning#48

Binding ADRs: [ADR-0066](https://github.com/independentid/i2gosignals-planning/blob/main/docs/adr/0066-business-stream-l2-menu-and-none-invariant.md) §D3.