### PR TITLE
security(streams): enforce ADR-0066 D2 — None+unverified unrepresentable (#235)

### DIFF
--- a/internal/server/api_sstp.go
+++ b/internal/server/api_sstp.go
@@ -75,6 +75,22 @@ func ReceiveSstpEventHandler(sa SsfApplicationInterface, w http.ResponseWriter, 
 	// bearer that IS presented is still held to the full check, so the gate is
 	// enforced whenever an Authorization header is present or the stream is not
 	// signing-only — leaving flag-off pairs byte-for-byte unchanged.
+	//
+	// ADR-0066 §D2 audit (i2goSignals#235): dropping the L2 bearer requirement
+	// is safe ONLY when the L3 SET-signature verification path has a real trust
+	// root. The invariant is enforced upstream by three cooperating layers:
+	//   1. StreamService.CreateStream — validateBusinessStreamSecurity rejects
+	//      SigningOnly=true without a trust root at create time.
+	//   2. StreamService.UpdateStream — same validator on the update path,
+	//      before any DAO write.
+	//   3. LoadReceiverStreams startup guard — persisted-but-invalid records
+	//      (from an older validator) are marked disabled before they can
+	//      serve traffic.
+	// Under these three, this handler is entered only for pairs that satisfy
+	// the invariant, so no additional runtime "no trust root" gate is needed
+	// (and a naive `IssuerJWKSUrl == ""` check here would false-positive on
+	// the DEFAULT-loopback issuer, whose trust root is resolved by local key
+	// lookup rather than by an outbound URL fetch — see loadInboundJwksForPair).
 	signingOnly := rec.SstpInbound != nil && rec.SstpInbound.SigningOnly
 	bearerPresented := r.Header.Get("Authorization") != ""
 

--- a/pkg/services/stream_service.go
+++ b/pkg/services/stream_service.go
@@ -119,6 +119,64 @@ func (s *StreamService) validateSubjectFilterMode(ctx context.Context, rec *mode
 // validateSubjectFilterMode in the create/update pipeline. Only the request
 // value is checked here — the WARN-and-drop for a receiver stream is the
 // caller's responsibility, since the rejection must be field-shape only.
+// normalizeStreamTrustFields applies the "NONE" → empty normalization to the
+// stream's IssuerJWKSUrl. Some SCIM peers signal "the key is internal to this
+// server" by literally writing "NONE" for IssuerJWKSUrl; downstream code and
+// the validateBusinessStreamSecurity invariant expect an empty value in that
+// case. Case-insensitive per the historical CreateStream normalization.
+func normalizeStreamTrustFields(cfg *model.StreamConfiguration) {
+	if cfg == nil {
+		return
+	}
+	if strings.EqualFold(cfg.IssuerJWKSUrl, "NONE") {
+		cfg.IssuerJWKSUrl = ""
+	}
+}
+
+// validateBusinessStreamSecurity enforces the ADR-0066 §D2 invariant: every
+// business stream MUST have at least one active authentication layer — L2
+// channel auth (bearer / mTLS), OR L3 SET-signature verification against a
+// configured trust root (IssuerJWKSUrl + Iss).
+//
+// In this codebase, the receive-side L2 posture is represented by SigningOnly:
+// when SigningOnly is TRUE the transport bearer requirement is dropped
+// (see internal/server/api_sstp.go and internal/server/api_receiver.go under
+// #184), so the ONLY remaining trust layer is the SET signature — and that
+// requires a real trust anchor (Iss + IssuerJWKSUrl). When SigningOnly is
+// FALSE the bearer requirement is in force and the L2 layer is active; a
+// trust anchor is still allowed (belt-and-suspenders) but is not required.
+//
+// This function is invariant-only: it does NOT validate SSF-shape fields or
+// operator knobs. Call this from every create/update entry point, and from
+// startup receiver-stream loading, so a persisted-but-invalid configuration
+// cannot go live.
+//
+// The invariant guard is expressed positively so a diff or a reviewer can
+// see it at a glance:
+//   - if L2 = None (SigningOnly): trust root MUST be configured.
+//   - otherwise: no additional guard.
+//
+// The "None + unverified" state is not representable through this validator.
+func validateBusinessStreamSecurity(cfg model.StreamConfiguration) error {
+	if !cfg.SigningOnly {
+		// L2 (bearer) is the active authentication layer — invariant satisfied.
+		return nil
+	}
+	// L2 = None; a trust anchor (Iss + IssuerJWKSUrl) is mandatory (ADR-0066 §D2).
+	if strings.EqualFold(cfg.IssuerJWKSUrl, "NONE") {
+		// Defensive: callers should have normalized this to "" before validating.
+		return errors.New(
+			"signingOnly (L2=None) requires a configured trust root — " +
+				"IssuerJWKSUrl 'NONE' is not a trust root (ADR-0066 §D2)")
+	}
+	if cfg.Iss == "" || cfg.IssuerJWKSUrl == "" {
+		return errors.New(
+			"signingOnly (L2=None) requires both iss and issuerJWKSUrl to be " +
+				"configured — 'None + unverified' is not a configurable state (ADR-0066 §D2)")
+	}
+	return nil
+}
+
 func validateSubjectRemovalGrace(grace int) error {
 	if grace < 0 {
 		return fmt.Errorf("invalid subject_removal_grace_seconds: must be >= 0, got %d", grace)
@@ -268,10 +326,8 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamSt
 
 	// Normalise IssuerJWKSUrl == "NONE" (any case) to the empty string. SCIM
 	// servers signal "key is internal to this server" via "NONE"; downstream
-	// code expects an empty value.
-	if strings.EqualFold(request.IssuerJWKSUrl, "NONE") {
-		request.IssuerJWKSUrl = ""
-	}
+	// code and the ADR-0066 §D2 invariant expect an empty value.
+	normalizeStreamTrustFields(&request.StreamConfiguration)
 
 	// Validate goSignals-specific knobs before any state is mutated. The SSF
 	// §9.3 grace override (PRD #97 #98) is validated alongside #89's mode and
@@ -280,13 +336,12 @@ func (s *StreamService) CreateStream(ctx context.Context, request model.StreamSt
 		return model.StreamConfiguration{}, err
 	}
 
-	// Signing-only receive posture guardrail (#184): a stream that gates trust on
-	// the SET's JWS signature (rather than a transport bearer) MUST carry an explicit
-	// trust anchor — the issuer it trusts plus where that issuer's keys live. We
-	// validate the request as supplied (before Iss is defaulted to the local issuer),
-	// so signingOnly can never be silently enabled without a real trust anchor.
-	if request.SigningOnly && (request.Iss == "" || request.IssuerJWKSUrl == "") {
-		return model.StreamConfiguration{}, errors.New("signingOnly requires both iss and issuerJWKSUrl to be configured")
+	// ADR-0066 §D2 invariant — "None + unverified" is not a configurable state
+	// (i2goSignals#235). We validate the request as supplied (before Iss is
+	// defaulted to the local issuer), so signingOnly can never be silently
+	// enabled without a real trust anchor.
+	if err := validateBusinessStreamSecurity(request.StreamConfiguration); err != nil {
+		return model.StreamConfiguration{}, err
 	}
 
 	mid := bson.NewObjectID()
@@ -1108,14 +1163,17 @@ func (s *StreamService) UpdateStream(ctx context.Context, streamID string, proje
 	}
 
 	// Signing-only posture (#184) is settable on receiver streams via update; it is a
-	// no-op on transmitter streams. Apply the same trust-anchor guardrail as create:
-	// the resulting stream must name both an issuer and a JWKS URL when signing-only.
+	// no-op on transmitter streams. Normalize the NONE→empty JWKS-URL sentinel
+	// exactly as CreateStream does — the invariant validator below assumes the
+	// normalized form. Then apply the ADR-0066 §D2 invariant (i2goSignals#235)
+	// so the "None + unverified" state is unreachable via update.
 	switch config.Delivery.GetMethod() {
 	case model.ReceivePoll, model.ReceivePush:
 		config.SigningOnly = configReq.SigningOnly
 	}
-	if config.SigningOnly && (config.Iss == "" || config.IssuerJWKSUrl == "") {
-		return nil, errors.New("signingOnly requires both iss and issuerJWKSUrl to be configured")
+	normalizeStreamTrustFields(config)
+	if err := validateBusinessStreamSecurity(*config); err != nil {
+		return nil, err
 	}
 
 	streamRec.StreamConfiguration = *config
@@ -1392,6 +1450,23 @@ func (s *StreamService) LoadReceiverStreams(ctx context.Context) map[string]*mod
 	res := map[string]*model.StreamStateRecord{}
 	for _, streamState := range recs {
 		state := streamState
+
+		// ADR-0066 §D2 (i2goSignals#235) fail-closed startup guard: if a
+		// persisted stream violates the "at least one active auth layer"
+		// invariant — i.e. it was configured by an older validator that let
+		// "None + unverified" through — disable it here rather than surface a
+		// live unauthenticated event-injection endpoint. Operator must
+		// reconfigure it (with a JWKS URL, or SigningOnly=false) before it
+		// will accept traffic again. A single WARN with the SID + the concrete
+		// violation makes the remediation obvious.
+		if err := s.disableIfSecurityInvariantViolated(ctx, &state); err != nil {
+			// Persisting the disabled status failed — do NOT surface the
+			// stream: skip loading it entirely so it cannot serve requests.
+			ssLog.Error("Fail-closed: skipping load of security-invariant-violating stream",
+				"sid", state.StreamConfiguration.Id, "error", err)
+			continue
+		}
+
 		// An SSTP pair receives on its inbound direction: preload the inbound JWKS
 		// keyed under the rx-side SID (== SstpInbound.Id), the key the receive path
 		// looks up (finding #1/#2/#10). The tx-side primary config holds no inbound
@@ -1411,6 +1486,52 @@ func (s *StreamService) LoadReceiverStreams(ctx context.Context) map[string]*mod
 	s.receiverStreams = res
 	s.mu.Unlock()
 	return res
+}
+
+// disableIfSecurityInvariantViolated re-validates a persisted receiver stream
+// against ADR-0066 §D2 at load time and, if the invariant is violated, marks
+// the stream disabled with a clear operator-visible error message. The
+// resulting record is written back through the DAO so the disabled state
+// survives a restart. Returns any DAO write error so the caller can decide
+// whether to surface the stream at all.
+//
+// The invariant is applied to both the primary StreamConfiguration and the
+// SstpInbound leg (an SSTP pair's rx-side has its own iss/JWKS/signing-only
+// posture). If either violates, the pair is disabled — a partially-invariant
+// pair cannot safely accept inbound events.
+func (s *StreamService) disableIfSecurityInvariantViolated(
+	ctx context.Context, rec *model.StreamStateRecord,
+) error {
+	normalizeStreamTrustFields(&rec.StreamConfiguration)
+	if err := validateBusinessStreamSecurity(rec.StreamConfiguration); err != nil {
+		return s.disableInvariantViolation(ctx, rec, "primary", err)
+	}
+	if rec.SstpInbound != nil {
+		normalizeStreamTrustFields(rec.SstpInbound)
+		if err := validateBusinessStreamSecurity(*rec.SstpInbound); err != nil {
+			return s.disableInvariantViolation(ctx, rec, "sstp-inbound", err)
+		}
+	}
+	return nil
+}
+
+// disableInvariantViolation writes the fail-closed disabled state back to the
+// DAO and emits a single WARN naming the violation source ("primary" vs
+// "sstp-inbound"), the stream SID, and the invariant error. Split out from
+// disableIfSecurityInvariantViolated so both legs share the same disable
+// path.
+func (s *StreamService) disableInvariantViolation(
+	ctx context.Context, rec *model.StreamStateRecord, leg string, invariantErr error,
+) error {
+	sid := rec.StreamConfiguration.Id
+	ssLog.Warn("Fail-closed: disabling receiver stream that violates ADR-0066 §D2 (None + unverified)",
+		"sid", sid, "leg", leg, "invariant", invariantErr.Error())
+	rec.Status = model.StreamStateDisable
+	rec.ErrorMsg = "ADR-0066 §D2 invariant violation (" + leg + "): " + invariantErr.Error()
+	if err := s.streamDAO.Update(ctx, rec); err != nil {
+		return fmt.Errorf("persist disabled state: %w", err)
+	}
+	return nil
 }
 
 // isPermanentJwksError determines if a JWKS loading error is permanent (should disable stream)

--- a/pkg/services/stream_service.go
+++ b/pkg/services/stream_service.go
@@ -114,11 +114,6 @@ func (s *StreamService) validateSubjectFilterMode(ctx context.Context, rec *mode
 	return nil
 }
 
-// validateSubjectRemovalGrace rejects a malformed SSF §9.3 grace override on
-// the request before any state is mutated (PRD #97 issue #98). Sits alongside
-// validateSubjectFilterMode in the create/update pipeline. Only the request
-// value is checked here — the WARN-and-drop for a receiver stream is the
-// caller's responsibility, since the rejection must be field-shape only.
 // normalizeStreamTrustFields applies the "NONE" → empty normalization to the
 // stream's IssuerJWKSUrl. Some SCIM peers signal "the key is internal to this
 // server" by literally writing "NONE" for IssuerJWKSUrl; downstream code and
@@ -177,6 +172,11 @@ func validateBusinessStreamSecurity(cfg model.StreamConfiguration) error {
 	return nil
 }
 
+// validateSubjectRemovalGrace rejects a malformed SSF §9.3 grace override on
+// the request before any state is mutated (PRD #97 issue #98). Sits alongside
+// validateSubjectFilterMode in the create/update pipeline. Only the request
+// value is checked here — the WARN-and-drop for a receiver stream is the
+// caller's responsibility, since the rejection must be field-shape only.
 func validateSubjectRemovalGrace(grace int) error {
 	if grace < 0 {
 		return fmt.Errorf("invalid subject_removal_grace_seconds: must be >= 0, got %d", grace)

--- a/pkg/services/stream_service_adr0066_invariant_test.go
+++ b/pkg/services/stream_service_adr0066_invariant_test.go
@@ -1,0 +1,327 @@
+package services
+
+// ADR-0066 §D2 — "None + unverified" is not a configurable state.
+//
+// These tests pin the invariant that i2goSignals#235 introduced:
+//   - Business-stream config validation rejects L2=None (SigningOnly=true)
+//     combined with no configured trust root (IssuerJWKSUrl / Iss) — on
+//     CREATE and UPDATE, across push, poll, and SSTP-business shapes.
+//   - The "NONE" sentinel is normalized to empty and then rejected under
+//     signing-only, on both create and update paths.
+//   - LoadReceiverStreams fail-closes any persisted stream that violates
+//     the invariant (disables it, records the reason on the record), so
+//     an older validator that let None+unverified through cannot silently
+//     surface a live unauthenticated event-injection endpoint at restart.
+//
+// If any of these tests fail, planning#48 has regressed on the ADR-0066 §D2
+// posture and the injection hole has reopened.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/i2-open/i2goSignals/pkg/dao/memory"
+	model "github.com/i2-open/i2goSignals/pkg/ssfModels"
+)
+
+// noneUnverifiedPollReceive constructs a receive-side poll-mode stream request
+// that is L2=None (SigningOnly=true) with NO configured trust root. Under the
+// old guard this was rejected only because the guard exists; the point of
+// these tests is to prove that (a) the invariant is stated as such and (b)
+// the "NONE" sentinel is also caught.
+func noneUnverifiedPollReceive(iss, jwksUrl string) model.StreamStateRecord {
+	return model.StreamStateRecord{StreamConfiguration: model.StreamConfiguration{
+		Iss:             iss,
+		IssuerJWKSUrl:   jwksUrl,
+		SigningOnly:     true,
+		EventsRequested: []string{"urn:ietf:params:sse:event-type:risc:account-enabled"},
+		Delivery: &model.OneOfStreamConfigurationDelivery{
+			PollReceiveMethod: &model.PollReceiveMethod{Method: model.ReceivePoll},
+		},
+	}}
+}
+
+// noneUnverifiedPushReceive is the push shape of the same scenario. The
+// invariant is delivery-shape-agnostic: the L2=None posture on any receive
+// method requires a trust root.
+func noneUnverifiedPushReceive(iss, jwksUrl string) model.StreamStateRecord {
+	return model.StreamStateRecord{StreamConfiguration: model.StreamConfiguration{
+		Iss:             iss,
+		IssuerJWKSUrl:   jwksUrl,
+		SigningOnly:     true,
+		EventsRequested: []string{"urn:ietf:params:sse:event-type:risc:account-enabled"},
+		Delivery: &model.OneOfStreamConfigurationDelivery{
+			PushReceiveMethod: &model.PushReceiveMethod{Method: model.ReceivePush},
+		},
+	}}
+}
+
+// TestADR0066_Invariant_Helper_PositivelyStated pins the shape of the
+// invariant helper's decision table so a refactor cannot accidentally flip
+// the polarity of the guard.
+func TestADR0066_Invariant_Helper_PositivelyStated(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     model.StreamConfiguration
+		wantErr bool
+		errHint string
+	}{
+		{
+			name:    "L2=bearer (SigningOnly=false) with no trust root — invariant satisfied by L2",
+			cfg:     model.StreamConfiguration{SigningOnly: false},
+			wantErr: false,
+		},
+		{
+			name:    "L2=bearer with a trust root — allowed (belt-and-suspenders)",
+			cfg:     model.StreamConfiguration{SigningOnly: false, Iss: "https://iss.example", IssuerJWKSUrl: "https://jwks.example"},
+			wantErr: false,
+		},
+		{
+			name:    "L2=None + no iss + no jwks — REJECTED (None + unverified)",
+			cfg:     model.StreamConfiguration{SigningOnly: true},
+			wantErr: true,
+			errHint: "None + unverified",
+		},
+		{
+			name:    "L2=None + iss only, missing jwks — REJECTED",
+			cfg:     model.StreamConfiguration{SigningOnly: true, Iss: "https://iss.example"},
+			wantErr: true,
+			errHint: "None + unverified",
+		},
+		{
+			name:    "L2=None + jwks only, missing iss — REJECTED",
+			cfg:     model.StreamConfiguration{SigningOnly: true, IssuerJWKSUrl: "https://jwks.example"},
+			wantErr: true,
+			errHint: "None + unverified",
+		},
+		{
+			name:    "L2=None + iss + jwks='NONE' (un-normalized sentinel) — REJECTED",
+			cfg:     model.StreamConfiguration{SigningOnly: true, Iss: "https://iss.example", IssuerJWKSUrl: "NONE"},
+			wantErr: true,
+			errHint: "IssuerJWKSUrl 'NONE' is not a trust root",
+		},
+		{
+			name:    "L2=None + full trust root — invariant satisfied by L3",
+			cfg:     model.StreamConfiguration{SigningOnly: true, Iss: "https://iss.example", IssuerJWKSUrl: "https://jwks.example"},
+			wantErr: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateBusinessStreamSecurity(tc.cfg)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errHint)
+				assert.Contains(t, err.Error(), "ADR-0066")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestADR0066_Create_PollReceive_NoTrustRoot_Rejected — the poll-receive
+// business-stream shape rejects None+unverified at create time.
+func TestADR0066_Create_PollReceive_NoTrustRoot_Rejected(t *testing.T) {
+	svc := newStrictTestStreamService(t)
+	ctx := context.Background()
+
+	_, err := svc.CreateStream(ctx, noneUnverifiedPollReceive("", ""), "test-project", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "None + unverified")
+	assert.Contains(t, err.Error(), "ADR-0066")
+}
+
+// TestADR0066_Create_PushReceive_NoTrustRoot_Rejected — the push-receive
+// business-stream shape rejects the same misconfiguration.
+func TestADR0066_Create_PushReceive_NoTrustRoot_Rejected(t *testing.T) {
+	svc := newStrictTestStreamService(t)
+	ctx := context.Background()
+
+	_, err := svc.CreateStream(ctx, noneUnverifiedPushReceive("", ""), "test-project", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "None + unverified")
+}
+
+// TestADR0066_Create_NoneSentinelRejected proves that the "NONE" sentinel
+// (case-insensitive) is normalized THEN caught by the invariant validator.
+// A signing-only stream cannot smuggle an unverified posture past validation
+// by writing "NONE" for IssuerJWKSUrl.
+func TestADR0066_Create_NoneSentinelRejected(t *testing.T) {
+	svc := newStrictTestStreamService(t)
+	ctx := context.Background()
+
+	for _, sentinel := range []string{"NONE", "None", "none"} {
+		t.Run(sentinel, func(t *testing.T) {
+			_, err := svc.CreateStream(ctx, noneUnverifiedPollReceive("https://iss.example", sentinel), "test-project", nil)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "None + unverified")
+		})
+	}
+}
+
+// TestADR0066_Update_RejectsFlipToNoneUnverified proves the update path also
+// enforces the invariant: flipping a bare receiver stream (no trust root) to
+// SigningOnly=true is rejected with the ADR-0066 wording. This complements
+// TestUpdateStream_SigningOnlyGuardrail which exercises the same code path
+// but does not assert the ADR-0066 wording — the wording is what future
+// reviewers grep for when auditing the invariant.
+func TestADR0066_Update_RejectsFlipToNoneUnverified(t *testing.T) {
+	svc := newStrictTestStreamService(t)
+	ctx := context.Background()
+
+	// Create a plain receiver with no trust root and SigningOnly=false —
+	// invariant satisfied by L2 (bearer).
+	plain := model.StreamStateRecord{StreamConfiguration: model.StreamConfiguration{
+		EventsRequested: []string{"urn:ietf:params:sse:event-type:risc:account-enabled"},
+		Delivery: &model.OneOfStreamConfigurationDelivery{
+			PollReceiveMethod: &model.PollReceiveMethod{Method: model.ReceivePoll},
+		},
+	}}
+	created, err := svc.CreateStream(ctx, plain, "test-project", nil)
+	require.NoError(t, err)
+	require.False(t, created.SigningOnly)
+
+	// Flip SigningOnly on without adding a trust root — should be rejected.
+	flip := model.StreamStateRecord{StreamConfiguration: model.StreamConfiguration{
+		SigningOnly: true,
+		Delivery: &model.OneOfStreamConfigurationDelivery{
+			PollReceiveMethod: &model.PollReceiveMethod{Method: model.ReceivePoll},
+		},
+	}}
+	_, err = svc.UpdateStream(ctx, created.Id, "test-project", flip)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "None + unverified")
+	assert.Contains(t, err.Error(), "ADR-0066")
+}
+
+// TestADR0066_LoadReceiverStreams_FailClosedOnPersistedViolation proves the
+// startup fail-closed guard: a stream persisted directly through the DAO
+// (bypassing CreateStream, mimicking an older release's validator letting
+// None+unverified through) is disabled when LoadReceiverStreams runs, with
+// the reason recorded on the record. Operator remediation is then obvious.
+func TestADR0066_LoadReceiverStreams_FailClosedOnPersistedViolation(t *testing.T) {
+	svc := newStrictTestStreamService(t)
+	ctx := context.Background()
+
+	// Persist a signing-only stream with NO trust root, bypassing the
+	// validator (as an older release would have allowed).
+	bad := &model.StreamStateRecord{
+		StreamConfiguration: model.StreamConfiguration{
+			Id:              "bad-none-unverified-sid",
+			Iss:             "", // no iss
+			IssuerJWKSUrl:   "", // no jwks
+			SigningOnly:     true,
+			EventsRequested: []string{"urn:ietf:params:sse:event-type:risc:account-enabled"},
+			Delivery: &model.OneOfStreamConfigurationDelivery{
+				PollReceiveMethod: &model.PollReceiveMethod{Method: model.ReceivePoll},
+			},
+		},
+		Status: model.StreamStateEnabled, // was live under the old validator
+	}
+	require.NoError(t, svc.streamDAO.Create(ctx,bad))
+
+	// Simulate a restart: LoadReceiverStreams should re-validate and
+	// fail-closed the offending record.
+	_ = svc.LoadReceiverStreams(ctx)
+
+	reloaded, err := svc.GetStreamState(ctx, "bad-none-unverified-sid")
+	require.NoError(t, err)
+	require.NotNil(t, reloaded)
+	assert.Equal(t, model.StreamStateDisable, reloaded.Status,
+		"a persisted None+unverified stream must be disabled at startup (ADR-0066 §D2)")
+	assert.Contains(t, reloaded.ErrorMsg, "ADR-0066 §D2 invariant violation")
+	assert.Contains(t, reloaded.ErrorMsg, "primary")
+}
+
+// TestADR0066_LoadReceiverStreams_PermitsValidStreams proves the fail-closed
+// startup guard does NOT touch streams that satisfy the invariant.
+func TestADR0066_LoadReceiverStreams_PermitsValidStreams(t *testing.T) {
+	svc := newStrictTestStreamService(t)
+	ctx := context.Background()
+	jwks := emptyJwksServer(t)
+
+	// A signing-only stream WITH a real trust root — invariant satisfied.
+	good := &model.StreamStateRecord{
+		StreamConfiguration: model.StreamConfiguration{
+			Id:              "good-signing-only-sid",
+			Iss:             "https://issuer.example.com",
+			IssuerJWKSUrl:   jwks.URL,
+			SigningOnly:     true,
+			EventsRequested: []string{"urn:ietf:params:sse:event-type:risc:account-enabled"},
+			Delivery: &model.OneOfStreamConfigurationDelivery{
+				PollReceiveMethod: &model.PollReceiveMethod{Method: model.ReceivePoll},
+			},
+		},
+		Status: model.StreamStateEnabled,
+	}
+	require.NoError(t, svc.streamDAO.Create(ctx,good))
+
+	_ = svc.LoadReceiverStreams(ctx)
+
+	reloaded, err := svc.GetStreamState(ctx, "good-signing-only-sid")
+	require.NoError(t, err)
+	require.NotNil(t, reloaded)
+	assert.Equal(t, model.StreamStateEnabled, reloaded.Status,
+		"a compliant stream must remain enabled after startup fail-closed scan")
+	assert.Empty(t, reloaded.ErrorMsg)
+}
+
+// TestADR0066_LoadReceiverStreams_FailClosedOnSstpInboundViolation exercises
+// the SSTP-business shape: an SSTP pair whose rx-side (SstpInbound) leg is
+// signing-only without a trust root must also be disabled at startup. A
+// partially-invariant pair cannot safely accept inbound events.
+func TestADR0066_LoadReceiverStreams_FailClosedOnSstpInboundViolation(t *testing.T) {
+	svc := newStrictTestStreamService(t)
+	ctx := context.Background()
+
+	pair := &model.StreamStateRecord{
+		PairId: "sstp-pair-id",
+		StreamConfiguration: model.StreamConfiguration{
+			Id:  "sstp-pair-sid",
+			Iss: "https://tx.example",
+			Delivery: &model.OneOfStreamConfigurationDelivery{
+				SstpTransmitMarker: &model.SstpTransmitMarker{Method: model.DeliverySstp},
+			},
+		},
+		// SstpMethod being non-nil is what makes GetType() report
+		// DeliverySstpPair, which in turn makes HasInbound() report true and
+		// puts the record on the ListReceiverStreams path.
+		SstpMethod: &model.SstpMethod{
+			Role:        model.SstpRoleInitiator,
+			EndpointUrl: "https://peer.example/sstp/pair-peer",
+			PeerPairId:  "pair-peer",
+		},
+		// Rx-side (inbound) leg violates the invariant: signing-only with no
+		// trust root. The pair MUST be disabled even though the primary leg
+		// (tx side) is fine — a partially-invariant pair cannot safely accept
+		// inbound events.
+		SstpInbound: &model.StreamConfiguration{
+			Id:            "sstp-pair-inbound-sid",
+			Iss:           "",
+			IssuerJWKSUrl: "",
+			SigningOnly:   true,
+			Delivery: &model.OneOfStreamConfigurationDelivery{
+				SstpReceiveMarker: &model.SstpReceiveMarker{Method: model.ReceiveSstp},
+			},
+		},
+		Status: model.StreamStateEnabled,
+	}
+	require.NoError(t, svc.streamDAO.Create(ctx,pair))
+
+	_ = svc.LoadReceiverStreams(ctx)
+
+	reloaded, err := svc.GetStreamState(ctx, "sstp-pair-sid")
+	require.NoError(t, err)
+	require.NotNil(t, reloaded)
+	assert.Equal(t, model.StreamStateDisable, reloaded.Status,
+		"an SSTP pair whose inbound leg violates the invariant must be disabled at startup")
+	assert.Contains(t, reloaded.ErrorMsg, "sstp-inbound",
+		"the disable reason must name the offending leg for operator remediation")
+}
+
+// (guard against unused imports if the memory package alias flips)
+var _ = memory.NewStreamDAO


### PR DESCRIPTION
Per [ADR-0066](https://github.com/independentid/i2gosignals-planning/blob/main/docs/adr/0066-business-stream-l2-menu-and-none-invariant.md) §D2 (planning#48), every business stream MUST have at least one active authentication layer — L2 channel auth (bearer / mTLS) or L3 SET-signature verification against a configured trust root. **"None + unverified" is not a configurable state.** Companion to #234 (goSet `Parse`/`Peek` API split) — together they close the injection hole.

## What changes

### `pkg/services/stream_service.go`

- **New helper `validateBusinessStreamSecurity(cfg)`** captures the invariant positively:
  - **L2=bearer** (`SigningOnly=false`): satisfied by L2, no trust root required.
  - **L2=None** (`SigningOnly=true`): a trust root (`Iss` + `IssuerJWKSUrl`) is **mandatory**; the "NONE" sentinel (case-insensitive) is also rejected explicitly.
- **New helper `normalizeStreamTrustFields(cfg)`** applies the "NONE" → "" normalization consistently in both `CreateStream` and `UpdateStream` (previously only in create), so the invariant validator always sees the canonical form.
- `CreateStream` and `UpdateStream` now call these helpers in place of the ad-hoc `SigningOnly && (Iss=="" || IssuerJWKSUrl=="")` check. Error messages cite ADR-0066 §D2 for grep-forward reviewability.
- `LoadReceiverStreams` runs a **fail-closed startup guard**: any persisted receiver stream that violates the invariant (from an older validator) is marked **disabled** with a clear operator-visible error message before it can serve traffic. Covers both the primary `StreamConfiguration` and the `SstpInbound` leg of an SSTP pair — a partially-invariant pair cannot safely accept inbound events.

### `internal/server/api_sstp.go`

Audits the "signing-only + no bearer presented" acceptance branch against the ADR-0066 §D2 invariant. Under the three cooperating validation layers above (create + update + startup fail-closed), this handler is entered only for pairs that satisfy the invariant, so no additional runtime "no trust root" gate is needed. Comment now documents the audit conclusion and calls out why a naive inline `IssuerJWKSUrl==""` check would false-positive on the DEFAULT-loopback issuer case (trust root resolved by local key lookup, not by an outbound URL fetch).

### `pkg/services/stream_service_adr0066_invariant_test.go` (new)

Table-driven invariant tests pin the positive/negative decision matrix of `validateBusinessStreamSecurity`, then exercise the full paths:

- Create-rejection on both `PollReceive` and `PushReceive` shapes.
- Create-rejection on all three "NONE" sentinel casings.
- Update-rejection when `SigningOnly` is flipped on without adding a trust root (with the ADR-0066 wording asserted).
- `LoadReceiverStreams` fail-closed on a persisted `None+unverified` primary stream (invariant violation is recorded on `ErrorMsg` with the "primary" leg label).
- `LoadReceiverStreams` fail-closed on a persisted SSTP pair whose inbound leg violates the invariant (labelled "sstp-inbound").
- `LoadReceiverStreams` leaves a compliant signing-only stream enabled.

## Gates

- `go test -race ./...` green
- `go vet ./...` green
- `make seams` (ephemeral wide go.work self-check) green

Delivers i2-open/i2goSignals#235
Part of independentid/i2gosignals-planning#48

Binding ADRs: [ADR-0066](https://github.com/independentid/i2gosignals-planning/blob/main/docs/adr/0066-business-stream-l2-menu-and-none-invariant.md) §D2.