### PR TITLE
Add experimental WISE semantic receiver helpers

### DIFF
--- a/docs/wise-semantic-receiver.md
+++ b/docs/wise-semantic-receiver.md
@@ -1,0 +1,66 @@
+# Experimental WISE semantic Receiver helpers
+
+This repository's SSF Poll receiver validates the SET transport envelope,
+signature, issuer and audience. The proposed Workload Identity Security Events
+(WISE) profile adds workload-specific event semantics. This page describes an
+**experimental, opt-in** semantic helper for a small high-priority WISE subset.
+WISE itself is not an adopted OpenID specification, so this is neither a WISE
+conformance claim nor a stable protocol commitment.
+
+The current proposal is published at
+https://github.com/identitymonk/openid-wise.
+
+## What is provided
+
+`pkg/goSet/events` exposes:
+
+- WISE event URI constants;
+- `ParseWISESET`, which parses four high-priority WISE event types and returns
+  a `WISERecommendedAction`;
+- `ValidateWISESET`, usable as `goSetPoll.ReceiverConfig.SETValidator`.
+
+The supported events are `workload-compromised`, `credential-compromise`,
+`credential-revoked` and `trust-anchor-changed`. The helper checks the WISE
+required claims for the latter three and requires the profile's primary `uri`
+subject format. It accepts valid absolute URI schemes used by the proposal,
+including `wimse`, `spiffe` and `https`; it does not invent a receiver-scoped
+opaque-subject profile.
+
+```go
+response, _, err := goSetPoll.Poll(ctx, request, goSetPoll.ReceiverConfig{
+    EndpointURL:  endpoint,
+    JWKS:         issuerJWKS,
+    SETValidator: events.ValidateWISESET,
+})
+```
+
+For a failing validator, `Poll` places an `invalid_request` entry in its
+`setErrs` result, ready for the next RFC 8936 polling request. A successful
+validator merely means the event is understood; the caller still owns durable
+processing and acknowledgement.
+
+## Policy boundary
+
+`WISERecommendedAction` is receiver-local guidance, not a command from the
+transmitter. In particular, a `workload-compromised` event can recommend
+isolation or credential revocation, but it neither grants authority to act nor
+proves that an action occurred. A production integration must bind the finding
+to its own authorization, audit, retention and incident-response controls.
+
+## JWKS rollover
+
+`goSet.GetJwks` configures the underlying key resolver with
+`RefreshUnknownKID: true`. A new signing `kid` can therefore trigger a JWKS
+refresh; the unit test in `pkg/goSet/jwks_loader_test.go` covers an old-plus-new
+key rollover. Key revocation remains an operational trust-policy decision: a
+Receiver must define how it consumes its trust material and handles a
+`trust-anchor-changed` finding.
+
+## Deliberate limits
+
+- No transport retry, policy action, or replay store is implemented by this
+  helper.
+- Unsupported WISE events are reported as unsupported by this selected subset,
+  not as invalid under the WISE proposal.
+- Maintainers must decide whether the API and supported subset belong in this
+  project before it can be called a maintained WISE Receiver.

--- a/pkg/goSet/events/wise.go
+++ b/pkg/goSet/events/wise.go
@@ -1,0 +1,178 @@
+// Package events contains event-profile helpers for Security Event Tokens.
+package events
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/i2-open/i2goSignals/pkg/goSet"
+)
+
+// WISEEventPrefix is the event-type URI prefix currently used by the proposed
+// Workload Identity Security Events (WISE) profile.
+//
+// WISE is a proposed profile, not an adopted OpenID specification. These
+// helpers deliberately classify only the initial high-priority events below;
+// callers remain responsible for transport, issuer/audience validation,
+// replay handling, authorization and all operational policy.
+const WISEEventPrefix = "https://schemas.openid.net/secevent/wise/event-type/"
+
+const (
+	WISECredentialRevokedURI    = WISEEventPrefix + "credential-revoked"
+	WISECredentialCompromiseURI = WISEEventPrefix + "credential-compromise"
+	WISETrustAnchorChangedURI   = WISEEventPrefix + "trust-anchor-changed"
+	WISEWorkloadCompromisedURI  = WISEEventPrefix + "workload-compromised"
+)
+
+var (
+	// ErrUnsupportedWISEEvent means that a SET contains an event outside this
+	// deliberately small semantic profile. It is not a conclusion that the SET
+	// is invalid under WISE; a Receiver may support additional events.
+	ErrUnsupportedWISEEvent = errors.New("unsupported WISE event")
+
+	// ErrInvalidWISEEvent means a supported event is missing a required field or
+	// has a subject that cannot be interpreted by this profile helper.
+	ErrInvalidWISEEvent = errors.New("invalid WISE event")
+)
+
+// WISERecommendedAction is receiver-local guidance derived from an event's
+// meaning. It is not an instruction from the transmitter, an authority grant,
+// or evidence that any action occurred.
+type WISERecommendedAction string
+
+const (
+	WISEActionIsolateOrRevokeCredentials  WISERecommendedAction = "receiver_local_isolate_or_revoke_credentials"
+	WISEActionHoldAndRevalidateCredential WISERecommendedAction = "receiver_local_hold_and_revalidate_credential"
+	WISEActionRevalidateCredential        WISERecommendedAction = "receiver_local_revalidate_credential"
+	WISEActionRefreshTrustMaterial        WISERecommendedAction = "receiver_local_refresh_trust_material"
+	WISEActionRefreshAndRejectRevokedKey  WISERecommendedAction = "receiver_local_refresh_and_reject_revoked_key"
+)
+
+// WISEEvent is the semantic result for one supported event in a previously
+// verified SET. Subject is the URI payload value, not a stable internal handle.
+type WISEEvent struct {
+	Type              string
+	Subject           string
+	RecommendedAction WISERecommendedAction
+}
+
+// ParseWISESET validates and classifies the supported WISE event payloads in a
+// previously verified SET. The caller must verify the JWS and SET envelope
+// before using this function, for example through goSetPoll.Poll.
+//
+// The proposed WISE profile describes URI as its primary workload subject
+// identifier format. URI schemes such as wimse, spiffe and https are accepted;
+// no receiver-scoped opaque-subject profile is inferred here.
+func ParseWISESET(set *goSet.SecurityEventToken) ([]WISEEvent, error) {
+	if set == nil || len(set.Events) == 0 {
+		return nil, fmt.Errorf("%w: SET has no events", ErrInvalidWISEEvent)
+	}
+
+	parsed := make([]WISEEvent, 0, len(set.Events))
+	for eventURI, rawPayload := range set.Events {
+		payload, ok := rawPayload.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("%w: %s payload is not an object", ErrInvalidWISEEvent, eventURI)
+		}
+		subject, err := wiseURISubject(payload)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %s: %v", ErrInvalidWISEEvent, eventURI, err)
+		}
+
+		finding, err := classifyWISEEvent(eventURI, subject, payload)
+		if err != nil {
+			return nil, err
+		}
+		parsed = append(parsed, finding)
+	}
+	return parsed, nil
+}
+
+// ValidateWISESET is suitable for goSetPoll.ReceiverConfig.SETValidator. It
+// performs no policy action; it only rejects malformed or unsupported event
+// payloads for a Receiver that explicitly opts into this limited WISE profile.
+func ValidateWISESET(set *goSet.SecurityEventToken) error {
+	_, err := ParseWISESET(set)
+	return err
+}
+
+func classifyWISEEvent(eventURI, subject string, payload map[string]interface{}) (WISEEvent, error) {
+	finding := WISEEvent{Type: eventURI, Subject: subject}
+	switch eventURI {
+	case WISEWorkloadCompromisedURI:
+		// WISE describes this as high severity and says it SHOULD trigger
+		// immediate isolation or credential revocation. The exact choice stays
+		// with the Receiver's local policy.
+		finding.RecommendedAction = WISEActionIsolateOrRevokeCredentials
+	case WISECredentialCompromiseURI:
+		if !nonEmptyString(payload, "credential_type") {
+			return WISEEvent{}, fmt.Errorf("%w: credential_type is required", ErrInvalidWISEEvent)
+		}
+		finding.RecommendedAction = WISEActionHoldAndRevalidateCredential
+	case WISECredentialRevokedURI:
+		if !nonEmptyString(payload, "credential_type") {
+			return WISEEvent{}, fmt.Errorf("%w: credential_type is required", ErrInvalidWISEEvent)
+		}
+		reason, _ := payload["reason"].(string)
+		if reason == "compromise" || reason == "key_compromise" {
+			finding.RecommendedAction = WISEActionHoldAndRevalidateCredential
+		} else {
+			finding.RecommendedAction = WISEActionRevalidateCredential
+		}
+	case WISETrustAnchorChangedURI:
+		if !nonEmptyString(payload, "anchor_type") || !nonEmptyString(payload, "change_type") || !nonEmptyString(payload, "trust_domain") {
+			return WISEEvent{}, fmt.Errorf("%w: anchor_type, change_type and trust_domain are required", ErrInvalidWISEEvent)
+		}
+		anchorType, _ := payload["anchor_type"].(string)
+		if !oneOf(anchorType, "jwks", "x509_ca") {
+			return WISEEvent{}, fmt.Errorf("%w: unsupported anchor_type %q", ErrInvalidWISEEvent, anchorType)
+		}
+		changeType, _ := payload["change_type"].(string)
+		if !oneOf(changeType, "key_added", "key_rotated", "key_revoked", "key_expired", "full_replacement") {
+			return WISEEvent{}, fmt.Errorf("%w: unsupported change_type %q", ErrInvalidWISEEvent, changeType)
+		}
+		if changeType == "key_revoked" {
+			finding.RecommendedAction = WISEActionRefreshAndRejectRevokedKey
+		} else {
+			finding.RecommendedAction = WISEActionRefreshTrustMaterial
+		}
+	default:
+		return WISEEvent{}, fmt.Errorf("%w: %s", ErrUnsupportedWISEEvent, eventURI)
+	}
+	return finding, nil
+}
+
+func wiseURISubject(payload map[string]interface{}) (string, error) {
+	rawSubject, ok := payload["subject"].(map[string]interface{})
+	if !ok {
+		return "", errors.New("subject must be an object")
+	}
+	if rawSubject["format"] != "uri" {
+		return "", errors.New("subject format must be uri")
+	}
+	uri, ok := rawSubject["uri"].(string)
+	if !ok || strings.TrimSpace(uri) == "" {
+		return "", errors.New("subject uri is required")
+	}
+	parsed, err := url.ParseRequestURI(uri)
+	if err != nil || parsed.Scheme == "" {
+		return "", errors.New("subject uri is not an absolute URI")
+	}
+	return uri, nil
+}
+
+func nonEmptyString(payload map[string]interface{}, name string) bool {
+	value, ok := payload[name].(string)
+	return ok && strings.TrimSpace(value) != ""
+}
+
+func oneOf(value string, allowed ...string) bool {
+	for _, candidate := range allowed {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/goSet/events/wise_test.go
+++ b/pkg/goSet/events/wise_test.go
@@ -1,0 +1,100 @@
+package events
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/i2-open/i2goSignals/pkg/goSet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func wiseSET(eventURI string, payload map[string]interface{}) *goSet.SecurityEventToken {
+	return &goSet.SecurityEventToken{Events: map[string]interface{}{eventURI: payload}}
+}
+
+func wiseSubject(uri string) map[string]interface{} {
+	return map[string]interface{}{"format": "uri", "uri": uri}
+}
+
+func TestParseWISESETWorkloadCompromised(t *testing.T) {
+	findings, err := ParseWISESET(wiseSET(WISEWorkloadCompromisedURI, map[string]interface{}{
+		"subject":          wiseSubject("wimse://trust.example/workload/payment-service"),
+		"detection_method": "runtime-monitor",
+	}))
+
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	assert.Equal(t, WISEActionIsolateOrRevokeCredentials, findings[0].RecommendedAction)
+	assert.Equal(t, "wimse://trust.example/workload/payment-service", findings[0].Subject)
+}
+
+func TestParseWISESETAcceptsPrimaryURIFormats(t *testing.T) {
+	for _, subject := range []string{
+		"wimse://trust.example/workload/payment-service",
+		"spiffe://trust.example/ns/prod/sa/payment-service",
+		"https://client.example/.well-known/oauth-client",
+	} {
+		t.Run(subject, func(t *testing.T) {
+			_, err := ParseWISESET(wiseSET(WISEWorkloadCompromisedURI, map[string]interface{}{"subject": wiseSubject(subject)}))
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestParseWISESETCredentialRequiresType(t *testing.T) {
+	_, err := ParseWISESET(wiseSET(WISECredentialCompromiseURI, map[string]interface{}{
+		"subject": wiseSubject("wimse://trust.example/workload/payment-service"),
+	}))
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrInvalidWISEEvent))
+}
+
+func TestParseWISESETCredentialRevokedByCompromise(t *testing.T) {
+	findings, err := ParseWISESET(wiseSET(WISECredentialRevokedURI, map[string]interface{}{
+		"subject":         wiseSubject("wimse://trust.example/workload/payment-service"),
+		"credential_type": "wic",
+		"reason":          "key_compromise",
+	}))
+
+	require.NoError(t, err)
+	assert.Equal(t, WISEActionHoldAndRevalidateCredential, findings[0].RecommendedAction)
+}
+
+func TestParseWISESETTrustAnchorRevoked(t *testing.T) {
+	findings, err := ParseWISESET(wiseSET(WISETrustAnchorChangedURI, map[string]interface{}{
+		"subject":      wiseSubject("wimse://trust.example"),
+		"anchor_type":  "jwks",
+		"change_type":  "key_revoked",
+		"trust_domain": "trust.example",
+	}))
+
+	require.NoError(t, err)
+	assert.Equal(t, WISEActionRefreshAndRejectRevokedKey, findings[0].RecommendedAction)
+}
+
+func TestParseWISESETTrustAnchorRejectsUnknownValues(t *testing.T) {
+	_, err := ParseWISESET(wiseSET(WISETrustAnchorChangedURI, map[string]interface{}{
+		"subject":      wiseSubject("wimse://trust.example"),
+		"anchor_type":  "unknown",
+		"change_type":  "key_rotated",
+		"trust_domain": "trust.example",
+	}))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrInvalidWISEEvent))
+}
+
+func TestParseWISESETRejectsOpaqueSubjectAndUnknownEvent(t *testing.T) {
+	_, err := ParseWISESET(wiseSET(WISEWorkloadCompromisedURI, map[string]interface{}{
+		"subject": map[string]interface{}{"format": "opaque", "id": "receiver-local"},
+	}))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrInvalidWISEEvent))
+
+	_, err = ParseWISESET(wiseSET(WISEEventPrefix+"not-yet-supported", map[string]interface{}{
+		"subject": wiseSubject("wimse://trust.example/workload/payment-service"),
+	}))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnsupportedWISEEvent))
+}

--- a/pkg/goSet/jwks_loader_test.go
+++ b/pkg/goSet/jwks_loader_test.go
@@ -1,0 +1,71 @@
+package goSet
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func rsaJWK(key *rsa.PrivateKey, kid string) map[string]string {
+	return map[string]string{
+		"kty": "RSA",
+		"kid": kid,
+		"use": "sig",
+		"alg": "RS256",
+		"n":   base64.RawURLEncoding.EncodeToString(key.PublicKey.N.Bytes()),
+		"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.PublicKey.E)).Bytes()),
+	}
+}
+
+func signedToken(t *testing.T, key *rsa.PrivateKey, kid string) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{"iss": "https://issuer.example"})
+	token.Header["kid"] = kid
+	encoded, err := token.SignedString(key)
+	require.NoError(t, err)
+	return encoded
+}
+
+func TestGetJwksRefreshesOnUnknownKIDAfterRollover(t *testing.T) {
+	oldKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	newKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	var mu sync.RWMutex
+	keys := []map[string]string{rsaJWK(oldKey, "issuer-old")}
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"keys": keys})
+	}))
+	defer server.Close()
+
+	jwks, err := GetJwks(server.URL)
+	require.NoError(t, err)
+	_, err = jwt.Parse(signedToken(t, oldKey, "issuer-old"), jwks.Keyfunc)
+	require.NoError(t, err)
+
+	mu.Lock()
+	keys = []map[string]string{rsaJWK(oldKey, "issuer-old"), rsaJWK(newKey, "issuer-new")}
+	mu.Unlock()
+
+	_, err = jwt.Parse(signedToken(t, newKey, "issuer-new"), jwks.Keyfunc)
+	require.NoError(t, err)
+	mu.RLock()
+	defer mu.RUnlock()
+	assert.GreaterOrEqual(t, requests, 2, "unknown kid must trigger a JWKS refresh")
+}

--- a/pkg/goSetPoll/poll.go
+++ b/pkg/goSetPoll/poll.go
@@ -46,6 +46,12 @@ type SetErrType struct {
 	Description string `json:"description,omitempty"`
 }
 
+// SETValidator adds an optional event-profile validation step after JWS,
+// issuer and audience validation. It must not perform a durable policy action:
+// callers do that only after they decide to acknowledge a successfully handled
+// SET. Returning an error reports the SET as invalid_request in the next poll.
+type SETValidator func(*goSet.SecurityEventToken) error
+
 // ParsedPollResponse extends PollResponse with parsed and validated SET tokens.
 type ParsedPollResponse struct {
 	// Sets contains the raw SET token strings keyed by JTI.
@@ -79,6 +85,11 @@ type ReceiverConfig struct {
 
 	// ExpectedAudiences is the list of acceptable "aud" values. Empty skips validation.
 	ExpectedAudiences []string
+
+	// SETValidator optionally validates event-profile semantics after the SET
+	// envelope has been verified. For example, events.ValidateWISESET can make
+	// a Receiver explicitly opt into the supported WISE semantic subset.
+	SETValidator SETValidator
 
 	// HTTPClient is an optional custom HTTP client. If nil, a default is used.
 	HTTPClient *http.Client

--- a/pkg/goSetPoll/receiver.go
+++ b/pkg/goSetPoll/receiver.go
@@ -139,6 +139,17 @@ func Poll(ctx context.Context, request PollRequest, config ReceiverConfig) (*Par
 			}
 		}
 
+		if config.SETValidator != nil {
+			if err := config.SETValidator(token); err != nil {
+				log.Warn("RFC8936: SET semantic validation error", "jti", jti, "error", err)
+				result.Errors[jti] = SetErrType{
+					Error:       "invalid_request",
+					Description: "The SET event payload is unsupported or invalid: " + err.Error(),
+				}
+				continue
+			}
+		}
+
 		result.ParsedSETs[jti] = token
 	}
 

--- a/pkg/goSetPoll/semantic_validator_test.go
+++ b/pkg/goSetPoll/semantic_validator_test.go
@@ -1,0 +1,153 @@
+package goSetPoll
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/i2-open/i2goSignals/pkg/goSet"
+	"github.com/i2-open/i2goSignals/pkg/goSet/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeWISETestSET(t *testing.T, key *rsa.PrivateKey, eventURI string, payload map[string]interface{}) (string, string) {
+	t.Helper()
+	set := goSet.CreateSet(nil, "https://issuer.example.com", []string{"https://aud.example.com"})
+	set.AddEventPayload(eventURI, payload)
+	token, err := set.JWS(jwt.SigningMethodRS256, key)
+	require.NoError(t, err)
+	return set.ID, token
+}
+
+func makeWISETestSETWithKID(t *testing.T, key *rsa.PrivateKey, kid, eventURI string, payload map[string]interface{}) (string, string) {
+	t.Helper()
+	set := goSet.CreateSet(nil, "https://issuer.example.com", []string{"https://aud.example.com"})
+	set.Kid = kid
+	set.AddEventPayload(eventURI, payload)
+	token, err := set.JWS(jwt.SigningMethodRS256, key)
+	require.NoError(t, err)
+	return set.ID, token
+}
+
+func publicRSAJWK(key *rsa.PrivateKey, kid string) map[string]string {
+	return map[string]string{
+		"kty": "RSA",
+		"kid": kid,
+		"use": "sig",
+		"alg": "RS256",
+		"n":   base64.RawURLEncoding.EncodeToString(key.PublicKey.N.Bytes()),
+		"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.PublicKey.E)).Bytes()),
+	}
+}
+
+func TestPollWithWISESemanticValidator(t *testing.T) {
+	key := generateTestKey(t)
+	jti, token := makeWISETestSET(t, key, events.WISEWorkloadCompromisedURI, map[string]interface{}{
+		"subject": map[string]interface{}{
+			"format": "uri",
+			"uri":    "spiffe://trust.example/ns/prod/sa/payment-service",
+		},
+	})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(PollResponse{Sets: map[string]string{jti: token}})
+	}))
+	defer server.Close()
+
+	parsed, _, err := Poll(context.Background(), PollRequest{ReturnImmediately: true}, ReceiverConfig{
+		EndpointURL:       server.URL,
+		ExpectedIssuer:    "https://issuer.example.com",
+		ExpectedAudiences: []string{"https://aud.example.com"},
+		SETValidator:      events.ValidateWISESET,
+	})
+
+	require.NoError(t, err)
+	assert.Contains(t, parsed.ParsedSETs, jti)
+	assert.Empty(t, parsed.Errors)
+}
+
+func TestPollWithWISESemanticValidatorReportsMalformedPayload(t *testing.T) {
+	key := generateTestKey(t)
+	jti, token := makeWISETestSET(t, key, events.WISECredentialCompromiseURI, map[string]interface{}{
+		"subject": map[string]interface{}{
+			"format": "uri",
+			"uri":    "wimse://trust.example/workload/payment-service",
+		},
+	})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(PollResponse{Sets: map[string]string{jti: token}})
+	}))
+	defer server.Close()
+
+	parsed, _, err := Poll(context.Background(), PollRequest{ReturnImmediately: true}, ReceiverConfig{
+		EndpointURL:  server.URL,
+		SETValidator: events.ValidateWISESET,
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, parsed.ParsedSETs)
+	require.Contains(t, parsed.Errors, jti)
+	assert.Equal(t, "invalid_request", parsed.Errors[jti].Error)
+}
+
+func TestPollWithWISESemanticValidatorRefreshesJWKSAfterRollover(t *testing.T) {
+	oldKey := generateTestKey(t)
+	newKey := generateTestKey(t)
+	var mu sync.RWMutex
+	jwksKeys := []map[string]string{publicRSAJWK(oldKey, "issuer-old")}
+	jwksRequests := 0
+	jwksServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		jwksRequests++
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"keys": jwksKeys})
+	}))
+	defer jwksServer.Close()
+
+	jwks, err := goSet.GetJwks(jwksServer.URL)
+	require.NoError(t, err)
+	firstJTI, firstSET := makeWISETestSETWithKID(t, oldKey, "issuer-old", events.WISEWorkloadCompromisedURI, map[string]interface{}{
+		"subject": map[string]interface{}{"format": "uri", "uri": "wimse://trust.example/workload/payment-service"},
+	})
+	secondJTI, secondSET := makeWISETestSETWithKID(t, newKey, "issuer-new", events.WISETrustAnchorChangedURI, map[string]interface{}{
+		"subject":      map[string]interface{}{"format": "uri", "uri": "wimse://trust.example"},
+		"anchor_type":  "jwks",
+		"change_type":  "key_rotated",
+		"trust_domain": "trust.example",
+	})
+	currentJTI, currentSET := firstJTI, firstSET
+	pollServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(PollResponse{Sets: map[string]string{currentJTI: currentSET}})
+	}))
+	defer pollServer.Close()
+	config := ReceiverConfig{
+		EndpointURL:       pollServer.URL,
+		JWKS:              jwks,
+		ExpectedIssuer:    "https://issuer.example.com",
+		ExpectedAudiences: []string{"https://aud.example.com"},
+		SETValidator:      events.ValidateWISESET,
+	}
+
+	parsed, _, err := Poll(context.Background(), PollRequest{ReturnImmediately: true}, config)
+	require.NoError(t, err)
+	assert.Contains(t, parsed.ParsedSETs, firstJTI)
+
+	mu.Lock()
+	jwksKeys = []map[string]string{publicRSAJWK(oldKey, "issuer-old"), publicRSAJWK(newKey, "issuer-new")}
+	mu.Unlock()
+	currentJTI, currentSET = secondJTI, secondSET
+	parsed, _, err = Poll(context.Background(), PollRequest{ReturnImmediately: true}, config)
+	require.NoError(t, err)
+	assert.Contains(t, parsed.ParsedSETs, secondJTI)
+
+	mu.RLock()
+	defer mu.RUnlock()
+	assert.GreaterOrEqual(t, jwksRequests, 2, "new kid must cause a JWKS refresh")
+}


### PR DESCRIPTION
## Summary

This draft adds an experimental, opt-in WISE semantic Receiver helper to the
existing RFC 8936 Poll receiver path.

It intentionally does **not** claim WISE conformance, production policy
coverage, or that a SET is an authority grant or action receipt. WISE is still
a proposed profile.

## What changes

- Add `events.ParseWISESET` and `events.ValidateWISESET` for four initial
  high-priority event types: `workload-compromised`, `credential-compromise`,
  `credential-revoked`, and `trust-anchor-changed`.
- Add the generic optional `goSetPoll.ReceiverConfig.SETValidator` hook, run
  after JWS, issuer and audience validation. A validation failure is surfaced
  as `invalid_request` in the next RFC 8936 `setErrs` payload.
- Return receiver-local recommended actions only. Durable action, authorization,
  replay persistence and acknowledgement remain the caller's responsibility.
- Accept WISE's primary `uri` subject format without inventing a
  receiver-scoped opaque-subject profile. `wimse`, `spiffe` and `https` URI
  examples are covered.
- Add JWKS old-plus-new-key rollover tests, including an end-to-end Poll
  Receiver test where an unknown new `kid` refreshes JWKS and then passes WISE
  semantic validation.

## Review requested

Please assess whether this small semantic layer belongs in goSignals and,
especially:

1. whether `SETValidator` is the right extension point;
2. whether the initial supported WISE subset and receiver-local action labels
   are appropriately scoped; and
3. how unsupported WISE events should be surfaced by a Receiver that has
   explicitly enabled this subset.

## Validation

`GOFLAGS=-buildvcs=false go test ./...` passes in Go 1.26.

The companion documentation is `docs/wise-semantic-receiver.md`.
